### PR TITLE
Various improvements

### DIFF
--- a/generator/config/expression/add.yaml
+++ b/generator/config/expression/add.yaml
@@ -7,7 +7,7 @@ type:
     - resolvesToDouble
     - resolvesToDecimal
     - resolvesToDate
-encode: array
+encode: single
 description: |
     Adds numbers to return the sum, or adds numbers and a date to return a new date. If adding numbers and a date, treats the numbers as milliseconds. Accepts any number of argument expressions, but at most, one expression can resolve to a date.
 arguments:

--- a/generator/config/expression/add.yaml
+++ b/generator/config/expression/add.yaml
@@ -2,7 +2,10 @@
 name: $add
 link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/add/'
 type:
-    - resolvesToNumber
+    - resolvesToInt
+    - resolvesToLong
+    - resolvesToDouble
+    - resolvesToDecimal
     - resolvesToDate
 encode: array
 description: |

--- a/generator/config/expression/add.yaml
+++ b/generator/config/expression/add.yaml
@@ -19,3 +19,26 @@ arguments:
         variadic: array
         description: |
             The arguments can be any valid expression as long as they resolve to either all numbers or to numbers and a date.
+tests:
+    -
+        name: 'Add Numbers'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/add/#add-numbers'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    total:
+                        $add:
+                            - '$price'
+                            - '$fee'
+    -
+        name: 'Perform Addition on a Date'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/add/#perform-addition-on-a-date'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    billing_date:
+                        $add:
+                            - '$date'
+                            - 259200000

--- a/generator/config/expression/mergeObjects.yaml
+++ b/generator/config/expression/mergeObjects.yaml
@@ -14,3 +14,26 @@ arguments:
         variadic: array
         description: |
             Any valid expression that resolves to a document.
+tests:
+    -
+        name: '$mergeObjects'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/mergeObjects/#-mergeobjects'
+        pipeline:
+            -
+                $lookup:
+                    from: 'items'
+                    localField: 'item'
+                    foreignField: 'item'
+                    as: 'fromItems'
+            -
+                $replaceRoot:
+                    newRoot:
+                        $mergeObjects:
+                            -
+                                $arrayElemAt:
+                                    - '$fromItems'
+                                    - 0
+                            - '$$ROOT'
+            -
+                $project:
+                    fromItems: 0

--- a/generator/config/expression/mergeObjects.yaml
+++ b/generator/config/expression/mergeObjects.yaml
@@ -1,0 +1,16 @@
+# $schema: ../schema.json
+name: $mergeObjects
+link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/mergeObjects/'
+type:
+    - resolvesToObject
+encode: single
+description: |
+    Combines multiple documents into a single document.
+arguments:
+    -
+        name: document
+        type:
+            - resolvesToObject
+        variadic: array
+        description: |
+            Any valid expression that resolves to a document.

--- a/generator/config/expression/subtract.yaml
+++ b/generator/config/expression/subtract.yaml
@@ -2,7 +2,10 @@
 name: $subtract
 link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/subtract/'
 type:
-    - resolvesToNumber
+    - resolvesToInt
+    - resolvesToLong
+    - resolvesToDouble
+    - resolvesToDecimal
     - resolvesToDate
 encode: array
 description: |

--- a/generator/config/expression/subtract.yaml
+++ b/generator/config/expression/subtract.yaml
@@ -21,3 +21,40 @@ arguments:
         type:
             - resolvesToNumber
             - resolvesToDate
+tests:
+    -
+        name: 'Subtract Numbers'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/subtract/#subtract-numbers'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    total:
+                        $subtract:
+                            -
+                                $add:
+                                    - '$price'
+                                    - '$fee'
+                            - '$discount'
+    -
+        name: 'Subtract Two Dates'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/subtract/#subtract-two-dates'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    dateDifference:
+                        $subtract:
+                            - '$$NOW'
+                            - '$date'
+    -
+        name: 'Subtract Milliseconds from a Date'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/subtract/#subtract-milliseconds-from-a-date'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    dateDifference:
+                        $subtract:
+                            - '$date'
+                            - 300000

--- a/generator/config/expression/zip.yaml
+++ b/generator/config/expression/zip.yaml
@@ -32,3 +32,56 @@ arguments:
             An array of default element values to use if the input arrays have different lengths. You must specify useLongestLength: true along with this field, or else $zip will return an error.
             If useLongestLength: true but defaults is empty or not specified, $zip uses null as the default value.
             If specifying a non-empty defaults, you must specify a default for each input array or else $zip will return an error.
+tests:
+    -
+        name: 'Matrix Transposition'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/zip/#matrix-transposition'
+        pipeline:
+            -
+                $project:
+                    _id: false
+                    transposed:
+                        $zip:
+                            inputs:
+                                -
+                                    $arrayElemAt:
+                                        - '$matrix'
+                                        - 0
+                                -
+                                    $arrayElemAt:
+                                        - '$matrix'
+                                        - 1
+                                -
+                                    $arrayElemAt:
+                                        - '$matrix'
+                                        - 2
+    -
+        name: 'Filtering and Preserving Indexes'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/zip/#filtering-and-preserving-indexes'
+        pipeline:
+            -
+                $project:
+                    _id: false
+                    pages:
+                        $filter:
+                            input:
+                                $zip:
+                                    inputs:
+                                        - '$pages'
+                                        -
+                                            $range:
+                                                - 0
+                                                -
+                                                    $size: '$pages'
+                            as: 'pageWithIndex'
+                            cond:
+                                $let:
+                                    vars:
+                                        page:
+                                            $arrayElemAt:
+                                                - '$$pageWithIndex'
+                                                - 0
+                                    in:
+                                        $gte:
+                                            - '$$page.reviews'
+                                            - 1

--- a/generator/config/expression/zip.yaml
+++ b/generator/config/expression/zip.yaml
@@ -26,6 +26,7 @@ arguments:
         name: defaults
         type:
             - array
+        optional: true
         description: |
             An array of default element values to use if the input arrays have different lengths. You must specify useLongestLength: true along with this field, or else $zip will return an error.
             If useLongestLength: true but defaults is empty or not specified, $zip uses null as the default value.

--- a/generator/config/expression/zip.yaml
+++ b/generator/config/expression/zip.yaml
@@ -19,6 +19,7 @@ arguments:
         name: useLongestLength
         type:
             - bool
+        optional: true
         description: |
             A boolean which specifies whether the length of the longest array determines the number of arrays in the output array.
             The default value is false: the shortest array length determines the number of arrays in the output array.

--- a/generator/config/query/expr.yaml
+++ b/generator/config/query/expr.yaml
@@ -2,7 +2,7 @@
 name: $expr
 link: 'https://www.mongodb.com/docs/manual/reference/operator/query/expr/'
 type:
-    - fieldQuery
+    - query
 encode: single
 description: |
     Allows use of aggregation expressions within the query language.

--- a/generator/config/query/expr.yaml
+++ b/generator/config/query/expr.yaml
@@ -11,3 +11,37 @@ arguments:
         name: expression
         type:
             - expression
+tests:
+    -
+        name: 'Compare Two Fields from A Single Document'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/expr/#compare-two-fields-from-a-single-document'
+        pipeline:
+            -
+                $match:
+                    $expr:
+                        $gt:
+                            - '$spent'
+                            - '$budget'
+    -
+        name: 'Using $expr With Conditional Statements'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/expr/#using--expr-with-conditional-statements'
+        pipeline:
+            -
+                $match:
+                    $expr:
+                        $lt:
+                            -
+                                $cond:
+                                    if:
+                                        $gte:
+                                            - '$qty'
+                                            - 100
+                                    then:
+                                        $multiply:
+                                            - '$price'
+                                            - 0.5
+                                    else:
+                                        $multiply:
+                                            - '$price'
+                                            - 0.75
+                            - 5

--- a/src/Builder/Expression/AddOperator.php
+++ b/src/Builder/Expression/AddOperator.php
@@ -24,7 +24,7 @@ use function array_is_list;
  */
 class AddOperator implements ResolvesToInt, ResolvesToLong, ResolvesToDouble, ResolvesToDecimal, ResolvesToDate, OperatorInterface
 {
-    public const ENCODE = Encode::Array;
+    public const ENCODE = Encode::Single;
 
     /** @var list<Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int> $expression The arguments can be any valid expression as long as they resolve to either all numbers or to numbers and a date. */
     public readonly array $expression;

--- a/src/Builder/Expression/AddOperator.php
+++ b/src/Builder/Expression/AddOperator.php
@@ -22,7 +22,7 @@ use function array_is_list;
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/add/
  */
-class AddOperator implements ResolvesToNumber, ResolvesToDate, OperatorInterface
+class AddOperator implements ResolvesToInt, ResolvesToLong, ResolvesToDouble, ResolvesToDecimal, ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -2347,14 +2347,14 @@ trait FactoryTrait
      * If any of the inputs arrays does not resolve to an array or null nor refers to a missing field, $zip returns an error.
      * @param bool $useLongestLength A boolean which specifies whether the length of the longest array determines the number of arrays in the output array.
      * The default value is false: the shortest array length determines the number of arrays in the output array.
-     * @param BSONArray|PackedArray|array $defaults An array of default element values to use if the input arrays have different lengths. You must specify useLongestLength: true along with this field, or else $zip will return an error.
+     * @param Optional|BSONArray|PackedArray|array $defaults An array of default element values to use if the input arrays have different lengths. You must specify useLongestLength: true along with this field, or else $zip will return an error.
      * If useLongestLength: true but defaults is empty or not specified, $zip uses null as the default value.
      * If specifying a non-empty defaults, you must specify a default for each input array or else $zip will return an error.
      */
     public static function zip(
         PackedArray|ResolvesToArray|BSONArray|array $inputs,
         bool $useLongestLength,
-        PackedArray|BSONArray|array $defaults,
+        Optional|PackedArray|BSONArray|array $defaults = Optional::Undefined,
     ): ZipOperator
     {
         return new ZipOperator($inputs, $useLongestLength, $defaults);

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -2345,7 +2345,7 @@ trait FactoryTrait
      * @param BSONArray|PackedArray|ResolvesToArray|array $inputs An array of expressions that resolve to arrays. The elements of these input arrays combine to form the arrays of the output array.
      * If any of the inputs arrays resolves to a value of null or refers to a missing field, $zip returns null.
      * If any of the inputs arrays does not resolve to an array or null nor refers to a missing field, $zip returns an error.
-     * @param bool $useLongestLength A boolean which specifies whether the length of the longest array determines the number of arrays in the output array.
+     * @param Optional|bool $useLongestLength A boolean which specifies whether the length of the longest array determines the number of arrays in the output array.
      * The default value is false: the shortest array length determines the number of arrays in the output array.
      * @param Optional|BSONArray|PackedArray|array $defaults An array of default element values to use if the input arrays have different lengths. You must specify useLongestLength: true along with this field, or else $zip will return an error.
      * If useLongestLength: true but defaults is empty or not specified, $zip uses null as the default value.
@@ -2353,7 +2353,7 @@ trait FactoryTrait
      */
     public static function zip(
         PackedArray|ResolvesToArray|BSONArray|array $inputs,
-        bool $useLongestLength,
+        Optional|bool $useLongestLength = Optional::Undefined,
         Optional|PackedArray|BSONArray|array $defaults = Optional::Undefined,
     ): ZipOperator
     {

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -1260,6 +1260,20 @@ trait FactoryTrait
     }
 
     /**
+     * Combines multiple documents into a single document.
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/mergeObjects/
+     * @no-named-arguments
+     * @param Document|ResolvesToObject|Serializable|array|stdClass ...$document Any valid expression that resolves to a document.
+     */
+    public static function mergeObjects(
+        Document|Serializable|ResolvesToObject|stdClass|array ...$document,
+    ): MergeObjectsOperator
+    {
+        return new MergeObjectsOperator(...$document);
+    }
+
+    /**
      * Access available per-document metadata related to the aggregation operation.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/meta/

--- a/src/Builder/Expression/MergeObjectsOperator.php
+++ b/src/Builder/Expression/MergeObjectsOperator.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * THIS FILE IS AUTO-GENERATED. ANY CHANGES WILL BE LOST!
+ */
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Expression;
+
+use MongoDB\BSON\Document;
+use MongoDB\BSON\Serializable;
+use MongoDB\Builder\Type\Encode;
+use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Exception\InvalidArgumentException;
+use stdClass;
+
+use function array_is_list;
+
+/**
+ * Combines multiple documents into a single document.
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/mergeObjects/
+ */
+class MergeObjectsOperator implements ResolvesToObject, OperatorInterface
+{
+    public const ENCODE = Encode::Single;
+
+    /** @var list<Document|ResolvesToObject|Serializable|array|stdClass> $document Any valid expression that resolves to a document. */
+    public readonly array $document;
+
+    /**
+     * @param Document|ResolvesToObject|Serializable|array|stdClass ...$document Any valid expression that resolves to a document.
+     * @no-named-arguments
+     */
+    public function __construct(Document|Serializable|ResolvesToObject|stdClass|array ...$document)
+    {
+        if (\count($document) < 1) {
+            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $document, got %d.', 1, \count($document)));
+        }
+
+        if (! array_is_list($document)) {
+            throw new InvalidArgumentException('Expected $document arguments to be a list (array), named arguments are not supported');
+        }
+
+        $this->document = $document;
+    }
+
+    public function getOperator(): string
+    {
+        return '$mergeObjects';
+    }
+}

--- a/src/Builder/Expression/SubtractOperator.php
+++ b/src/Builder/Expression/SubtractOperator.php
@@ -19,7 +19,7 @@ use MongoDB\Builder\Type\OperatorInterface;
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/subtract/
  */
-class SubtractOperator implements ResolvesToNumber, ResolvesToDate, OperatorInterface
+class SubtractOperator implements ResolvesToInt, ResolvesToLong, ResolvesToDouble, ResolvesToDecimal, ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/ZipOperator.php
+++ b/src/Builder/Expression/ZipOperator.php
@@ -35,10 +35,10 @@ class ZipOperator implements ResolvesToArray, OperatorInterface
     public readonly PackedArray|ResolvesToArray|BSONArray|array $inputs;
 
     /**
-     * @var bool $useLongestLength A boolean which specifies whether the length of the longest array determines the number of arrays in the output array.
+     * @var Optional|bool $useLongestLength A boolean which specifies whether the length of the longest array determines the number of arrays in the output array.
      * The default value is false: the shortest array length determines the number of arrays in the output array.
      */
-    public readonly bool $useLongestLength;
+    public readonly Optional|bool $useLongestLength;
 
     /**
      * @var Optional|BSONArray|PackedArray|array $defaults An array of default element values to use if the input arrays have different lengths. You must specify useLongestLength: true along with this field, or else $zip will return an error.
@@ -51,7 +51,7 @@ class ZipOperator implements ResolvesToArray, OperatorInterface
      * @param BSONArray|PackedArray|ResolvesToArray|array $inputs An array of expressions that resolve to arrays. The elements of these input arrays combine to form the arrays of the output array.
      * If any of the inputs arrays resolves to a value of null or refers to a missing field, $zip returns null.
      * If any of the inputs arrays does not resolve to an array or null nor refers to a missing field, $zip returns an error.
-     * @param bool $useLongestLength A boolean which specifies whether the length of the longest array determines the number of arrays in the output array.
+     * @param Optional|bool $useLongestLength A boolean which specifies whether the length of the longest array determines the number of arrays in the output array.
      * The default value is false: the shortest array length determines the number of arrays in the output array.
      * @param Optional|BSONArray|PackedArray|array $defaults An array of default element values to use if the input arrays have different lengths. You must specify useLongestLength: true along with this field, or else $zip will return an error.
      * If useLongestLength: true but defaults is empty or not specified, $zip uses null as the default value.
@@ -59,7 +59,7 @@ class ZipOperator implements ResolvesToArray, OperatorInterface
      */
     public function __construct(
         PackedArray|ResolvesToArray|BSONArray|array $inputs,
-        bool $useLongestLength,
+        Optional|bool $useLongestLength = Optional::Undefined,
         Optional|PackedArray|BSONArray|array $defaults = Optional::Undefined,
     ) {
         if (is_array($inputs) && ! array_is_list($inputs)) {

--- a/src/Builder/Expression/ZipOperator.php
+++ b/src/Builder/Expression/ZipOperator.php
@@ -11,6 +11,7 @@ namespace MongoDB\Builder\Expression;
 use MongoDB\BSON\PackedArray;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\Optional;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\BSONArray;
 
@@ -40,11 +41,11 @@ class ZipOperator implements ResolvesToArray, OperatorInterface
     public readonly bool $useLongestLength;
 
     /**
-     * @var BSONArray|PackedArray|array $defaults An array of default element values to use if the input arrays have different lengths. You must specify useLongestLength: true along with this field, or else $zip will return an error.
+     * @var Optional|BSONArray|PackedArray|array $defaults An array of default element values to use if the input arrays have different lengths. You must specify useLongestLength: true along with this field, or else $zip will return an error.
      * If useLongestLength: true but defaults is empty or not specified, $zip uses null as the default value.
      * If specifying a non-empty defaults, you must specify a default for each input array or else $zip will return an error.
      */
-    public readonly PackedArray|BSONArray|array $defaults;
+    public readonly Optional|PackedArray|BSONArray|array $defaults;
 
     /**
      * @param BSONArray|PackedArray|ResolvesToArray|array $inputs An array of expressions that resolve to arrays. The elements of these input arrays combine to form the arrays of the output array.
@@ -52,14 +53,14 @@ class ZipOperator implements ResolvesToArray, OperatorInterface
      * If any of the inputs arrays does not resolve to an array or null nor refers to a missing field, $zip returns an error.
      * @param bool $useLongestLength A boolean which specifies whether the length of the longest array determines the number of arrays in the output array.
      * The default value is false: the shortest array length determines the number of arrays in the output array.
-     * @param BSONArray|PackedArray|array $defaults An array of default element values to use if the input arrays have different lengths. You must specify useLongestLength: true along with this field, or else $zip will return an error.
+     * @param Optional|BSONArray|PackedArray|array $defaults An array of default element values to use if the input arrays have different lengths. You must specify useLongestLength: true along with this field, or else $zip will return an error.
      * If useLongestLength: true but defaults is empty or not specified, $zip uses null as the default value.
      * If specifying a non-empty defaults, you must specify a default for each input array or else $zip will return an error.
      */
     public function __construct(
         PackedArray|ResolvesToArray|BSONArray|array $inputs,
         bool $useLongestLength,
-        PackedArray|BSONArray|array $defaults,
+        Optional|PackedArray|BSONArray|array $defaults = Optional::Undefined,
     ) {
         if (is_array($inputs) && ! array_is_list($inputs)) {
             throw new InvalidArgumentException('Expected $inputs argument to be a list, got an associative array.');

--- a/src/Builder/Query/ExprOperator.php
+++ b/src/Builder/Query/ExprOperator.php
@@ -11,8 +11,8 @@ namespace MongoDB\Builder\Query;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
-use MongoDB\Builder\Type\FieldQueryInterface;
 use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\QueryInterface;
 use stdClass;
 
 /**
@@ -20,7 +20,7 @@ use stdClass;
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/expr/
  */
-class ExprOperator implements FieldQueryInterface, OperatorInterface
+class ExprOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/tests/Builder/Expression/AddOperatorTest.php
+++ b/tests/Builder/Expression/AddOperatorTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $add expression
+ */
+class AddOperatorTest extends PipelineTestCase
+{
+    public function testAddNumbers(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                total: Expression::add(
+                    Expression::fieldPath('price'),
+                    Expression::fieldPath('fee'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::AddAddNumbers, $pipeline);
+    }
+
+    public function testPerformAdditionOnADate(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                billing_date: Expression::add(
+                    Expression::fieldPath('date'),
+                    3 * 24 * 60 * 60000,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::AddPerformAdditionOnADate, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/MergeObjectsOperatorTest.php
+++ b/tests/Builder/Expression/MergeObjectsOperatorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $mergeObjects expression
+ */
+class MergeObjectsOperatorTest extends PipelineTestCase
+{
+    public function testMergeObjects(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::lookup(
+                as: 'fromItems',
+                from: 'items',   // field in the orders collection
+                localField: 'item', // field in the items collection
+                foreignField: 'item',
+            ),
+            Stage::replaceRoot(
+                Expression::mergeObjects(
+                    Expression::arrayElemAt(Expression::arrayFieldPath('fromItems'), 0),
+                    Expression::variable('ROOT'),
+                ),
+            ),
+            Stage::project(
+                fromItems: 0,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MergeObjectsMergeObjects, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -10,6 +10,54 @@ namespace MongoDB\Tests\Builder\Expression;
 
 enum Pipelines: string
 {
+    /**
+     * Add Numbers
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/add/#add-numbers
+     */
+    case AddAddNumbers = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "total": {
+                    "$add": [
+                        "$price",
+                        "$fee"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Perform Addition on a Date
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/add/#perform-addition-on-a-date
+     */
+    case AddPerformAdditionOnADate = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "billing_date": {
+                    "$add": [
+                        "$date",
+                        {
+                            "$numberInt": "259200000"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
     /** Use in $addFields Stage */
     case FirstUseInAddFieldsStage = <<<'JSON'
     [
@@ -114,6 +162,228 @@ enum Pipelines: string
                         "input": "$array",
                         "n": {
                             "$numberInt": "3"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * $mergeObjects
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/mergeObjects/#-mergeobjects
+     */
+    case MergeObjectsMergeObjects = <<<'JSON'
+    [
+        {
+            "$lookup": {
+                "from": "items",
+                "localField": "item",
+                "foreignField": "item",
+                "as": "fromItems"
+            }
+        },
+        {
+            "$replaceRoot": {
+                "newRoot": {
+                    "$mergeObjects": [
+                        {
+                            "$arrayElemAt": [
+                                "$fromItems",
+                                {
+                                    "$numberInt": "0"
+                                }
+                            ]
+                        },
+                        "$$ROOT"
+                    ]
+                }
+            }
+        },
+        {
+            "$project": {
+                "fromItems": {
+                    "$numberInt": "0"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Subtract Numbers
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/subtract/#subtract-numbers
+     */
+    case SubtractSubtractNumbers = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "total": {
+                    "$subtract": [
+                        {
+                            "$add": [
+                                "$price",
+                                "$fee"
+                            ]
+                        },
+                        "$discount"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Subtract Two Dates
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/subtract/#subtract-two-dates
+     */
+    case SubtractSubtractTwoDates = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "dateDifference": {
+                    "$subtract": [
+                        "$$NOW",
+                        "$date"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Subtract Milliseconds from a Date
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/subtract/#subtract-milliseconds-from-a-date
+     */
+    case SubtractSubtractMillisecondsFromADate = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "dateDifference": {
+                    "$subtract": [
+                        "$date",
+                        {
+                            "$numberInt": "300000"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Matrix Transposition
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/zip/#matrix-transposition
+     */
+    case ZipMatrixTransposition = <<<'JSON'
+    [
+        {
+            "$project": {
+                "_id": false,
+                "transposed": {
+                    "$zip": {
+                        "inputs": [
+                            {
+                                "$arrayElemAt": [
+                                    "$matrix",
+                                    {
+                                        "$numberInt": "0"
+                                    }
+                                ]
+                            },
+                            {
+                                "$arrayElemAt": [
+                                    "$matrix",
+                                    {
+                                        "$numberInt": "1"
+                                    }
+                                ]
+                            },
+                            {
+                                "$arrayElemAt": [
+                                    "$matrix",
+                                    {
+                                        "$numberInt": "2"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Filtering and Preserving Indexes
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/zip/#filtering-and-preserving-indexes
+     */
+    case ZipFilteringAndPreservingIndexes = <<<'JSON'
+    [
+        {
+            "$project": {
+                "_id": false,
+                "pages": {
+                    "$filter": {
+                        "input": {
+                            "$zip": {
+                                "inputs": [
+                                    "$pages",
+                                    {
+                                        "$range": [
+                                            {
+                                                "$numberInt": "0"
+                                            },
+                                            {
+                                                "$size": "$pages"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "as": "pageWithIndex",
+                        "cond": {
+                            "$let": {
+                                "vars": {
+                                    "page": {
+                                        "$arrayElemAt": [
+                                            "$$pageWithIndex",
+                                            {
+                                                "$numberInt": "0"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "in": {
+                                    "$gte": [
+                                        "$$page.reviews",
+                                        {
+                                            "$numberInt": "1"
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     }
                 }

--- a/tests/Builder/Expression/SubtractOperatorTest.php
+++ b/tests/Builder/Expression/SubtractOperatorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $subtract expression
+ */
+class SubtractOperatorTest extends PipelineTestCase
+{
+    public function testSubtractMillisecondsFromADate(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                dateDifference: Expression::subtract(
+                    Expression::dateFieldPath('date'),
+                    5 * 60 * 1000,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SubtractSubtractMillisecondsFromADate, $pipeline);
+    }
+
+    public function testSubtractNumbers(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                total: Expression::subtract(
+                    Expression::add(
+                        Expression::numberFieldPath('price'),
+                        Expression::numberFieldPath('fee'),
+                    ),
+                    Expression::numberFieldPath('discount'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SubtractSubtractNumbers, $pipeline);
+    }
+
+    public function testSubtractTwoDates(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                dateDifference: Expression::subtract(
+                    Expression::variable('NOW'),
+                    Expression::dateFieldPath('date'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SubtractSubtractTwoDates, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/ZipOperatorTest.php
+++ b/tests/Builder/Expression/ZipOperatorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $zip expression
+ */
+class ZipOperatorTest extends PipelineTestCase
+{
+    public function testFilteringAndPreservingIndexes(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                _id: false,
+                pages: Expression::filter(
+                    input: Expression::zip([
+                        Expression::arrayFieldPath('pages'),
+                        Expression::range(0, Expression::size(Expression::arrayFieldPath('pages'))),
+                    ]),
+                    cond: Expression::let(
+                        vars: object(
+                            page: Expression::arrayElemAt(Expression::variable('pageWithIndex'), 0),
+                        ),
+                        in: Expression::gte(Expression::variable('page.reviews'), 1),
+                    ),
+                    as: 'pageWithIndex',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ZipFilteringAndPreservingIndexes, $pipeline);
+    }
+
+    public function testMatrixTransposition(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                _id: false,
+                transposed: Expression::zip([
+                    Expression::arrayElemAt(Expression::arrayFieldPath('matrix'), 0),
+                    Expression::arrayElemAt(Expression::arrayFieldPath('matrix'), 1),
+                    Expression::arrayElemAt(Expression::arrayFieldPath('matrix'), 2),
+                ]),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ZipMatrixTransposition, $pipeline);
+    }
+}

--- a/tests/Builder/Query/ExprOperatorTest.php
+++ b/tests/Builder/Query/ExprOperatorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $expr query
+ */
+class ExprOperatorTest extends PipelineTestCase
+{
+    public function testCompareTwoFieldsFromASingleDocument(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::expr(
+                    Expression::gt(
+                        Expression::fieldPath('spent'),
+                        Expression::fieldPath('budget'),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ExprCompareTwoFieldsFromASingleDocument, $pipeline);
+    }
+
+    public function testUsingExprWithConditionalStatements(): void
+    {
+        $discountedPrice = Expression::cond(
+            if: Expression::gte(Expression::fieldPath('qty'), 100),
+            then: Expression::multiply(
+                Expression::numberfieldPath('price'),
+                0.5,
+            ),
+            else: Expression::multiply(
+                Expression::numberfieldPath('price'),
+                0.75,
+            ),
+        );
+
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::expr(
+                    Expression::lt($discountedPrice, 5),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ExprUsingExprWithConditionalStatements, $pipeline);
+    }
+}

--- a/tests/Builder/Query/Pipelines.php
+++ b/tests/Builder/Query/Pipelines.php
@@ -184,6 +184,75 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Compare Two Fields from A Single Document
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/expr/#compare-two-fields-from-a-single-document
+     */
+    case ExprCompareTwoFieldsFromASingleDocument = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$expr": {
+                    "$gt": [
+                        "$spent",
+                        "$budget"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Using $expr With Conditional Statements
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/expr/#using--expr-with-conditional-statements
+     */
+    case ExprUsingExprWithConditionalStatements = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$expr": {
+                    "$lt": [
+                        {
+                            "$cond": {
+                                "if": {
+                                    "$gte": [
+                                        "$qty",
+                                        {
+                                            "$numberInt": "100"
+                                        }
+                                    ]
+                                },
+                                "then": {
+                                    "$multiply": [
+                                        "$price",
+                                        {
+                                            "$numberDouble": "0.5"
+                                        }
+                                    ]
+                                },
+                                "else": {
+                                    "$multiply": [
+                                        "$price",
+                                        {
+                                            "$numberDouble": "0.75"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "$numberInt": "5"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Perform a LIKE Match
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/regex/#perform-a-like-match


### PR DESCRIPTION
This PR adds a few improvements I've noticed while working on some pipelines:
* `$mergeObjects` is also available as an expression operator. I've followed the same strategy we previously used for `$first`
* The `defaults` argument for `$zip` should be optional
* `$add` and `$subtract` only implemented `ResolvesToNumber`. This made them unsuitable for use in places where an integer was required (in my case the `n` argument to `$slice`). I've changed the operators to resolve to all numeric types individually. Note that the pipeline may error on the server if `$add` evaluates to a value of the wrong type, but we can't solve that without adding generics
* The `$expr` query operator was marked as a `fieldQuery` when it is actually a `query` similar to `$and` and `$or`.