### PR TITLE
Add test for `$unwind` and a complex `$group` stage

### DIFF
--- a/tests/Builder/BuilderEncoderTest.php
+++ b/tests/Builder/BuilderEncoderTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MongoDB\Tests\Builder;
 
-use App\Import\Value\Field\Fieldtype;
 use Generator;
 use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\BuilderEncoder;

--- a/tests/Builder/BuilderEncoderTest.php
+++ b/tests/Builder/BuilderEncoderTest.php
@@ -287,8 +287,45 @@ class BuilderEncoderTest extends TestCase
         );
 
         $expected = [
-            ['$unwind' => '$fielgroups'],
-            ['$unwind' => '$fielgroups.fields'],
+            ['$unwind' => '$fieldgroups'],
+            ['$unwind' => '$fieldgroups.fields'],
+        ];
+
+        $this->assertSamePipeline($expected, $pipeline);
+    }
+
+    public function testComplexGroupStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: null,
+                results: Accumulator::push(
+                    Expression::arrayToObject([[
+                       'k' => Expression::toString(Expression::fieldPath('key')),
+                       'v' => Expression::fieldPath('value'),
+                    ]]),
+                ),
+            ),
+        );
+
+        $expected = [
+            [
+                '$group' => [
+                    '_id' => null,
+                    'results' => [
+                        '$push' => [
+                            '$arrayToObject' => [
+                                [
+                                    [
+                                        'k' => ['$toString' => '$key'],
+                                        'v' => '$value',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ];
 
         $this->assertSamePipeline($expected, $pipeline);

--- a/tests/Builder/BuilderEncoderTest.php
+++ b/tests/Builder/BuilderEncoderTest.php
@@ -282,13 +282,15 @@ class BuilderEncoderTest extends TestCase
     public function testUnwind(): void
     {
         $pipeline = new Pipeline(
-            Stage::unwind('$fieldgroups'),
-            Stage::unwind('$fieldgroups.fields'),
+            Stage::unwind('$foo'),
+            Stage::unwind('$foo.bar'),
+            Stage::unwind(Expression::arrayFieldPath('foo.bar.baz')),
         );
 
         $expected = [
-            ['$unwind' => '$fieldgroups'],
-            ['$unwind' => '$fieldgroups.fields'],
+            ['$unwind' => '$foo'],
+            ['$unwind' => '$foo.bar'],
+            ['$unwind' => '$foo.bar.baz'],
         ];
 
         $this->assertSamePipeline($expected, $pipeline);

--- a/tests/Builder/BuilderEncoderTest.php
+++ b/tests/Builder/BuilderEncoderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Tests\Builder;
 
+use App\Import\Value\Field\Fieldtype;
 use Generator;
 use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\BuilderEncoder;
@@ -274,6 +275,21 @@ class BuilderEncoderTest extends TestCase
                     ],
                 ],
             ],
+        ];
+
+        $this->assertSamePipeline($expected, $pipeline);
+    }
+
+    public function testUnwind(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::unwind('$fieldgroups'),
+            Stage::unwind('$fieldgroups.fields'),
+        );
+
+        $expected = [
+            ['$unwind' => '$fielgroups'],
+            ['$unwind' => '$fielgroups.fields'],
         ];
 
         $this->assertSamePipeline($expected, $pipeline);


### PR DESCRIPTION
I am using it this way in my pipeline and when I use the `assertSamePipeline` method from this repository (copy/pasted), I receive the following error:
![CleanShot 2023-10-20 at 21 56 07](https://github.com/mongodb/mongo-php-builder/assets/995707/5ad2be3a-e58c-49fc-8f4c-7630f197e975)

With this test in your CI I want to achieve, that it is not a problem of the `assertSamePipeline` method.

cc @alcaeus @GromNaN 