### PR TITLE
PHPLIB-1292 Accept a single array as query to support filter on numerical field names

### DIFF
--- a/generator/config/expressions.php
+++ b/generator/config/expressions.php
@@ -83,11 +83,11 @@ return $expressions + [
     ],
     'fieldQuery' => [
         'returnType' => Type\FieldQueryInterface::class,
-        'acceptedTypes' => [Type\FieldQueryInterface::class, ...$bsonTypes['any']],
+        'acceptedTypes' => [Type\FieldQueryInterface::class, BSON\Regex::class, 'bool', 'int', 'float', 'string', 'array', 'null', stdClass::class],
     ],
     'query' => [
         'returnType' => Type\QueryInterface::class,
-        'acceptedTypes' => [Type\QueryInterface::class, ...$bsonTypes['object']],
+        'acceptedTypes' => [Type\QueryInterface::class, 'array'],
     ],
     'projection' => [
         'returnType' => Type\ProjectionInterface::class,

--- a/generator/config/expressions.php
+++ b/generator/config/expressions.php
@@ -83,7 +83,7 @@ return $expressions + [
     ],
     'fieldQuery' => [
         'returnType' => Type\FieldQueryInterface::class,
-        'acceptedTypes' => [Type\FieldQueryInterface::class, BSON\Regex::class, 'bool', 'int', 'float', 'string', 'array', 'null', stdClass::class],
+        'acceptedTypes' => [Type\FieldQueryInterface::class, BSON\Regex::class, 'bool', 'string', 'array', 'null', stdClass::class, ...$bsonTypes['number']],
     ],
     'query' => [
         'returnType' => Type\QueryInterface::class,

--- a/generator/config/query/and.yaml
+++ b/generator/config/query/and.yaml
@@ -12,4 +12,4 @@ arguments:
         type:
             - query
         variadic: array
-        variadicMin: 2
+        variadicMin: 1

--- a/generator/config/query/and.yaml
+++ b/generator/config/query/and.yaml
@@ -8,7 +8,8 @@ description: |
     Joins query clauses with a logical AND returns all documents that match the conditions of both clauses.
 arguments:
     -
-        name: expression
+        name: queries
         type:
             - query
         variadic: array
+        variadicMin: 2

--- a/generator/config/query/nor.yaml
+++ b/generator/config/query/nor.yaml
@@ -12,4 +12,4 @@ arguments:
         type:
             - query
         variadic: array
-        variadicMin: 2
+        variadicMin: 1

--- a/generator/config/query/nor.yaml
+++ b/generator/config/query/nor.yaml
@@ -8,7 +8,8 @@ description: |
     Joins query clauses with a logical NOR returns all documents that fail to match both clauses.
 arguments:
     -
-        name: expression
+        name: queries
         type:
             - query
         variadic: array
+        variadicMin: 2

--- a/generator/config/query/not.yaml
+++ b/generator/config/query/not.yaml
@@ -10,5 +10,4 @@ arguments:
     -
         name: expression
         type:
-            - query
-            - regex
+            - fieldQuery

--- a/generator/config/query/or.yaml
+++ b/generator/config/query/or.yaml
@@ -12,4 +12,4 @@ arguments:
         type:
             - query
         variadic: array
-        variadicMin: 2
+        variadicMin: 1

--- a/generator/config/query/or.yaml
+++ b/generator/config/query/or.yaml
@@ -8,7 +8,8 @@ description: |
     Joins query clauses with a logical OR returns all documents that match the conditions of either clause.
 arguments:
     -
-        name: expression
+        name: queries
         type:
             - query
         variadic: array
+        variadicMin: 2

--- a/generator/config/schema.json
+++ b/generator/config/schema.json
@@ -102,6 +102,7 @@
                         "enum": [
                             "accumulator",
                             "query",
+                            "fieldQuery",
                             "pipeline",
                             "window",
                             "expression",

--- a/generator/src/OperatorClassGenerator.php
+++ b/generator/src/OperatorClassGenerator.php
@@ -76,7 +76,7 @@ class OperatorClassGenerator extends OperatorGenerator
                 $constuctor->setVariadic();
                 $constuctor->addComment('@param ' . $type->doc . ' ...$' . $argument->name . rtrim(' ' . $argument->description));
 
-                if ($argument->variadicMin !== null) {
+                if ($argument->variadicMin > 0) {
                     $constuctor->addBody(<<<PHP
                     if (\count(\${$argument->name}) < {$argument->variadicMin}) {
                         throw new \InvalidArgumentException(\sprintf('Expected at least %d values for \${$argument->name}, got %d.', {$argument->variadicMin}, \count(\${$argument->name})));
@@ -140,11 +140,10 @@ class OperatorClassGenerator extends OperatorGenerator
 
                 if ($type->query) {
                     $namespace->addUseFunction('is_array');
-                    $namespace->addUseFunction('is_object');
                     $namespace->addUse(QueryObject::class);
                     $constuctor->addBody(<<<PHP
-                    if (is_array(\${$argument->name}) || is_object(\${$argument->name})) {
-                        \${$argument->name} = QueryObject::create(...\${$argument->name});
+                    if (is_array(\${$argument->name})) {
+                        \${$argument->name} = QueryObject::create(\${$argument->name});
                     }
 
                     PHP);

--- a/generator/src/OperatorClassGenerator.php
+++ b/generator/src/OperatorClassGenerator.php
@@ -81,6 +81,7 @@ class OperatorClassGenerator extends OperatorGenerator
                     if (\count(\${$argument->name}) < {$argument->variadicMin}) {
                         throw new \InvalidArgumentException(\sprintf('Expected at least %d values for \${$argument->name}, got %d.', {$argument->variadicMin}, \count(\${$argument->name})));
                     }
+
                     PHP);
                 }
 
@@ -96,6 +97,7 @@ class OperatorClassGenerator extends OperatorGenerator
                     if (! array_is_list(\${$argument->name})) {
                         throw new InvalidArgumentException('Expected \${$argument->name} arguments to be a list (array), named arguments are not supported');
                     }
+
                     PHP);
                 } elseif ($argument->variadic === VariadicType::Object) {
                     $namespace->addUse(stdClass::class);
@@ -109,6 +111,7 @@ class OperatorClassGenerator extends OperatorGenerator
                             throw new InvalidArgumentException('Expected \${$argument->name} arguments to be a map (object), named arguments (<name>:<value>) or array unpacking ...[\'<name>\' => <value>] must be used');
                         }
                     }
+
                     \${$argument->name} = (object) \${$argument->name};
                     PHP);
                 }

--- a/generator/src/OperatorFactoryGenerator.php
+++ b/generator/src/OperatorFactoryGenerator.php
@@ -6,6 +6,7 @@ namespace MongoDB\CodeGenerator;
 
 use MongoDB\CodeGenerator\Definition\GeneratorDefinition;
 use MongoDB\CodeGenerator\Definition\OperatorDefinition;
+use MongoDB\CodeGenerator\Definition\VariadicType;
 use Nette\PhpGenerator\Literal;
 use Nette\PhpGenerator\PhpNamespace;
 use Nette\PhpGenerator\TraitType;
@@ -67,6 +68,11 @@ final class OperatorFactoryGenerator extends OperatorGenerator
             $parameter = $method->addParameter($argument->name);
             $parameter->setType($type->native);
             if ($argument->variadic) {
+                if ($argument->variadic === VariadicType::Array) {
+                    // Warn that named arguments are not supported
+                    // @see https://psalm.dev/docs/running_psalm/issues/NamedArgumentNotAllowed/
+                    $method->addComment('@no-named-arguments');
+                }
                 $method->setVariadic();
                 $method->addComment('@param ' . $type->doc . ' ...$' . $argument->name . rtrim(' ' . $argument->description));
                 $args[] = '...$' . $argument->name;

--- a/generator/src/OperatorFactoryGenerator.php
+++ b/generator/src/OperatorFactoryGenerator.php
@@ -73,6 +73,7 @@ final class OperatorFactoryGenerator extends OperatorGenerator
                     // @see https://psalm.dev/docs/running_psalm/issues/NamedArgumentNotAllowed/
                     $method->addComment('@no-named-arguments');
                 }
+
                 $method->setVariadic();
                 $method->addComment('@param ' . $type->doc . ' ...$' . $argument->name . rtrim(' ' . $argument->description));
                 $args[] = '...$' . $argument->name;

--- a/src/Builder/Accumulator/FactoryTrait.php
+++ b/src/Builder/Accumulator/FactoryTrait.php
@@ -332,6 +332,7 @@ trait FactoryTrait
      * Combines multiple documents into a single document.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/mergeObjects/
+     * @no-named-arguments
      * @param Document|ResolvesToObject|Serializable|array|stdClass ...$document Any valid expression that resolves to a document.
      */
     public static function mergeObjects(

--- a/src/Builder/Accumulator/MergeObjectsAccumulator.php
+++ b/src/Builder/Accumulator/MergeObjectsAccumulator.php
@@ -40,9 +40,11 @@ class MergeObjectsAccumulator implements AccumulatorInterface, OperatorInterface
         if (\count($document) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $document, got %d.', 1, \count($document)));
         }
+
         if (! array_is_list($document)) {
             throw new InvalidArgumentException('Expected $document arguments to be a list (array), named arguments are not supported');
         }
+
         $this->document = $document;
     }
 

--- a/src/Builder/BuilderEncoder.php
+++ b/src/Builder/BuilderEncoder.php
@@ -213,14 +213,14 @@ class BuilderEncoder implements Encoder
             if ($value instanceof QueryInterface) {
                 // The sub-objects is merged into the main object, replacing duplicate keys
                 foreach (get_object_vars($this->recursiveEncode($value)) as $subKey => $subValue) {
-                    if (property_exists($result, $subKey)) {
+                    if (property_exists($result, (string) $subKey)) {
                         throw new LogicException(sprintf('Duplicate key "%s" in query object', $subKey));
                     }
 
                     $result->{$subKey} = $subValue;
                 }
             } else {
-                if (property_exists($result, $key)) {
+                if (property_exists($result, (string) $key)) {
                     throw new LogicException(sprintf('Duplicate key "%s" in query object', $key));
                 }
 

--- a/src/Builder/Expression/AddOperator.php
+++ b/src/Builder/Expression/AddOperator.php
@@ -38,9 +38,11 @@ class AddOperator implements ResolvesToNumber, ResolvesToDate, OperatorInterface
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
+
         if (! array_is_list($expression)) {
             throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
         }
+
         $this->expression = $expression;
     }
 

--- a/src/Builder/Expression/AllElementsTrueOperator.php
+++ b/src/Builder/Expression/AllElementsTrueOperator.php
@@ -37,9 +37,11 @@ class AllElementsTrueOperator implements ResolvesToBool, OperatorInterface
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
+
         if (! array_is_list($expression)) {
             throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
         }
+
         $this->expression = $expression;
     }
 

--- a/src/Builder/Expression/AndOperator.php
+++ b/src/Builder/Expression/AndOperator.php
@@ -41,9 +41,11 @@ class AndOperator implements ResolvesToBool, OperatorInterface
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
+
         if (! array_is_list($expression)) {
             throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
         }
+
         $this->expression = $expression;
     }
 

--- a/src/Builder/Expression/AvgOperator.php
+++ b/src/Builder/Expression/AvgOperator.php
@@ -38,9 +38,11 @@ class AvgOperator implements ResolvesToNumber, OperatorInterface
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
+
         if (! array_is_list($expression)) {
             throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
         }
+
         $this->expression = $expression;
     }
 

--- a/src/Builder/Expression/BitAndOperator.php
+++ b/src/Builder/Expression/BitAndOperator.php
@@ -37,9 +37,11 @@ class BitAndOperator implements ResolvesToInt, ResolvesToLong, OperatorInterface
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
+
         if (! array_is_list($expression)) {
             throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
         }
+
         $this->expression = $expression;
     }
 

--- a/src/Builder/Expression/BitOrOperator.php
+++ b/src/Builder/Expression/BitOrOperator.php
@@ -37,9 +37,11 @@ class BitOrOperator implements ResolvesToInt, ResolvesToLong, OperatorInterface
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
+
         if (! array_is_list($expression)) {
             throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
         }
+
         $this->expression = $expression;
     }
 

--- a/src/Builder/Expression/BitXorOperator.php
+++ b/src/Builder/Expression/BitXorOperator.php
@@ -37,9 +37,11 @@ class BitXorOperator implements ResolvesToInt, ResolvesToLong, OperatorInterface
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
+
         if (! array_is_list($expression)) {
             throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
         }
+
         $this->expression = $expression;
     }
 

--- a/src/Builder/Expression/ConcatArraysOperator.php
+++ b/src/Builder/Expression/ConcatArraysOperator.php
@@ -37,9 +37,11 @@ class ConcatArraysOperator implements ResolvesToArray, OperatorInterface
         if (\count($array) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $array, got %d.', 1, \count($array)));
         }
+
         if (! array_is_list($array)) {
             throw new InvalidArgumentException('Expected $array arguments to be a list (array), named arguments are not supported');
         }
+
         $this->array = $array;
     }
 

--- a/src/Builder/Expression/ConcatOperator.php
+++ b/src/Builder/Expression/ConcatOperator.php
@@ -35,9 +35,11 @@ class ConcatOperator implements ResolvesToString, OperatorInterface
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
+
         if (! array_is_list($expression)) {
             throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
         }
+
         $this->expression = $expression;
     }
 

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -71,6 +71,7 @@ trait FactoryTrait
      * Adds numbers to return the sum, or adds numbers and a date to return a new date. If adding numbers and a date, treats the numbers as milliseconds. Accepts any number of argument expressions, but at most, one expression can resolve to a date.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/add/
+     * @no-named-arguments
      * @param Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int ...$expression The arguments can be any valid expression as long as they resolve to either all numbers or to numbers and a date.
      */
     public static function add(
@@ -84,6 +85,7 @@ trait FactoryTrait
      * Returns true if no element of a set evaluates to false, otherwise, returns false. Accepts a single argument expression.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/allElementsTrue/
+     * @no-named-arguments
      * @param BSONArray|PackedArray|ResolvesToArray|array ...$expression
      */
     public static function allElementsTrue(
@@ -97,6 +99,7 @@ trait FactoryTrait
      * Returns true only when all its expressions evaluate to true. Accepts any number of argument expressions.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/and/
+     * @no-named-arguments
      * @param Decimal128|ExpressionInterface|Int64|ResolvesToBool|ResolvesToNull|ResolvesToNumber|ResolvesToString|Type|array|bool|float|int|non-empty-string|null|stdClass ...$expression
      */
     public static function and(
@@ -219,6 +222,7 @@ trait FactoryTrait
      * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/avg/
+     * @no-named-arguments
      * @param Decimal128|Int64|ResolvesToNumber|float|int ...$expression
      */
     public static function avg(Decimal128|Int64|ResolvesToNumber|float|int ...$expression): AvgOperator
@@ -244,6 +248,7 @@ trait FactoryTrait
      * New in MongoDB 6.3.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bitAnd/
+     * @no-named-arguments
      * @param Int64|ResolvesToInt|ResolvesToLong|int ...$expression
      */
     public static function bitAnd(Int64|ResolvesToInt|ResolvesToLong|int ...$expression): BitAndOperator
@@ -268,6 +273,7 @@ trait FactoryTrait
      * New in MongoDB 6.3.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bitOr/
+     * @no-named-arguments
      * @param Int64|ResolvesToInt|ResolvesToLong|int ...$expression
      */
     public static function bitOr(Int64|ResolvesToInt|ResolvesToLong|int ...$expression): BitOrOperator
@@ -280,6 +286,7 @@ trait FactoryTrait
      * New in MongoDB 6.3.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bitXor/
+     * @no-named-arguments
      * @param Int64|ResolvesToInt|ResolvesToLong|int ...$expression
      */
     public static function bitXor(Int64|ResolvesToInt|ResolvesToLong|int ...$expression): BitXorOperator
@@ -330,6 +337,7 @@ trait FactoryTrait
      * Concatenates any number of strings.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/concat/
+     * @no-named-arguments
      * @param ResolvesToString|non-empty-string ...$expression
      */
     public static function concat(ResolvesToString|string ...$expression): ConcatOperator
@@ -341,6 +349,7 @@ trait FactoryTrait
      * Concatenates arrays to return the concatenated array.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/concatArrays/
+     * @no-named-arguments
      * @param BSONArray|PackedArray|ResolvesToArray|array ...$array
      */
     public static function concatArrays(PackedArray|ResolvesToArray|BSONArray|array ...$array): ConcatArraysOperator
@@ -806,6 +815,7 @@ trait FactoryTrait
      * Returns either the non-null result of the first expression or the result of the second expression if the first expression results in a null result. Null result encompasses instances of undefined values or missing fields. Accepts two expressions as arguments. The result of the second expression can be null.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/ifNull/
+     * @no-named-arguments
      * @param ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass ...$expression
      */
     public static function ifNull(
@@ -920,6 +930,7 @@ trait FactoryTrait
      * Determines if the operand is an array. Returns a boolean.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/isArray/
+     * @no-named-arguments
      * @param ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass ...$expression
      */
     public static function isArray(
@@ -935,6 +946,7 @@ trait FactoryTrait
      * New in MongoDB 4.4.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/isNumber/
+     * @no-named-arguments
      * @param ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass ...$expression
      */
     public static function isNumber(
@@ -1153,6 +1165,7 @@ trait FactoryTrait
      * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/max/
+     * @no-named-arguments
      * @param ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass ...$expression
      */
     public static function max(
@@ -1225,6 +1238,7 @@ trait FactoryTrait
      * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/min/
+     * @no-named-arguments
      * @param ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass ...$expression
      */
     public static function min(
@@ -1298,6 +1312,7 @@ trait FactoryTrait
      * Multiplies numbers to return the product. Accepts any number of argument expressions.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/multiply/
+     * @no-named-arguments
      * @param Decimal128|Int64|ResolvesToNumber|float|int ...$expression The arguments can be any valid expression as long as they resolve to numbers.
      * Starting in MongoDB 6.1 you can optimize the $multiply operation. To improve performance, group references at the end of the argument list.
      */
@@ -1351,6 +1366,7 @@ trait FactoryTrait
      * Returns true when any of its expressions evaluates to true. Accepts any number of argument expressions.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/or/
+     * @no-named-arguments
      * @param ExpressionInterface|ResolvesToBool|Type|array|bool|float|int|non-empty-string|null|stdClass ...$expression
      */
     public static function or(
@@ -1655,6 +1671,7 @@ trait FactoryTrait
      * Returns true if the input sets have the same distinct elements. Accepts two or more argument expressions.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setEquals/
+     * @no-named-arguments
      * @param BSONArray|PackedArray|ResolvesToArray|array ...$expression
      */
     public static function setEquals(PackedArray|ResolvesToArray|BSONArray|array ...$expression): SetEqualsOperator
@@ -1685,6 +1702,7 @@ trait FactoryTrait
      * Returns a set with elements that appear in all of the input sets. Accepts any number of argument expressions.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setIntersection/
+     * @no-named-arguments
      * @param BSONArray|PackedArray|ResolvesToArray|array ...$expression
      */
     public static function setIntersection(
@@ -1713,6 +1731,7 @@ trait FactoryTrait
      * Returns a set with elements that appear in any of the input sets.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setUnion/
+     * @no-named-arguments
      * @param BSONArray|PackedArray|ResolvesToArray|array ...$expression
      */
     public static function setUnion(PackedArray|ResolvesToArray|BSONArray|array ...$expression): SetUnionOperator
@@ -1822,6 +1841,7 @@ trait FactoryTrait
      * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/stdDevPop/
+     * @no-named-arguments
      * @param Decimal128|Int64|ResolvesToNumber|float|int ...$expression
      */
     public static function stdDevPop(Decimal128|Int64|ResolvesToNumber|float|int ...$expression): StdDevPopOperator
@@ -1834,6 +1854,7 @@ trait FactoryTrait
      * If the values represent the entire population of data or you do not wish to generalize about a larger population, use $stdDevPop instead.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/stdDevSamp/
+     * @no-named-arguments
      * @param Decimal128|Int64|ResolvesToNumber|float|int ...$expression
      */
     public static function stdDevSamp(Decimal128|Int64|ResolvesToNumber|float|int ...$expression): StdDevSampOperator
@@ -1949,6 +1970,7 @@ trait FactoryTrait
      * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sum/
+     * @no-named-arguments
      * @param Decimal128|Int64|ResolvesToNumber|float|int ...$expression
      */
     public static function sum(Decimal128|Int64|ResolvesToNumber|float|int ...$expression): SumOperator

--- a/src/Builder/Expression/IfNullOperator.php
+++ b/src/Builder/Expression/IfNullOperator.php
@@ -38,9 +38,11 @@ class IfNullOperator implements ResolvesToAny, OperatorInterface
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
+
         if (! array_is_list($expression)) {
             throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
         }
+
         $this->expression = $expression;
     }
 

--- a/src/Builder/Expression/IsArrayOperator.php
+++ b/src/Builder/Expression/IsArrayOperator.php
@@ -38,9 +38,11 @@ class IsArrayOperator implements ResolvesToBool, OperatorInterface
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
+
         if (! array_is_list($expression)) {
             throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
         }
+
         $this->expression = $expression;
     }
 

--- a/src/Builder/Expression/IsNumberOperator.php
+++ b/src/Builder/Expression/IsNumberOperator.php
@@ -40,9 +40,11 @@ class IsNumberOperator implements ResolvesToBool, OperatorInterface
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
+
         if (! array_is_list($expression)) {
             throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
         }
+
         $this->expression = $expression;
     }
 

--- a/src/Builder/Expression/MaxOperator.php
+++ b/src/Builder/Expression/MaxOperator.php
@@ -39,9 +39,11 @@ class MaxOperator implements ResolvesToAny, OperatorInterface
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
+
         if (! array_is_list($expression)) {
             throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
         }
+
         $this->expression = $expression;
     }
 

--- a/src/Builder/Expression/MinOperator.php
+++ b/src/Builder/Expression/MinOperator.php
@@ -39,9 +39,11 @@ class MinOperator implements ResolvesToAny, OperatorInterface
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
+
         if (! array_is_list($expression)) {
             throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
         }
+
         $this->expression = $expression;
     }
 

--- a/src/Builder/Expression/MultiplyOperator.php
+++ b/src/Builder/Expression/MultiplyOperator.php
@@ -41,9 +41,11 @@ class MultiplyOperator implements ResolvesToDecimal, OperatorInterface
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
+
         if (! array_is_list($expression)) {
             throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
         }
+
         $this->expression = $expression;
     }
 

--- a/src/Builder/Expression/OrOperator.php
+++ b/src/Builder/Expression/OrOperator.php
@@ -39,9 +39,11 @@ class OrOperator implements ResolvesToBool, OperatorInterface
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
+
         if (! array_is_list($expression)) {
             throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
         }
+
         $this->expression = $expression;
     }
 

--- a/src/Builder/Expression/SetEqualsOperator.php
+++ b/src/Builder/Expression/SetEqualsOperator.php
@@ -37,9 +37,11 @@ class SetEqualsOperator implements ResolvesToBool, OperatorInterface
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
+
         if (! array_is_list($expression)) {
             throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
         }
+
         $this->expression = $expression;
     }
 

--- a/src/Builder/Expression/SetIntersectionOperator.php
+++ b/src/Builder/Expression/SetIntersectionOperator.php
@@ -37,9 +37,11 @@ class SetIntersectionOperator implements ResolvesToArray, OperatorInterface
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
+
         if (! array_is_list($expression)) {
             throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
         }
+
         $this->expression = $expression;
     }
 

--- a/src/Builder/Expression/SetUnionOperator.php
+++ b/src/Builder/Expression/SetUnionOperator.php
@@ -37,9 +37,11 @@ class SetUnionOperator implements ResolvesToArray, OperatorInterface
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
+
         if (! array_is_list($expression)) {
             throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
         }
+
         $this->expression = $expression;
     }
 

--- a/src/Builder/Expression/StdDevPopOperator.php
+++ b/src/Builder/Expression/StdDevPopOperator.php
@@ -39,9 +39,11 @@ class StdDevPopOperator implements ResolvesToDouble, OperatorInterface
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
+
         if (! array_is_list($expression)) {
             throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
         }
+
         $this->expression = $expression;
     }
 

--- a/src/Builder/Expression/StdDevSampOperator.php
+++ b/src/Builder/Expression/StdDevSampOperator.php
@@ -38,9 +38,11 @@ class StdDevSampOperator implements ResolvesToDouble, OperatorInterface
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
+
         if (! array_is_list($expression)) {
             throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
         }
+
         $this->expression = $expression;
     }
 

--- a/src/Builder/Expression/SumOperator.php
+++ b/src/Builder/Expression/SumOperator.php
@@ -38,9 +38,11 @@ class SumOperator implements ResolvesToNumber, OperatorInterface
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
+
         if (! array_is_list($expression)) {
             throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
         }
+
         $this->expression = $expression;
     }
 

--- a/src/Builder/Projection/ElemMatchOperator.php
+++ b/src/Builder/Projection/ElemMatchOperator.php
@@ -8,17 +8,13 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Projection;
 
-use MongoDB\BSON\Document;
-use MongoDB\BSON\Serializable;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
 use MongoDB\Builder\Type\ProjectionInterface;
 use MongoDB\Builder\Type\QueryInterface;
 use MongoDB\Builder\Type\QueryObject;
-use stdClass;
 
 use function is_array;
-use function is_object;
 
 /**
  * Projects the first element in an array that matches the specified $elemMatch condition.
@@ -29,16 +25,16 @@ class ElemMatchOperator implements ProjectionInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
-    /** @var Document|QueryInterface|Serializable|array|stdClass $query */
-    public readonly Document|Serializable|QueryInterface|stdClass|array $query;
+    /** @var QueryInterface|array $query */
+    public readonly QueryInterface|array $query;
 
     /**
-     * @param Document|QueryInterface|Serializable|array|stdClass $query
+     * @param QueryInterface|array $query
      */
-    public function __construct(Document|Serializable|QueryInterface|stdClass|array $query)
+    public function __construct(QueryInterface|array $query)
     {
-        if (is_array($query) || is_object($query)) {
-            $query = QueryObject::create(...$query);
+        if (is_array($query)) {
+            $query = QueryObject::create($query);
         }
 
         $this->query = $query;

--- a/src/Builder/Projection/FactoryTrait.php
+++ b/src/Builder/Projection/FactoryTrait.php
@@ -8,16 +8,13 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Projection;
 
-use MongoDB\BSON\Document;
 use MongoDB\BSON\PackedArray;
-use MongoDB\BSON\Serializable;
 use MongoDB\Builder\Expression\ResolvesToArray;
 use MongoDB\Builder\Expression\ResolvesToBool;
 use MongoDB\Builder\Expression\ResolvesToInt;
 use MongoDB\Builder\Type\Optional;
 use MongoDB\Builder\Type\QueryInterface;
 use MongoDB\Model\BSONArray;
-use stdClass;
 
 /**
  * @internal
@@ -28,9 +25,9 @@ trait FactoryTrait
      * Projects the first element in an array that matches the specified $elemMatch condition.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/projection/elemMatch/
-     * @param Document|QueryInterface|Serializable|array|stdClass $query
+     * @param QueryInterface|array $query
      */
-    public static function elemMatch(Document|Serializable|QueryInterface|stdClass|array $query): ElemMatchOperator
+    public static function elemMatch(QueryInterface|array $query): ElemMatchOperator
     {
         return new ElemMatchOperator($query);
     }

--- a/src/Builder/Query.php
+++ b/src/Builder/Query.php
@@ -42,7 +42,7 @@ final class Query
 
     public static function query(FieldQueryInterface|QueryInterface|Serializable|array|bool|float|int|stdClass|string|null ...$query): QueryInterface
     {
-        return QueryObject::create(...$query);
+        return QueryObject::create($query);
     }
 
     private function __construct()

--- a/src/Builder/Query/AllOperator.php
+++ b/src/Builder/Query/AllOperator.php
@@ -38,9 +38,11 @@ class AllOperator implements FieldQueryInterface, OperatorInterface
         if (\count($value) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $value, got %d.', 1, \count($value)));
         }
+
         if (! array_is_list($value)) {
             throw new InvalidArgumentException('Expected $value arguments to be a list (array), named arguments are not supported');
         }
+
         $this->value = $value;
     }
 

--- a/src/Builder/Query/AndOperator.php
+++ b/src/Builder/Query/AndOperator.php
@@ -8,13 +8,10 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Query;
 
-use MongoDB\BSON\Document;
-use MongoDB\BSON\Serializable;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
 use MongoDB\Builder\Type\QueryInterface;
 use MongoDB\Exception\InvalidArgumentException;
-use stdClass;
 
 use function array_is_list;
 
@@ -27,22 +24,22 @@ class AndOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 
-    /** @var list<Document|QueryInterface|Serializable|array|stdClass> $expression */
-    public readonly array $expression;
+    /** @var list<QueryInterface|array> $queries */
+    public readonly array $queries;
 
     /**
-     * @param Document|QueryInterface|Serializable|array|stdClass ...$expression
+     * @param QueryInterface|array ...$queries
      * @no-named-arguments
      */
-    public function __construct(Document|Serializable|QueryInterface|stdClass|array ...$expression)
+    public function __construct(QueryInterface|array ...$queries)
     {
-        if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
+        if (\count($queries) < 2) {
+            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $queries, got %d.', 2, \count($queries)));
         }
-        if (! array_is_list($expression)) {
-            throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
+        if (! array_is_list($queries)) {
+            throw new InvalidArgumentException('Expected $queries arguments to be a list (array), named arguments are not supported');
         }
-        $this->expression = $expression;
+        $this->queries = $queries;
     }
 
     public function getOperator(): string

--- a/src/Builder/Query/AndOperator.php
+++ b/src/Builder/Query/AndOperator.php
@@ -33,12 +33,14 @@ class AndOperator implements QueryInterface, OperatorInterface
      */
     public function __construct(QueryInterface|array ...$queries)
     {
-        if (\count($queries) < 2) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $queries, got %d.', 2, \count($queries)));
+        if (\count($queries) < 1) {
+            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $queries, got %d.', 1, \count($queries)));
         }
+
         if (! array_is_list($queries)) {
             throw new InvalidArgumentException('Expected $queries arguments to be a list (array), named arguments are not supported');
         }
+
         $this->queries = $queries;
     }
 

--- a/src/Builder/Query/ElemMatchOperator.php
+++ b/src/Builder/Query/ElemMatchOperator.php
@@ -8,17 +8,13 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Query;
 
-use MongoDB\BSON\Document;
-use MongoDB\BSON\Serializable;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\FieldQueryInterface;
 use MongoDB\Builder\Type\OperatorInterface;
 use MongoDB\Builder\Type\QueryInterface;
 use MongoDB\Builder\Type\QueryObject;
-use stdClass;
 
 use function is_array;
-use function is_object;
 
 /**
  * The $elemMatch operator matches documents that contain an array field with at least one element that matches all the specified query criteria.
@@ -29,16 +25,16 @@ class ElemMatchOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
-    /** @var Document|QueryInterface|Serializable|array|stdClass $query */
-    public readonly Document|Serializable|QueryInterface|stdClass|array $query;
+    /** @var QueryInterface|array $query */
+    public readonly QueryInterface|array $query;
 
     /**
-     * @param Document|QueryInterface|Serializable|array|stdClass $query
+     * @param QueryInterface|array $query
      */
-    public function __construct(Document|Serializable|QueryInterface|stdClass|array $query)
+    public function __construct(QueryInterface|array $query)
     {
-        if (is_array($query) || is_object($query)) {
-            $query = QueryObject::create(...$query);
+        if (is_array($query)) {
+            $query = QueryObject::create($query);
         }
 
         $this->query = $query;

--- a/src/Builder/Query/FactoryTrait.php
+++ b/src/Builder/Query/FactoryTrait.php
@@ -33,6 +33,7 @@ trait FactoryTrait
      * Matches arrays that contain all elements specified in the query.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/all/
+     * @no-named-arguments
      * @param Type|array|bool|float|int|non-empty-string|null|stdClass ...$value
      */
     public static function all(Type|stdClass|array|bool|float|int|null|string ...$value): AllOperator
@@ -44,6 +45,7 @@ trait FactoryTrait
      * Joins query clauses with a logical AND returns all documents that match the conditions of both clauses.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/and/
+     * @no-named-arguments
      * @param Document|QueryInterface|Serializable|array|stdClass ...$expression
      */
     public static function and(Document|Serializable|QueryInterface|stdClass|array ...$expression): AndOperator
@@ -398,6 +400,7 @@ trait FactoryTrait
      * Joins query clauses with a logical NOR returns all documents that fail to match both clauses.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/nor/
+     * @no-named-arguments
      * @param Document|QueryInterface|Serializable|array|stdClass ...$expression
      */
     public static function nor(Document|Serializable|QueryInterface|stdClass|array ...$expression): NorOperator
@@ -420,6 +423,7 @@ trait FactoryTrait
      * Joins query clauses with a logical OR returns all documents that match the conditions of either clause.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/or/
+     * @no-named-arguments
      * @param Document|QueryInterface|Serializable|array|stdClass ...$expression
      */
     public static function or(Document|Serializable|QueryInterface|stdClass|array ...$expression): OrOperator

--- a/src/Builder/Query/FactoryTrait.php
+++ b/src/Builder/Query/FactoryTrait.php
@@ -18,6 +18,7 @@ use MongoDB\BSON\Regex;
 use MongoDB\BSON\Serializable;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\ExpressionInterface;
+use MongoDB\Builder\Type\FieldQueryInterface;
 use MongoDB\Builder\Type\GeometryInterface;
 use MongoDB\Builder\Type\Optional;
 use MongoDB\Builder\Type\QueryInterface;
@@ -46,11 +47,11 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/and/
      * @no-named-arguments
-     * @param Document|QueryInterface|Serializable|array|stdClass ...$expression
+     * @param QueryInterface|array ...$queries
      */
-    public static function and(Document|Serializable|QueryInterface|stdClass|array ...$expression): AndOperator
+    public static function and(QueryInterface|array ...$queries): AndOperator
     {
-        return new AndOperator(...$expression);
+        return new AndOperator(...$queries);
     }
 
     /**
@@ -145,9 +146,9 @@ trait FactoryTrait
      * The $elemMatch operator matches documents that contain an array field with at least one element that matches all the specified query criteria.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/elemMatch/
-     * @param Document|QueryInterface|Serializable|array|stdClass $query
+     * @param QueryInterface|array $query
      */
-    public static function elemMatch(Document|Serializable|QueryInterface|stdClass|array $query): ElemMatchOperator
+    public static function elemMatch(QueryInterface|array $query): ElemMatchOperator
     {
         return new ElemMatchOperator($query);
     }
@@ -401,20 +402,22 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/nor/
      * @no-named-arguments
-     * @param Document|QueryInterface|Serializable|array|stdClass ...$expression
+     * @param QueryInterface|array ...$queries
      */
-    public static function nor(Document|Serializable|QueryInterface|stdClass|array ...$expression): NorOperator
+    public static function nor(QueryInterface|array ...$queries): NorOperator
     {
-        return new NorOperator(...$expression);
+        return new NorOperator(...$queries);
     }
 
     /**
      * Inverts the effect of a query expression and returns documents that do not match the query expression.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/not/
-     * @param Document|QueryInterface|Regex|Serializable|array|stdClass $expression
+     * @param FieldQueryInterface|Regex|array|bool|float|int|non-empty-string|null|stdClass $expression
      */
-    public static function not(Document|Regex|Serializable|QueryInterface|stdClass|array $expression): NotOperator
+    public static function not(
+        Regex|FieldQueryInterface|stdClass|array|bool|float|int|null|string $expression,
+    ): NotOperator
     {
         return new NotOperator($expression);
     }
@@ -424,11 +427,11 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/or/
      * @no-named-arguments
-     * @param Document|QueryInterface|Serializable|array|stdClass ...$expression
+     * @param QueryInterface|array ...$queries
      */
-    public static function or(Document|Serializable|QueryInterface|stdClass|array ...$expression): OrOperator
+    public static function or(QueryInterface|array ...$queries): OrOperator
     {
-        return new OrOperator(...$expression);
+        return new OrOperator(...$queries);
     }
 
     /**

--- a/src/Builder/Query/FactoryTrait.php
+++ b/src/Builder/Query/FactoryTrait.php
@@ -413,10 +413,10 @@ trait FactoryTrait
      * Inverts the effect of a query expression and returns documents that do not match the query expression.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/not/
-     * @param FieldQueryInterface|Regex|array|bool|float|int|non-empty-string|null|stdClass $expression
+     * @param Decimal128|FieldQueryInterface|Int64|Regex|array|bool|float|int|non-empty-string|null|stdClass $expression
      */
     public static function not(
-        Regex|FieldQueryInterface|stdClass|array|bool|float|int|null|string $expression,
+        Decimal128|Int64|Regex|FieldQueryInterface|stdClass|array|bool|float|int|null|string $expression,
     ): NotOperator
     {
         return new NotOperator($expression);

--- a/src/Builder/Query/NorOperator.php
+++ b/src/Builder/Query/NorOperator.php
@@ -33,12 +33,14 @@ class NorOperator implements QueryInterface, OperatorInterface
      */
     public function __construct(QueryInterface|array ...$queries)
     {
-        if (\count($queries) < 2) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $queries, got %d.', 2, \count($queries)));
+        if (\count($queries) < 1) {
+            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $queries, got %d.', 1, \count($queries)));
         }
+
         if (! array_is_list($queries)) {
             throw new InvalidArgumentException('Expected $queries arguments to be a list (array), named arguments are not supported');
         }
+
         $this->queries = $queries;
     }
 

--- a/src/Builder/Query/NorOperator.php
+++ b/src/Builder/Query/NorOperator.php
@@ -8,13 +8,10 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Query;
 
-use MongoDB\BSON\Document;
-use MongoDB\BSON\Serializable;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
 use MongoDB\Builder\Type\QueryInterface;
 use MongoDB\Exception\InvalidArgumentException;
-use stdClass;
 
 use function array_is_list;
 
@@ -27,22 +24,22 @@ class NorOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 
-    /** @var list<Document|QueryInterface|Serializable|array|stdClass> $expression */
-    public readonly array $expression;
+    /** @var list<QueryInterface|array> $queries */
+    public readonly array $queries;
 
     /**
-     * @param Document|QueryInterface|Serializable|array|stdClass ...$expression
+     * @param QueryInterface|array ...$queries
      * @no-named-arguments
      */
-    public function __construct(Document|Serializable|QueryInterface|stdClass|array ...$expression)
+    public function __construct(QueryInterface|array ...$queries)
     {
-        if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
+        if (\count($queries) < 2) {
+            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $queries, got %d.', 2, \count($queries)));
         }
-        if (! array_is_list($expression)) {
-            throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
+        if (! array_is_list($queries)) {
+            throw new InvalidArgumentException('Expected $queries arguments to be a list (array), named arguments are not supported');
         }
-        $this->expression = $expression;
+        $this->queries = $queries;
     }
 
     public function getOperator(): string

--- a/src/Builder/Query/NotOperator.php
+++ b/src/Builder/Query/NotOperator.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Query;
 
+use MongoDB\BSON\Decimal128;
+use MongoDB\BSON\Int64;
 use MongoDB\BSON\Regex;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\FieldQueryInterface;
@@ -23,14 +25,15 @@ class NotOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 
-    /** @var FieldQueryInterface|Regex|array|bool|float|int|non-empty-string|null|stdClass $expression */
-    public readonly Regex|FieldQueryInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var Decimal128|FieldQueryInterface|Int64|Regex|array|bool|float|int|non-empty-string|null|stdClass $expression */
+    public readonly Decimal128|Int64|Regex|FieldQueryInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param FieldQueryInterface|Regex|array|bool|float|int|non-empty-string|null|stdClass $expression
+     * @param Decimal128|FieldQueryInterface|Int64|Regex|array|bool|float|int|non-empty-string|null|stdClass $expression
      */
-    public function __construct(Regex|FieldQueryInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        Decimal128|Int64|Regex|FieldQueryInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 

--- a/src/Builder/Query/NotOperator.php
+++ b/src/Builder/Query/NotOperator.php
@@ -8,18 +8,11 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Query;
 
-use MongoDB\BSON\Document;
 use MongoDB\BSON\Regex;
-use MongoDB\BSON\Serializable;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\FieldQueryInterface;
 use MongoDB\Builder\Type\OperatorInterface;
-use MongoDB\Builder\Type\QueryInterface;
-use MongoDB\Builder\Type\QueryObject;
 use stdClass;
-
-use function is_array;
-use function is_object;
 
 /**
  * Inverts the effect of a query expression and returns documents that do not match the query expression.
@@ -30,18 +23,14 @@ class NotOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 
-    /** @var Document|QueryInterface|Regex|Serializable|array|stdClass $expression */
-    public readonly Document|Regex|Serializable|QueryInterface|stdClass|array $expression;
+    /** @var FieldQueryInterface|Regex|array|bool|float|int|non-empty-string|null|stdClass $expression */
+    public readonly Regex|FieldQueryInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param Document|QueryInterface|Regex|Serializable|array|stdClass $expression
+     * @param FieldQueryInterface|Regex|array|bool|float|int|non-empty-string|null|stdClass $expression
      */
-    public function __construct(Document|Regex|Serializable|QueryInterface|stdClass|array $expression)
+    public function __construct(Regex|FieldQueryInterface|stdClass|array|bool|float|int|null|string $expression)
     {
-        if (is_array($expression) || is_object($expression)) {
-            $expression = QueryObject::create(...$expression);
-        }
-
         $this->expression = $expression;
     }
 

--- a/src/Builder/Query/OrOperator.php
+++ b/src/Builder/Query/OrOperator.php
@@ -8,13 +8,10 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Query;
 
-use MongoDB\BSON\Document;
-use MongoDB\BSON\Serializable;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
 use MongoDB\Builder\Type\QueryInterface;
 use MongoDB\Exception\InvalidArgumentException;
-use stdClass;
 
 use function array_is_list;
 
@@ -27,22 +24,22 @@ class OrOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 
-    /** @var list<Document|QueryInterface|Serializable|array|stdClass> $expression */
-    public readonly array $expression;
+    /** @var list<QueryInterface|array> $queries */
+    public readonly array $queries;
 
     /**
-     * @param Document|QueryInterface|Serializable|array|stdClass ...$expression
+     * @param QueryInterface|array ...$queries
      * @no-named-arguments
      */
-    public function __construct(Document|Serializable|QueryInterface|stdClass|array ...$expression)
+    public function __construct(QueryInterface|array ...$queries)
     {
-        if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
+        if (\count($queries) < 2) {
+            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $queries, got %d.', 2, \count($queries)));
         }
-        if (! array_is_list($expression)) {
-            throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
+        if (! array_is_list($queries)) {
+            throw new InvalidArgumentException('Expected $queries arguments to be a list (array), named arguments are not supported');
         }
-        $this->expression = $expression;
+        $this->queries = $queries;
     }
 
     public function getOperator(): string

--- a/src/Builder/Query/OrOperator.php
+++ b/src/Builder/Query/OrOperator.php
@@ -33,12 +33,14 @@ class OrOperator implements QueryInterface, OperatorInterface
      */
     public function __construct(QueryInterface|array ...$queries)
     {
-        if (\count($queries) < 2) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $queries, got %d.', 2, \count($queries)));
+        if (\count($queries) < 1) {
+            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $queries, got %d.', 1, \count($queries)));
         }
+
         if (! array_is_list($queries)) {
             throw new InvalidArgumentException('Expected $queries arguments to be a list (array), named arguments are not supported');
         }
+
         $this->queries = $queries;
     }
 

--- a/src/Builder/Stage.php
+++ b/src/Builder/Stage.php
@@ -23,7 +23,7 @@ final class Stage
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/match/
      *
-     * @param QueryInterface|FieldQueryInterface|Decimal128|Int64|Regex|stdClass|array|bool|float|int|string|null ...$queries The query predicates to match
+     * @param QueryInterface|FieldQueryInterface|Decimal128|Int64|Regex|stdClass|array<array-key,mixed>|bool|float|int|string|null ...$queries The query predicates to match
      */
     public static function match(QueryInterface|FieldQueryInterface|Decimal128|Int64|Regex|stdClass|array|bool|float|int|string|null ...$queries): MatchStage
     {

--- a/src/Builder/Stage.php
+++ b/src/Builder/Stage.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder;
 
-use MongoDB\BSON\Serializable;
+use MongoDB\BSON\Decimal128;
+use MongoDB\BSON\Int64;
+use MongoDB\BSON\Regex;
 use MongoDB\Builder\Stage\MatchStage;
 use MongoDB\Builder\Type\FieldQueryInterface;
 use MongoDB\Builder\Type\QueryInterface;
@@ -21,9 +23,9 @@ final class Stage
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/match/
      *
-     * @param FieldQueryInterface|QueryInterface|Serializable|array<mixed>|bool|float|int|stdClass|string|null ...$queries The query predicates to match
+     * @param QueryInterface|FieldQueryInterface|Decimal128|Int64|Regex|stdClass|array|bool|float|int|string|null ...$queries The query predicates to match
      */
-    public static function match(FieldQueryInterface|QueryInterface|Serializable|array|bool|float|int|stdClass|string|null ...$queries): MatchStage
+    public static function match(QueryInterface|FieldQueryInterface|Decimal128|Int64|Regex|stdClass|array|bool|float|int|string|null ...$queries): MatchStage
     {
         // Override the generated method to allow variadic arguments
         return self::generatedMatch($queries);

--- a/src/Builder/Stage/AddFieldsStage.php
+++ b/src/Builder/Stage/AddFieldsStage.php
@@ -38,11 +38,13 @@ class AddFieldsStage implements StageInterface, OperatorInterface
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
+
         foreach($expression as $key => $value) {
             if (! is_string($key)) {
                 throw new InvalidArgumentException('Expected $expression arguments to be a map (object), named arguments (<name>:<value>) or array unpacking ...[\'<name>\' => <value>] must be used');
             }
         }
+
         $expression = (object) $expression;
         $this->expression = $expression;
     }

--- a/src/Builder/Stage/FacetStage.php
+++ b/src/Builder/Stage/FacetStage.php
@@ -39,11 +39,13 @@ class FacetStage implements StageInterface, OperatorInterface
         if (\count($facet) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $facet, got %d.', 1, \count($facet)));
         }
+
         foreach($facet as $key => $value) {
             if (! is_string($key)) {
                 throw new InvalidArgumentException('Expected $facet arguments to be a map (object), named arguments (<name>:<value>) or array unpacking ...[\'<name>\' => <value>] must be used');
             }
         }
+
         $facet = (object) $facet;
         $this->facet = $facet;
     }

--- a/src/Builder/Stage/FactoryTrait.php
+++ b/src/Builder/Stage/FactoryTrait.php
@@ -247,7 +247,7 @@ trait FactoryTrait
      * Specify the distance in meters if the specified point is GeoJSON and in radians if the specified point is legacy coordinate pairs.
      * @param Optional|Decimal128|Int64|float|int $minDistance The minimum distance from the center point that the documents can be. MongoDB limits the results to those documents that fall outside the specified distance from the center point.
      * Specify the distance in meters for GeoJSON data and in radians for legacy coordinate pairs.
-     * @param Optional|Document|QueryInterface|Serializable|array|stdClass $query Limits the results to the documents that match the query. The query syntax is the usual MongoDB read operation query syntax.
+     * @param Optional|QueryInterface|array $query Limits the results to the documents that match the query. The query syntax is the usual MongoDB read operation query syntax.
      * You cannot specify a $near predicate in the query field of the $geoNear stage.
      * @param Optional|bool $spherical Determines how MongoDB calculates the distance between two points:
      * - When true, MongoDB uses $nearSphere semantics and calculates distances using spherical geometry.
@@ -262,7 +262,7 @@ trait FactoryTrait
         Optional|string $key = Optional::Undefined,
         Optional|Decimal128|Int64|float|int $maxDistance = Optional::Undefined,
         Optional|Decimal128|Int64|float|int $minDistance = Optional::Undefined,
-        Optional|Document|Serializable|QueryInterface|stdClass|array $query = Optional::Undefined,
+        Optional|QueryInterface|array $query = Optional::Undefined,
         Optional|bool $spherical = Optional::Undefined,
     ): GeoNearStage
     {
@@ -281,7 +281,7 @@ trait FactoryTrait
      * @param non-empty-string $as Name of the array field added to each output document. Contains the documents traversed in the $graphLookup stage to reach the document.
      * @param Optional|int $maxDepth Non-negative integral number specifying the maximum recursion depth.
      * @param Optional|non-empty-string $depthField Name of the field to add to each traversed document in the search path. The value of this field is the recursion depth for the document, represented as a NumberLong. Recursion depth value starts at zero, so the first lookup corresponds to zero depth.
-     * @param Optional|Document|QueryInterface|Serializable|array|stdClass $restrictSearchWithMatch A document specifying additional conditions for the recursive search. The syntax is identical to query filter syntax.
+     * @param Optional|QueryInterface|array $restrictSearchWithMatch A document specifying additional conditions for the recursive search. The syntax is identical to query filter syntax.
      */
     public static function graphLookup(
         string $from,
@@ -291,7 +291,7 @@ trait FactoryTrait
         string $as,
         Optional|int $maxDepth = Optional::Undefined,
         Optional|string $depthField = Optional::Undefined,
-        Optional|Document|Serializable|QueryInterface|stdClass|array $restrictSearchWithMatch = Optional::Undefined,
+        Optional|QueryInterface|array $restrictSearchWithMatch = Optional::Undefined,
     ): GraphLookupStage
     {
         return new GraphLookupStage($from, $startWith, $connectFromField, $connectToField, $as, $maxDepth, $depthField, $restrictSearchWithMatch);
@@ -422,9 +422,9 @@ trait FactoryTrait
      * Filters the document stream to allow only matching documents to pass unmodified into the next pipeline stage. $match uses standard MongoDB queries. For each input document, outputs either one document (a match) or zero documents (no match).
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/match/
-     * @param Document|QueryInterface|Serializable|array|stdClass $query
+     * @param QueryInterface|array $query
      */
-    public static function match(Document|Serializable|QueryInterface|stdClass|array $query): MatchStage
+    public static function match(QueryInterface|array $query): MatchStage
     {
         return new MatchStage($query);
     }

--- a/src/Builder/Stage/FactoryTrait.php
+++ b/src/Builder/Stage/FactoryTrait.php
@@ -667,6 +667,7 @@ trait FactoryTrait
      * Alias for $project stage that removes or excludes fields.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/unset/
+     * @no-named-arguments
      * @param FieldPath|non-empty-string ...$field
      */
     public static function unset(FieldPath|string ...$field): UnsetStage

--- a/src/Builder/Stage/GeoNearStage.php
+++ b/src/Builder/Stage/GeoNearStage.php
@@ -21,7 +21,6 @@ use MongoDB\Builder\Type\StageInterface;
 use stdClass;
 
 use function is_array;
-use function is_object;
 
 /**
  * Returns an ordered stream of documents based on the proximity to a geospatial point. Incorporates the functionality of $match, $sort, and $limit for geospatial data. The output documents include an additional distance field and can include a location identifier field.
@@ -60,10 +59,10 @@ class GeoNearStage implements StageInterface, OperatorInterface
     public readonly Optional|Decimal128|Int64|float|int $minDistance;
 
     /**
-     * @var Optional|Document|QueryInterface|Serializable|array|stdClass $query Limits the results to the documents that match the query. The query syntax is the usual MongoDB read operation query syntax.
+     * @var Optional|QueryInterface|array $query Limits the results to the documents that match the query. The query syntax is the usual MongoDB read operation query syntax.
      * You cannot specify a $near predicate in the query field of the $geoNear stage.
      */
-    public readonly Optional|Document|Serializable|QueryInterface|stdClass|array $query;
+    public readonly Optional|QueryInterface|array $query;
 
     /**
      * @var Optional|bool $spherical Determines how MongoDB calculates the distance between two points:
@@ -83,7 +82,7 @@ class GeoNearStage implements StageInterface, OperatorInterface
      * Specify the distance in meters if the specified point is GeoJSON and in radians if the specified point is legacy coordinate pairs.
      * @param Optional|Decimal128|Int64|float|int $minDistance The minimum distance from the center point that the documents can be. MongoDB limits the results to those documents that fall outside the specified distance from the center point.
      * Specify the distance in meters for GeoJSON data and in radians for legacy coordinate pairs.
-     * @param Optional|Document|QueryInterface|Serializable|array|stdClass $query Limits the results to the documents that match the query. The query syntax is the usual MongoDB read operation query syntax.
+     * @param Optional|QueryInterface|array $query Limits the results to the documents that match the query. The query syntax is the usual MongoDB read operation query syntax.
      * You cannot specify a $near predicate in the query field of the $geoNear stage.
      * @param Optional|bool $spherical Determines how MongoDB calculates the distance between two points:
      * - When true, MongoDB uses $nearSphere semantics and calculates distances using spherical geometry.
@@ -98,7 +97,7 @@ class GeoNearStage implements StageInterface, OperatorInterface
         Optional|string $key = Optional::Undefined,
         Optional|Decimal128|Int64|float|int $maxDistance = Optional::Undefined,
         Optional|Decimal128|Int64|float|int $minDistance = Optional::Undefined,
-        Optional|Document|Serializable|QueryInterface|stdClass|array $query = Optional::Undefined,
+        Optional|QueryInterface|array $query = Optional::Undefined,
         Optional|bool $spherical = Optional::Undefined,
     ) {
         $this->distanceField = $distanceField;
@@ -108,8 +107,8 @@ class GeoNearStage implements StageInterface, OperatorInterface
         $this->key = $key;
         $this->maxDistance = $maxDistance;
         $this->minDistance = $minDistance;
-        if (is_array($query) || is_object($query)) {
-            $query = QueryObject::create(...$query);
+        if (is_array($query)) {
+            $query = QueryObject::create($query);
         }
 
         $this->query = $query;

--- a/src/Builder/Stage/GraphLookupStage.php
+++ b/src/Builder/Stage/GraphLookupStage.php
@@ -8,9 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Stage;
 
-use MongoDB\BSON\Document;
 use MongoDB\BSON\PackedArray;
-use MongoDB\BSON\Serializable;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -25,7 +23,6 @@ use stdClass;
 
 use function array_is_list;
 use function is_array;
-use function is_object;
 
 /**
  * Performs a recursive search on a collection. To each output document, adds a new array field that contains the traversal results of the recursive search for that document.
@@ -60,8 +57,8 @@ class GraphLookupStage implements StageInterface, OperatorInterface
     /** @var Optional|non-empty-string $depthField Name of the field to add to each traversed document in the search path. The value of this field is the recursion depth for the document, represented as a NumberLong. Recursion depth value starts at zero, so the first lookup corresponds to zero depth. */
     public readonly Optional|string $depthField;
 
-    /** @var Optional|Document|QueryInterface|Serializable|array|stdClass $restrictSearchWithMatch A document specifying additional conditions for the recursive search. The syntax is identical to query filter syntax. */
-    public readonly Optional|Document|Serializable|QueryInterface|stdClass|array $restrictSearchWithMatch;
+    /** @var Optional|QueryInterface|array $restrictSearchWithMatch A document specifying additional conditions for the recursive search. The syntax is identical to query filter syntax. */
+    public readonly Optional|QueryInterface|array $restrictSearchWithMatch;
 
     /**
      * @param non-empty-string $from Target collection for the $graphLookup operation to search, recursively matching the connectFromField to the connectToField. The from collection must be in the same database as any other collections used in the operation.
@@ -72,7 +69,7 @@ class GraphLookupStage implements StageInterface, OperatorInterface
      * @param non-empty-string $as Name of the array field added to each output document. Contains the documents traversed in the $graphLookup stage to reach the document.
      * @param Optional|int $maxDepth Non-negative integral number specifying the maximum recursion depth.
      * @param Optional|non-empty-string $depthField Name of the field to add to each traversed document in the search path. The value of this field is the recursion depth for the document, represented as a NumberLong. Recursion depth value starts at zero, so the first lookup corresponds to zero depth.
-     * @param Optional|Document|QueryInterface|Serializable|array|stdClass $restrictSearchWithMatch A document specifying additional conditions for the recursive search. The syntax is identical to query filter syntax.
+     * @param Optional|QueryInterface|array $restrictSearchWithMatch A document specifying additional conditions for the recursive search. The syntax is identical to query filter syntax.
      */
     public function __construct(
         string $from,
@@ -82,7 +79,7 @@ class GraphLookupStage implements StageInterface, OperatorInterface
         string $as,
         Optional|int $maxDepth = Optional::Undefined,
         Optional|string $depthField = Optional::Undefined,
-        Optional|Document|Serializable|QueryInterface|stdClass|array $restrictSearchWithMatch = Optional::Undefined,
+        Optional|QueryInterface|array $restrictSearchWithMatch = Optional::Undefined,
     ) {
         $this->from = $from;
         if (is_array($startWith) && ! array_is_list($startWith)) {
@@ -95,8 +92,8 @@ class GraphLookupStage implements StageInterface, OperatorInterface
         $this->as = $as;
         $this->maxDepth = $maxDepth;
         $this->depthField = $depthField;
-        if (is_array($restrictSearchWithMatch) || is_object($restrictSearchWithMatch)) {
-            $restrictSearchWithMatch = QueryObject::create(...$restrictSearchWithMatch);
+        if (is_array($restrictSearchWithMatch)) {
+            $restrictSearchWithMatch = QueryObject::create($restrictSearchWithMatch);
         }
 
         $this->restrictSearchWithMatch = $restrictSearchWithMatch;

--- a/src/Builder/Stage/GroupStage.php
+++ b/src/Builder/Stage/GroupStage.php
@@ -48,11 +48,13 @@ class GroupStage implements StageInterface, OperatorInterface
         if (\count($field) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $field, got %d.', 1, \count($field)));
         }
+
         foreach($field as $key => $value) {
             if (! is_string($key)) {
                 throw new InvalidArgumentException('Expected $field arguments to be a map (object), named arguments (<name>:<value>) or array unpacking ...[\'<name>\' => <value>] must be used');
             }
         }
+
         $field = (object) $field;
         $this->field = $field;
     }

--- a/src/Builder/Stage/MatchStage.php
+++ b/src/Builder/Stage/MatchStage.php
@@ -8,17 +8,13 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Stage;
 
-use MongoDB\BSON\Document;
-use MongoDB\BSON\Serializable;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
 use MongoDB\Builder\Type\QueryInterface;
 use MongoDB\Builder\Type\QueryObject;
 use MongoDB\Builder\Type\StageInterface;
-use stdClass;
 
 use function is_array;
-use function is_object;
 
 /**
  * Filters the document stream to allow only matching documents to pass unmodified into the next pipeline stage. $match uses standard MongoDB queries. For each input document, outputs either one document (a match) or zero documents (no match).
@@ -29,16 +25,16 @@ class MatchStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 
-    /** @var Document|QueryInterface|Serializable|array|stdClass $query */
-    public readonly Document|Serializable|QueryInterface|stdClass|array $query;
+    /** @var QueryInterface|array $query */
+    public readonly QueryInterface|array $query;
 
     /**
-     * @param Document|QueryInterface|Serializable|array|stdClass $query
+     * @param QueryInterface|array $query
      */
-    public function __construct(Document|Serializable|QueryInterface|stdClass|array $query)
+    public function __construct(QueryInterface|array $query)
     {
-        if (is_array($query) || is_object($query)) {
-            $query = QueryObject::create(...$query);
+        if (is_array($query)) {
+            $query = QueryObject::create($query);
         }
 
         $this->query = $query;

--- a/src/Builder/Stage/ProjectStage.php
+++ b/src/Builder/Stage/ProjectStage.php
@@ -41,11 +41,13 @@ class ProjectStage implements StageInterface, OperatorInterface
         if (\count($specification) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $specification, got %d.', 1, \count($specification)));
         }
+
         foreach($specification as $key => $value) {
             if (! is_string($key)) {
                 throw new InvalidArgumentException('Expected $specification arguments to be a map (object), named arguments (<name>:<value>) or array unpacking ...[\'<name>\' => <value>] must be used');
             }
         }
+
         $specification = (object) $specification;
         $this->specification = $specification;
     }

--- a/src/Builder/Stage/SetStage.php
+++ b/src/Builder/Stage/SetStage.php
@@ -39,11 +39,13 @@ class SetStage implements StageInterface, OperatorInterface
         if (\count($field) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $field, got %d.', 1, \count($field)));
         }
+
         foreach($field as $key => $value) {
             if (! is_string($key)) {
                 throw new InvalidArgumentException('Expected $field arguments to be a map (object), named arguments (<name>:<value>) or array unpacking ...[\'<name>\' => <value>] must be used');
             }
         }
+
         $field = (object) $field;
         $this->field = $field;
     }

--- a/src/Builder/Stage/UnsetStage.php
+++ b/src/Builder/Stage/UnsetStage.php
@@ -38,9 +38,11 @@ class UnsetStage implements StageInterface, OperatorInterface
         if (\count($field) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $field, got %d.', 1, \count($field)));
         }
+
         if (! array_is_list($field)) {
             throw new InvalidArgumentException('Expected $field arguments to be a list (array), named arguments are not supported');
         }
+
         $this->field = $field;
     }
 

--- a/src/Builder/Type/OutputWindow.php
+++ b/src/Builder/Type/OutputWindow.php
@@ -62,7 +62,7 @@ class OutputWindow implements WindowInterface
                 throw new InvalidArgumentException(sprintf('Expected $documents argument to be a list of 2 string or int. Got [%s, %s]', get_debug_type($documents[0]), get_debug_type($documents[1])));
             }
 
-            $window ??= new stdClass();
+            $window = new stdClass();
             $window->documents = $documents;
         }
 

--- a/src/Builder/Type/QueryObject.php
+++ b/src/Builder/Type/QueryObject.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Type;
 
-use MongoDB\BSON\Document;
-use MongoDB\BSON\Regex;
+use MongoDB\BSON\Type;
 use MongoDB\Exception\InvalidArgumentException;
 use stdClass;
 
 use function array_is_list;
+use function array_key_first;
 use function count;
 use function is_array;
 use function sprintf;
+use function str_starts_with;
 
 /**
  * Helper class to validate query objects.
@@ -24,7 +25,8 @@ final class QueryObject implements QueryInterface
 {
     public readonly array $queries;
 
-    public static function create(QueryInterface|FieldQueryInterface|array|stdClass|string|int|float|bool|Regex|Document|null ...$queries): QueryInterface
+    /** @param array<QueryInterface|FieldQueryInterface|Type|array|stdClass|int|float|string|bool> $queries */
+    public static function create(array $queries): QueryInterface
     {
         // We don't wrap a single query in a QueryObject
         if (count($queries) === 1 && isset($queries[0]) && $queries[0] instanceof QueryInterface) {
@@ -37,6 +39,17 @@ final class QueryObject implements QueryInterface
     /** @param array<object|array> $queriesOrArrayOfQueries */
     private function __construct(array $queriesOrArrayOfQueries)
     {
+        // If the first element is an array and not an operator, we assume variadic arguments were not used
+        if (
+            count($queriesOrArrayOfQueries) === 1 &&
+            isset($queriesOrArrayOfQueries[0]) &&
+            is_array($queriesOrArrayOfQueries[0]) &&
+            count($queriesOrArrayOfQueries[0]) > 0 &&
+            ! str_starts_with((string) array_key_first($queriesOrArrayOfQueries[0]), '$')
+        ) {
+            $queriesOrArrayOfQueries = $queriesOrArrayOfQueries[0];
+        }
+
         $seenQueryOperators = [];
         $queries = [];
 

--- a/src/Builder/Type/QueryObject.php
+++ b/src/Builder/Type/QueryObject.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Type;
 
-use MongoDB\BSON\Type;
+use MongoDB\BSON\Decimal128;
+use MongoDB\BSON\Int64;
+use MongoDB\BSON\Regex;
 use MongoDB\Exception\InvalidArgumentException;
 use stdClass;
 
@@ -25,7 +27,7 @@ final class QueryObject implements QueryInterface
 {
     public readonly array $queries;
 
-    /** @param array<QueryInterface|FieldQueryInterface|Type|array|stdClass|int|float|string|bool> $queries */
+    /** @param array<QueryInterface|FieldQueryInterface|Decimal128|Int64|Regex|FieldQueryInterface|stdClass|array|bool|float|int|string|null> $queries */
     public static function create(array $queries): QueryInterface
     {
         // We don't wrap a single query in a QueryObject
@@ -36,7 +38,7 @@ final class QueryObject implements QueryInterface
         return new self($queries);
     }
 
-    /** @param array<object|array> $queriesOrArrayOfQueries */
+    /** @param array<QueryInterface|FieldQueryInterface|Decimal128|Int64|Regex|FieldQueryInterface|stdClass|array|bool|float|int|string|null> $queriesOrArrayOfQueries */
     private function __construct(array $queriesOrArrayOfQueries)
     {
         // If the first element is an array and not an operator, we assume variadic arguments were not used

--- a/tests/Builder/BuilderEncoderTest.php
+++ b/tests/Builder/BuilderEncoderTest.php
@@ -40,6 +40,63 @@ class BuilderEncoderTest extends TestCase
         $this->assertSamePipeline($expected, $pipeline);
     }
 
+    public function testMatchNumericFieldName(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(['1' => Query::eq('dave')]),
+            Stage::match(['1' => Query::not(Query::eq('dave'))]),
+            Stage::match(
+                Query::and(
+                    Query::query(['2' => Query::gt(3)]),
+                    Query::query(['2' => Query::lt(4)]),
+                ),
+            ),
+            Stage::match(
+                Query::or(
+                    Query::query(['2' => Query::gt(3)]),
+                    Query::query(['2' => Query::lt(4)]),
+                ),
+            ),
+            Stage::match(
+                Query::nor(
+                    Query::query(['2' => Query::gt(3)]),
+                    Query::query(['2' => Query::lt(4)]),
+                ),
+            ),
+        );
+
+        $expected = [
+            ['$match' => ['1' => ['$eq' => 'dave']]],
+            ['$match' => ['1' => ['$not' => ['$eq' => 'dave']]]],
+            [
+                '$match' => [
+                    '$and' => [
+                        ['2' => ['$gt' => 3]],
+                        ['2' => ['$lt' => 4]],
+                    ],
+                ],
+            ],
+            [
+                '$match' => [
+                    '$or' => [
+                        ['2' => ['$gt' => 3]],
+                        ['2' => ['$lt' => 4]],
+                    ],
+                ],
+            ],
+            [
+                '$match' => [
+                    '$nor' => [
+                        ['2' => ['$gt' => 3]],
+                        ['2' => ['$lt' => 4]],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertSamePipeline($expected, $pipeline);
+    }
+
     /** @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sort/#ascending-descending-sort */
     public function testSort(): void
     {

--- a/tests/Builder/Type/QueryObjectTest.php
+++ b/tests/Builder/Type/QueryObjectTest.php
@@ -19,7 +19,7 @@ class QueryObjectTest extends TestCase
 {
     public function testEmptyQueryObject(): void
     {
-        $queryObject = QueryObject::create();
+        $queryObject = QueryObject::create([]);
 
         $this->assertSame([], $queryObject->queries);
     }
@@ -27,7 +27,7 @@ class QueryObjectTest extends TestCase
     public function testShortCutQueryObject(): void
     {
         $query = $this->createMock(QueryInterface::class);
-        $queryObject = QueryObject::create($query);
+        $queryObject = QueryObject::create([$query]);
 
         $this->assertSame($query, $queryObject);
     }
@@ -39,7 +39,20 @@ class QueryObjectTest extends TestCase
      */
     public function testCreateQueryObject(array $value, int $expectedCount = 1): void
     {
-        $queryObject = QueryObject::create(...$value);
+        $queryObject = QueryObject::create($value);
+
+        $this->assertCount($expectedCount, $queryObject->queries);
+    }
+
+    /**
+     * @param array<array-key, mixed> $value
+     *
+     * @dataProvider provideQueryObjectValue
+     */
+    public function testCreateQueryObjectFromArray(array $value, int $expectedCount = 1): void
+    {
+        // $value is wrapped in an array as if the user used an array instead of variadic arguments
+        $queryObject = QueryObject::create([$value]);
 
         $this->assertCount($expectedCount, $queryObject->queries);
     }
@@ -58,12 +71,14 @@ class QueryObjectTest extends TestCase
         yield 'operator as object' => [['foo' => (object) ['$eq' => 1]]];
         yield 'field query operator' => [['foo' => new EqOperator(1)]];
         yield 'query operator' => [[new CommentOperator('foo'), 'foo' => 1], 2];
+        yield 'numeric field with array' => [[1 => [2, 3]]];
+        yield 'numeric field with operator' => [[1 => ['$eq' => 2]]];
     }
 
     public function testFieldQueryList(): void
     {
         $queryObject = QueryObject::create(
-            foo: [new GtOperator(1), new LtOperator(5)],
+            ['foo' => [new GtOperator(1), new LtOperator(5)]],
         );
 
         $this->assertArrayHasKey('foo', $queryObject->queries);

--- a/tests/Builder/Type/QueryObjectTest.php
+++ b/tests/Builder/Type/QueryObjectTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace MongoDB\Tests\Builder\Type;
 
 use Generator;
+use MongoDB\BSON\Decimal128;
+use MongoDB\BSON\Int64;
 use MongoDB\BSON\Regex;
 use MongoDB\Builder\Query\CommentOperator;
 use MongoDB\Builder\Query\EqOperator;
@@ -64,6 +66,8 @@ class QueryObjectTest extends TestCase
         yield 'string' => [['foo' => 'bar']];
         yield 'bool' => [['foo' => true]];
         yield 'null' => [['foo' => null]];
+        yield 'decimal128' => [['foo' => new Decimal128('1.1')]];
+        yield 'int64' => [[1 => new Int64(1)]];
         yield 'regex' => [['foo' => new Regex('foo')]];
         yield 'object' => [['foo' => (object) ['bar' => 'baz']]];
         yield 'list' => [['foo' => ['bar', 'baz']]];


### PR DESCRIPTION
Fix [PHPLIB-1292](https://jira.mongodb.org/browse/PHPLIB-1292)

Numerical field names can't be used with named argument, because even if they comes from an array unpacking, the numerical keys are recalculated as a sequence: https://3v4l.org/Gj7jC

Everywhere a query is expected, an single array can be passed instead of the variadic arguments.

```php
Stage::match(['1' => Query::eq(2)]);
Stage::match(...['1' => Query::eq(2)]); // Incorrect
```

Identicals:
```php
Stage::match(['foo' => Query::eq(2)]);
Stage::match(foo: Query::eq(2));
```