### PR TITLE
Validate duplicate operators are not used in CombinedFieldQuery

### DIFF
--- a/src/Builder/Type/CombinedFieldQuery.php
+++ b/src/Builder/Type/CombinedFieldQuery.php
@@ -4,28 +4,84 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Type;
 
-use MongoDB\BSON\Document;
 use MongoDB\BSON\Serializable;
 use MongoDB\Exception\InvalidArgumentException;
 use stdClass;
 
+use function array_is_list;
+use function array_key_exists;
+use function array_key_first;
+use function array_merge;
+use function array_reduce;
+use function count;
 use function get_debug_type;
+use function get_object_vars;
 use function is_array;
 use function sprintf;
+use function str_starts_with;
 
 /**
- * List of filters that apply to the same field path.
+ * List of field query that apply to the same field path.
  */
 class CombinedFieldQuery implements FieldQueryInterface
 {
-    public function __construct(
-        /** @var list<FieldQueryInterface|Serializable|array|stdClass> $fieldQueries */
-        public readonly array $fieldQueries,
-    ) {
-        foreach ($fieldQueries as $fieldQuery) {
-            if (! $fieldQuery instanceof FieldQueryInterface && ! $fieldQuery instanceof Serializable && ! is_array($fieldQuery) && ! $fieldQuery instanceof stdClass) {
-                throw new InvalidArgumentException(sprintf('Expected filters to be a list of %s, %s, array or stdClass, %s given.', FieldQueryInterface::class, Document::class, get_debug_type($fieldQuery)));
+    /** @var list<FieldQueryInterface|Serializable|array|stdClass> $fieldQueries */
+    public readonly array $fieldQueries;
+
+    /** @param list<FieldQueryInterface|Serializable|array|stdClass> $fieldQueries */
+    public function __construct(array $fieldQueries)
+    {
+        if (! array_is_list($fieldQueries)) {
+            throw new InvalidArgumentException('Expected filters to be a list, invalid array given.');
+        }
+
+        // Flatten nested CombinedFieldQuery
+        $this->fieldQueries = array_reduce($fieldQueries, static function (array $fieldQueries, mixed $fieldQuery): array {
+            if ($fieldQuery instanceof CombinedFieldQuery) {
+                return array_merge($fieldQueries, $fieldQuery->fieldQueries);
             }
+
+            $fieldQueries[] = $fieldQuery;
+
+            return $fieldQueries;
+        }, []);
+
+        // Validate FieldQuery types and non-duplicate operators
+        $seenOperators = [];
+        foreach ($this->fieldQueries as $fieldQuery) {
+            if ($fieldQuery instanceof FieldQueryInterface && $fieldQuery instanceof OperatorInterface) {
+                $operator = $fieldQuery->getOperator();
+            } elseif (is_array($fieldQuery)) {
+                if (count($fieldQuery) !== 1) {
+                    throw new InvalidArgumentException(sprintf('Operator array must contain exactly one key starting with $. %d given.', count($fieldQuery)));
+                }
+
+                $operator = array_key_first($fieldQuery);
+                if (! str_starts_with($operator, '$')) {
+                    throw new InvalidArgumentException(sprintf('Operator array must contain exactly one key starting with $. "%s" given.', $operator));
+                }
+            } elseif ($fieldQuery instanceof stdClass) {
+                $fieldQuery = get_object_vars($fieldQuery);
+                if (count($fieldQuery) !== 1) {
+                    throw new InvalidArgumentException(sprintf('Operator object must contain exactly one key starting with $. %d given.', count($fieldQuery)));
+                }
+
+                $operator = array_key_first($fieldQuery);
+                if (! str_starts_with($operator, '$')) {
+                    throw new InvalidArgumentException(sprintf('Operator object must contain exactly one key starting with $. "%s" given.', $operator));
+                }
+            } elseif ($fieldQuery instanceof Serializable) {
+                // Unknown operator, let the server handle it
+                continue;
+            } else {
+                throw new InvalidArgumentException(sprintf('Expected filters to be a list of field query operators, BSON documents, array or stdClass, %s given.', get_debug_type($fieldQuery)));
+            }
+
+            if (array_key_exists($operator, $seenOperators)) {
+                throw new InvalidArgumentException(sprintf('Duplicate operator "%s" detected.', $operator));
+            }
+
+            $seenOperators[$operator] = true;
         }
     }
 }

--- a/src/Builder/Type/CombinedFieldQuery.php
+++ b/src/Builder/Type/CombinedFieldQuery.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Type;
 
-use MongoDB\BSON\Serializable;
 use MongoDB\Exception\InvalidArgumentException;
 use stdClass;
 
@@ -25,10 +24,10 @@ use function str_starts_with;
  */
 class CombinedFieldQuery implements FieldQueryInterface
 {
-    /** @var list<FieldQueryInterface|Serializable|array|stdClass> $fieldQueries */
+    /** @var list<FieldQueryInterface|array|stdClass> $fieldQueries */
     public readonly array $fieldQueries;
 
-    /** @param list<FieldQueryInterface|Serializable|array|stdClass> $fieldQueries */
+    /** @param list<FieldQueryInterface|array|stdClass> $fieldQueries */
     public function __construct(array $fieldQueries)
     {
         if (! array_is_list($fieldQueries)) {

--- a/src/Builder/Type/CombinedFieldQuery.php
+++ b/src/Builder/Type/CombinedFieldQuery.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Type;
 
+use MongoDB\BSON\Decimal128;
+use MongoDB\BSON\Int64;
+use MongoDB\BSON\Regex;
 use MongoDB\Exception\InvalidArgumentException;
 use stdClass;
 
@@ -25,10 +28,10 @@ use function str_starts_with;
  */
 class CombinedFieldQuery implements FieldQueryInterface
 {
-    /** @var list<FieldQueryInterface|array|stdClass> $fieldQueries */
+    /** @var list<QueryInterface|FieldQueryInterface|Decimal128|Int64|Regex|stdClass|array|bool|float|int|string|null> $fieldQueries */
     public readonly array $fieldQueries;
 
-    /** @param list<FieldQueryInterface|array|stdClass> $fieldQueries */
+    /** @param list<QueryInterface|FieldQueryInterface|Decimal128|Int64|Regex|stdClass|array|bool|float|int|string|null> $fieldQueries */
     public function __construct(array $fieldQueries)
     {
         if (! array_is_list($fieldQueries)) {
@@ -36,7 +39,7 @@ class CombinedFieldQuery implements FieldQueryInterface
         }
 
         // Flatten nested CombinedFieldQuery
-        $this->fieldQueries = array_reduce($fieldQueries, static function (array $fieldQueries, FieldQueryInterface|array|stdClass $fieldQuery): array {
+        $this->fieldQueries = array_reduce($fieldQueries, static function (array $fieldQueries, QueryInterface|FieldQueryInterface|Decimal128|Int64|Regex|stdClass|array|bool|float|int|string|null $fieldQuery): array {
             if ($fieldQuery instanceof CombinedFieldQuery) {
                 return array_merge($fieldQueries, $fieldQuery->fieldQueries);
             }

--- a/src/Builder/Type/CombinedFieldQuery.php
+++ b/src/Builder/Type/CombinedFieldQuery.php
@@ -53,32 +53,29 @@ class CombinedFieldQuery implements FieldQueryInterface
                 $operator = $fieldQuery->getOperator();
             } elseif (is_array($fieldQuery)) {
                 if (count($fieldQuery) !== 1) {
-                    throw new InvalidArgumentException(sprintf('Operator array must contain exactly one key starting with $. %d given.', count($fieldQuery)));
+                    throw new InvalidArgumentException(sprintf('Operator array must contain exactly one key, %d given', count($fieldQuery)));
                 }
 
                 $operator = array_key_first($fieldQuery);
                 if (! str_starts_with($operator, '$')) {
-                    throw new InvalidArgumentException(sprintf('Operator array must contain exactly one key starting with $. "%s" given.', $operator));
+                    throw new InvalidArgumentException(sprintf('Operator array must contain exactly one key starting with $. "%s" given', $operator));
                 }
             } elseif ($fieldQuery instanceof stdClass) {
                 $fieldQuery = get_object_vars($fieldQuery);
                 if (count($fieldQuery) !== 1) {
-                    throw new InvalidArgumentException(sprintf('Operator object must contain exactly one key starting with $. %d given.', count($fieldQuery)));
+                    throw new InvalidArgumentException(sprintf('Operator object must contain exactly one key. %d given', count($fieldQuery)));
                 }
 
                 $operator = array_key_first($fieldQuery);
                 if (! str_starts_with($operator, '$')) {
-                    throw new InvalidArgumentException(sprintf('Operator object must contain exactly one key starting with $. "%s" given.', $operator));
+                    throw new InvalidArgumentException(sprintf('Operator object must contain exactly one key starting with $. "%s" given', $operator));
                 }
-            } elseif ($fieldQuery instanceof Serializable) {
-                // Unknown operator, let the server handle it
-                continue;
             } else {
-                throw new InvalidArgumentException(sprintf('Expected filters to be a list of field query operators, BSON documents, array or stdClass, %s given.', get_debug_type($fieldQuery)));
+                throw new InvalidArgumentException(sprintf('Expected filters to be a list of field query operators, array or stdClass, %s given', get_debug_type($fieldQuery)));
             }
 
             if (array_key_exists($operator, $seenOperators)) {
-                throw new InvalidArgumentException(sprintf('Duplicate operator "%s" detected.', $operator));
+                throw new InvalidArgumentException(sprintf('Duplicate operator "%s" detected', $operator));
             }
 
             $seenOperators[$operator] = true;

--- a/tests/Builder/Type/CombinedFieldQueryTest.php
+++ b/tests/Builder/Type/CombinedFieldQueryTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace MongoDB\Tests\Builder\Type;
 
 use Generator;
+use MongoDB\BSON\Serializable;
+use MongoDB\Builder\Query\EqOperator;
+use MongoDB\Builder\Query\GtOperator;
 use MongoDB\Builder\Type\CombinedFieldQuery;
 use MongoDB\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -21,9 +24,31 @@ class CombinedFieldQueryTest extends TestCase
     public function testFieldQueries(): void
     {
         $fieldQueries = new CombinedFieldQuery([
-            $this->createMock(CombinedFieldQuery::class),
+            new EqOperator(1),
             ['$gt' => 1],
-            new CombinedFieldQuery([]),
+            (object) ['$lt' => 1],
+            new class implements Serializable {
+                public function bsonSerialize(): array
+                {
+                    return ['$gte' => 1];
+                }
+            },
+        ]);
+
+        $this->assertCount(4, $fieldQueries->fieldQueries);
+    }
+
+    public function testFlattenCombinedFieldQueries(): void
+    {
+        $fieldQueries = new CombinedFieldQuery([
+            new CombinedFieldQuery([
+                new CombinedFieldQuery([
+                    ['$lt' => 1],
+                    new CombinedFieldQuery([]),
+                ]),
+                ['$gt' => 1],
+            ]),
+            ['$gte' => 1],
         ]);
 
         $this->assertCount(3, $fieldQueries->fieldQueries);
@@ -44,5 +69,49 @@ class CombinedFieldQueryTest extends TestCase
         yield 'string' => ['foo'];
         yield 'bool' => [true];
         yield 'null' => [null];
+        yield 'empy array' => [[]];
+        yield 'empy object' => [(object) []];
+        yield 'not operator array' => [['eq' => 1]];
+        yield 'not operator object' => [(object) ['eq' => 1]];
+    }
+
+    /**
+     * @param array<mixed> $fieldQueries
+     *
+     * @dataProvider provideDuplicateOperator
+     */
+    public function testRejectDuplicateOperator(array $fieldQueries): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Duplicate operator "$eq" detected.');
+
+        new CombinedFieldQuery([
+            ['$eq' => 1],
+            new EqOperator(2),
+        ]);
+    }
+
+    public function provideDuplicateOperator(): Generator
+    {
+        yield 'array and FieldQuery' => [
+            [
+                ['$eq' => 1],
+                new EqOperator(2),
+            ],
+        ];
+
+        yield 'object and FieldQuery' => [
+            [
+                (object) ['$gt' => 1],
+                new GtOperator(2),
+            ],
+        ];
+
+        yield 'object and array' => [
+            [
+                (object) ['$ne' => 1],
+                ['$ne' => 2],
+            ],
+        ];
     }
 }

--- a/tests/Builder/Type/CombinedFieldQueryTest.php
+++ b/tests/Builder/Type/CombinedFieldQueryTest.php
@@ -63,12 +63,12 @@ class CombinedFieldQueryTest extends TestCase
         yield 'string' => ['foo', 'Expected filters to be a list of field query operators, array or stdClass, string given'];
         yield 'bool' => [true, 'Expected filters to be a list of field query operators, array or stdClass, bool given'];
         yield 'null' => [null, 'Expected filters to be a list of field query operators, array or stdClass, null given'];
-        yield 'empty array' => [[], 'Operator array must contain exactly one key, 0 given'];
-        yield 'array with two keys' => [['$eq' => 1, '$ne' => 2], 'Operator array must contain exactly one key, 2 given'];
-        yield 'array key without $' => [['eq' => 1], 'Operator array must contain exactly one key starting with $. "eq" given'];
-        yield 'empty object' => [(object) [], 'Operator object must contain exactly one key. 0 given'];
-        yield 'object with two keys' => [(object) ['$eq' => 1, '$ne' => 2], 'Operator object must contain exactly one key. 2 given'];
-        yield 'object key without $' => [(object) ['eq' => 1], 'Operator object must contain exactly one key starting with $. "eq" given'];
+        yield 'empty array' => [[], 'Operator must contain exactly one key, 0 given'];
+        yield 'array with two keys' => [['$eq' => 1, '$ne' => 2], 'Operator must contain exactly one key, 2 given'];
+        yield 'array key without $' => [['eq' => 1], 'Operator must contain exactly one key starting with $, "eq" given'];
+        yield 'empty object' => [(object) [], 'Operator must contain exactly one key, 0 given'];
+        yield 'object with two keys' => [(object) ['$eq' => 1, '$ne' => 2], 'Operator must contain exactly one key, 2 given'];
+        yield 'object key without $' => [(object) ['eq' => 1], 'Operator must contain exactly one key starting with $, "eq" given'];
     }
 
     /**


### PR DESCRIPTION
In MongoDB syntax, it's not possible to use the same operator twice. The last value in the object replaces the previous one. 

```ts
{ name: { $eq: "Mars", $eq: "Jupiter" } }
// Same as
{ name: { $eq: "Jupiter" } }
```

This PR proposes to prohibit the use of the same operator 2 times. But we could also choose to implement the same logic as in JS.