### PR TITLE
Use final class for factory methods

### DIFF
--- a/src/Builder/Accumulator.php
+++ b/src/Builder/Accumulator.php
@@ -17,7 +17,7 @@ use stdClass;
  * @see https://www.mongodb.com/docs/v3.4/reference/operator/aggregation-group/
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setWindowFields/
  */
-enum Accumulator
+final class Accumulator
 {
     use Accumulator\FactoryTrait;
 
@@ -34,5 +34,10 @@ enum Accumulator
         Optional|string $unit = Optional::Undefined,
     ): OutputWindow {
         return new OutputWindow($operator, $documents, $range, $unit);
+    }
+
+    private function __construct()
+    {
+        // This class cannot be instantiated
     }
 }

--- a/src/Builder/Expression.php
+++ b/src/Builder/Expression.php
@@ -9,8 +9,13 @@ namespace MongoDB\Builder;
  *
  * @see https://docs.mongodb.com/manual/reference/operator/aggregation/
  */
-enum Expression
+final class Expression
 {
     use Expression\ExpressionFactoryTrait;
     use Expression\FactoryTrait;
+
+    private function __construct()
+    {
+        // This class cannot be instantiated
+    }
 }

--- a/src/Builder/Projection.php
+++ b/src/Builder/Projection.php
@@ -11,7 +11,12 @@ use MongoDB\Builder\Projection\FactoryTrait;
  *
  * @see https://docs.mongodb.com/manual/reference/operator/projection/
  */
-enum Projection
+final class Projection
 {
     use FactoryTrait;
+
+    private function __construct()
+    {
+        // This class cannot be instantiated
+    }
 }

--- a/src/Builder/Query.php
+++ b/src/Builder/Query.php
@@ -20,7 +20,7 @@ use function is_string;
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/
  */
-enum Query
+final class Query
 {
     use Query\FactoryTrait {
         regex as private generatedRegex;
@@ -43,5 +43,10 @@ enum Query
     public static function query(FieldQueryInterface|QueryInterface|Serializable|array|bool|float|int|stdClass|string|null ...$query): QueryInterface
     {
         return QueryObject::create(...$query);
+    }
+
+    private function __construct()
+    {
+        // This class cannot be instantiated
     }
 }

--- a/src/Builder/Stage.php
+++ b/src/Builder/Stage.php
@@ -10,7 +10,7 @@ use MongoDB\Builder\Type\FieldQueryInterface;
 use MongoDB\Builder\Type\QueryInterface;
 use stdClass;
 
-enum Stage
+final class Stage
 {
     use Stage\FactoryTrait {
         match as private generatedMatch;
@@ -27,5 +27,10 @@ enum Stage
     {
         // Override the generated method to allow variadic arguments
         return self::generatedMatch($queries);
+    }
+
+    private function __construct()
+    {
+        // This class cannot be instantiated
     }
 }

--- a/src/Builder/Variable.php
+++ b/src/Builder/Variable.php
@@ -16,7 +16,7 @@ use MongoDB\Builder\Type\ExpressionInterface;
  *
  * @see https://www.mongodb.com/docs/manual/reference/aggregation-variables/
  */
-enum Variable
+final class Variable
 {
     /**
      * A variable that returns the current datetime value.
@@ -149,5 +149,10 @@ enum Variable
     public static function variable(string $name): Expression\Variable
     {
         return new Expression\Variable($name);
+    }
+
+    private function __construct()
+    {
+        // This class cannot be instantiated
     }
 }


### PR DESCRIPTION
Using `enum` to host factory functions wasn't a good idea:
- Enums contains additional static methods that can conflict (`enum::cases()`)

We don't support instantiating the factory classes using reflection.
