### PR TITLE
Support using first, firstN, last, lastN accumulators as expressions

### DIFF
--- a/generator/config/accumulator/first.yaml
+++ b/generator/config/accumulator/first.yaml
@@ -4,6 +4,7 @@ link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/first/
 type:
     - accumulator
     - window
+    - resolvesToAny
 encode: single
 description: |
     Returns the result of an expression for the first document in a group or window.

--- a/generator/config/accumulator/firstN.yaml
+++ b/generator/config/accumulator/firstN.yaml
@@ -4,6 +4,7 @@ link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/firstN
 type:
     - accumulator
     - window
+    - resolvesToAny
 encode: object
 description: |
     Returns a specified number of elements from the beginning of an array. Distinct from the $firstN accumulator.

--- a/generator/config/accumulator/last.yaml
+++ b/generator/config/accumulator/last.yaml
@@ -4,6 +4,7 @@ link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/last/'
 type:
     - accumulator
     - window
+    - resolvesToAny
 encode: single
 description: |
     Returns the result of an expression for the last document in a group or window.

--- a/generator/config/accumulator/lastN.yaml
+++ b/generator/config/accumulator/lastN.yaml
@@ -3,6 +3,7 @@ name: $lastN
 link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/lastN/'
 type:
     - window
+    - resolvesToAny
 encode: object
 description: |
     Returns a specified number of elements from the end of an array. Distinct from the $lastN accumulator.

--- a/src/Builder/Accumulator/FirstAccumulator.php
+++ b/src/Builder/Accumulator/FirstAccumulator.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace MongoDB\Builder\Accumulator;
 
 use MongoDB\BSON\Type;
+use MongoDB\Builder\Expression\ResolvesToAny;
 use MongoDB\Builder\Type\AccumulatorInterface;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -22,7 +23,7 @@ use stdClass;
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/first/
  */
-class FirstAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
+class FirstAccumulator implements AccumulatorInterface, WindowInterface, ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Accumulator/FirstNAccumulator.php
+++ b/src/Builder/Accumulator/FirstNAccumulator.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace MongoDB\Builder\Accumulator;
 
 use MongoDB\BSON\PackedArray;
+use MongoDB\Builder\Expression\ResolvesToAny;
 use MongoDB\Builder\Expression\ResolvesToArray;
 use MongoDB\Builder\Expression\ResolvesToInt;
 use MongoDB\Builder\Type\AccumulatorInterface;
@@ -26,7 +27,7 @@ use function is_array;
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/firstN/
  */
-class FirstNAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
+class FirstNAccumulator implements AccumulatorInterface, WindowInterface, ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Accumulator/LastAccumulator.php
+++ b/src/Builder/Accumulator/LastAccumulator.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace MongoDB\Builder\Accumulator;
 
 use MongoDB\BSON\Type;
+use MongoDB\Builder\Expression\ResolvesToAny;
 use MongoDB\Builder\Type\AccumulatorInterface;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -22,7 +23,7 @@ use stdClass;
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/last/
  */
-class LastAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
+class LastAccumulator implements AccumulatorInterface, WindowInterface, ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Accumulator/LastNAccumulator.php
+++ b/src/Builder/Accumulator/LastNAccumulator.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace MongoDB\Builder\Accumulator;
 
 use MongoDB\BSON\PackedArray;
+use MongoDB\Builder\Expression\ResolvesToAny;
 use MongoDB\Builder\Expression\ResolvesToArray;
 use MongoDB\Builder\Expression\ResolvesToInt;
 use MongoDB\Builder\Type\Encode;
@@ -25,7 +26,7 @@ use function is_array;
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/lastN/
  */
-class LastNAccumulator implements WindowInterface, OperatorInterface
+class LastNAccumulator implements WindowInterface, ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 


### PR DESCRIPTION
As per the documentation, the `$first`, `$firstN`, `$last`, and `$lastN` accumulators can also be used as aggregation expressions within non-grouping stages, e.g. `$addFields`. This PR makes sure these can be used accordingly.

I noted that other operators, such as `$max` and `$sum` have been duplicated as expressions, but those operators have a different syntax depending on whether they are used as expressions or accumulators. Since these array accumulators always have the same syntax, I decided to only leave them in as accumulators and avoid duplicating the config file in the generator. @GromNaN let me know if you'd rather duplicate the config to also add factories for these operators in the `Expression` builder class.