### PR TITLE
Use BSON round-trip to normalize pipelines for comparison

### DIFF
--- a/generator/config/query/regex.yaml
+++ b/generator/config/query/regex.yaml
@@ -20,10 +20,10 @@ tests:
             -
                 $match:
                     sku:
-                        # Should be nested in $regex
-                        $regularExpression:
-                            pattern: '789$'
-                            options: ''
+                        $regex:
+                            $regularExpression:
+                                pattern: '789$'
+                                options: ''
     -
         name: 'Perform Case-Insensitive Regular Expression Match'
         link: 'https://www.mongodb.com/docs/manual/reference/operator/query/regex/#perform-case-insensitive-regular-expression-match'
@@ -31,7 +31,7 @@ tests:
             -
                 $match:
                     sku:
-                        # Should be nested in $regex
-                        $regularExpression:
-                            pattern: '^ABC'
-                            options: 'i'
+                        $regex:
+                            $regularExpression:
+                                pattern: '^ABC'
+                                options: 'i'

--- a/generator/src/OperatorTestGenerator.php
+++ b/generator/src/OperatorTestGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MongoDB\CodeGenerator;
 
+use MongoDB\BSON\Document;
 use MongoDB\Builder\Pipeline;
 use MongoDB\CodeGenerator\Definition\GeneratorDefinition;
 use MongoDB\CodeGenerator\Definition\OperatorDefinition;
@@ -16,6 +17,7 @@ use RuntimeException;
 use Throwable;
 
 use function basename;
+use function json_decode;
 use function json_encode;
 use function ksort;
 use function sprintf;
@@ -81,7 +83,9 @@ class OperatorTestGenerator extends OperatorGenerator
             $testName = 'test' . str_replace([' ', '-'], '', ucwords(str_replace('$', '', $test->name)));
             $caseName = str_replace([' ', '-'], '', ucwords(str_replace('$', '', $operator->name . ' ' . $test->name)));
 
-            $case = $dataEnum->addCase($caseName, new Literal('<<<\'JSON\'' . "\n" . json_encode($test->pipeline, JSON_PRETTY_PRINT) . "\n" . 'JSON'));
+            $json = Document::fromPHP(['pipeline' => $test->pipeline])->toCanonicalExtendedJSON();
+            $json = json_encode(json_decode($json)->pipeline, JSON_PRETTY_PRINT);
+            $case = $dataEnum->addCase($caseName, new Literal('<<<\'JSON\'' . "\n" . $json . "\n" . 'JSON'));
             $case->setComment($test->name);
             if ($test->link) {
                 $case->addComment('');

--- a/src/Builder/Type/OutputWindow.php
+++ b/src/Builder/Type/OutputWindow.php
@@ -25,8 +25,6 @@ use function sprintf;
  */
 class OutputWindow implements WindowInterface
 {
-    public const ENCODE = Encode::Object;
-
     /**
      * Function used to initialize the state. The init function receives its arguments from the initArgs array expression.
      * You can specify the function definition as either BSON type Code or String.

--- a/tests/Builder/Accumulator/Pipelines.php
+++ b/tests/Builder/Accumulator/Pipelines.php
@@ -126,7 +126,9 @@ enum Pipelines: string
             "$setWindowFields": {
                 "partitionBy": "$state",
                 "sortBy": {
-                    "orderDate": 1
+                    "orderDate": {
+                        "$numberInt": "1"
+                    }
                 },
                 "output": {
                     "cakeTypesForState": {

--- a/tests/Builder/BuilderEncoderTest.php
+++ b/tests/Builder/BuilderEncoderTest.php
@@ -342,8 +342,8 @@ class BuilderEncoderTest extends TestCase
 
         // Normalize with BSON round-trip
         // BSON Documents doesn't support top-level arrays.
-        $actual = Document::fromPHP(['root' => $actual])->toRelaxedExtendedJSON();
-        $expected = Document::fromPHP(['root' => $expected])->toRelaxedExtendedJSON();
+        $actual = Document::fromPHP(['root' => $actual])->toCanonicalExtendedJSON();
+        $expected = Document::fromPHP(['root' => $expected])->toCanonicalExtendedJSON();
 
         self::assertJsonStringEqualsJsonString($expected, $actual, var_export($actual, true));
     }

--- a/tests/Builder/BuilderEncoderTest.php
+++ b/tests/Builder/BuilderEncoderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MongoDB\Tests\Builder;
 
 use Generator;
+use MongoDB\BSON\Document;
 use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\BuilderEncoder;
 use MongoDB\Builder\Expression;
@@ -15,10 +16,7 @@ use MongoDB\Builder\Stage;
 use MongoDB\Builder\Variable;
 use PHPUnit\Framework\TestCase;
 
-use function array_is_list;
 use function array_merge;
-use function array_walk;
-use function is_array;
 use function MongoDB\object;
 use function var_export;
 
@@ -342,26 +340,11 @@ class BuilderEncoderTest extends TestCase
         $codec = new BuilderEncoder();
         $actual = $codec->encode($pipeline);
 
-        self::objectify($expected);
+        // Normalize with BSON round-trip
+        // BSON Documents doesn't support top-level arrays.
+        $actual = Document::fromPHP(['root' => $actual])->toRelaxedExtendedJSON();
+        $expected = Document::fromPHP(['root' => $expected])->toRelaxedExtendedJSON();
 
-        self::assertEquals($expected, $actual, var_export($actual, true));
-    }
-
-    /**
-     * Recursively convert associative arrays to objects.
-     *
-     * @param array<mixed> $array
-     */
-    private static function objectify(array &$array): void
-    {
-        array_walk($array, function (&$value): void {
-            if (is_array($value)) {
-                self::objectify($value);
-
-                if (! array_is_list($value)) {
-                    $value = (object) $value;
-                }
-            }
-        });
+        self::assertJsonStringEqualsJsonString($expected, $actual, var_export($actual, true));
     }
 }

--- a/tests/Builder/PipelineTestCase.php
+++ b/tests/Builder/PipelineTestCase.php
@@ -24,7 +24,7 @@ abstract class PipelineTestCase extends TestCase
         $codec = new BuilderEncoder();
         $actual = $codec->encode($pipeline);
         // Normalize with BSON round-trip
-        $actual = Document::fromPHP(['pipeline' => $actual])->toRelaxedExtendedJSON();
+        $actual = Document::fromPHP(['pipeline' => $actual])->toCanonicalExtendedJSON();
 
         self::assertJsonStringEqualsJsonString($expected, $actual);
     }

--- a/tests/Builder/PipelineTestCase.php
+++ b/tests/Builder/PipelineTestCase.php
@@ -5,15 +5,12 @@ declare(strict_types=1);
 namespace MongoDB\Tests\Builder;
 
 use BackedEnum;
+use MongoDB\BSON\Document;
 use MongoDB\Builder\BuilderEncoder;
 use MongoDB\Builder\Pipeline;
 use PHPUnit\Framework\TestCase;
 
-use function MongoDB\BSON\fromJSON;
-use function MongoDB\BSON\toPHP;
-use function var_export;
-
-class PipelineTestCase extends TestCase
+abstract class PipelineTestCase extends TestCase
 {
     final public static function assertSamePipeline(string|BackedEnum $expectedJson, Pipeline $pipeline): void
     {
@@ -22,11 +19,13 @@ class PipelineTestCase extends TestCase
         }
 
         // BSON Documents doesn't support top-level arrays.
-        $expected = toPHP(fromJSON('{"root":' . $expectedJson . '}'))->root;
+        $expected = '{"pipeline":' . $expectedJson . '}';
 
         $codec = new BuilderEncoder();
         $actual = $codec->encode($pipeline);
+        // Normalize with BSON round-trip
+        $actual = Document::fromPHP(['pipeline' => $actual])->toRelaxedExtendedJSON();
 
-        self::assertEquals($expected, $actual, var_export($actual, true));
+        self::assertJsonStringEqualsJsonString($expected, $actual);
     }
 }

--- a/tests/Builder/Query/Pipelines.php
+++ b/tests/Builder/Query/Pipelines.php
@@ -20,9 +20,11 @@ enum Pipelines: string
         {
             "$match": {
                 "sku": {
-                    "$regularExpression": {
-                        "pattern": "789$",
-                        "options": ""
+                    "$regex": {
+                        "$regularExpression": {
+                            "pattern": "789$",
+                            "options": ""
+                        }
                     }
                 }
             }
@@ -40,9 +42,11 @@ enum Pipelines: string
         {
             "$match": {
                 "sku": {
-                    "$regularExpression": {
-                        "pattern": "^ABC",
-                        "options": "i"
+                    "$regex": {
+                        "$regularExpression": {
+                            "pattern": "^ABC",
+                            "options": "i"
+                        }
                     }
                 }
             }

--- a/tests/Builder/Query/RegexOperatorTest.php
+++ b/tests/Builder/Query/RegexOperatorTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace MongoDB\Tests\Builder\Query;
 
-use MongoDB\BSON\Regex;
 use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
 use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
@@ -18,8 +18,7 @@ class RegexOperatorTest extends PipelineTestCase
     {
         $pipeline = new Pipeline(
             Stage::match(
-                // sku: \MongoDB\Builder\Query::regex('789$', ''),
-                sku: new Regex('789$', ''),
+                sku: Query::regex('789$', ''),
             ),
         );
 
@@ -30,8 +29,7 @@ class RegexOperatorTest extends PipelineTestCase
     {
         $pipeline = new Pipeline(
             Stage::match(
-                // sku: \MongoDB\Builder\Query::regex('^ABC', 'i'),
-                sku: new Regex('^ABC', 'i'),
+                sku: Query::regex('^ABC', 'i'),
             ),
         );
 


### PR DESCRIPTION
Use the driver feature to normalize the aggregation pipeline in PHP.
Diffs are easier to read when using JSON comparison.

Part of [PHPLIB-1291](https://jira.mongodb.org/browse/PHPLIB-1291)

Related to https://github.com/mongodb/mongo-php-builder/pull/8