### PR TITLE
PHPLIB-1333 Add tests on Comparison Query Operators

### DIFF
--- a/generator/config/query/eq.yaml
+++ b/generator/config/query/eq.yaml
@@ -11,3 +11,55 @@ arguments:
         name: value
         type:
             - any
+tests:
+    -
+        name: 'Equals a Specified Value'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/eq/#equals-a-specified-value'
+        pipeline:
+            -
+                $match:
+                    qty:
+                        $eq: 20
+
+    -
+        name: 'Field in Embedded Document Equals a Value'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/eq/#field-in-embedded-document-equals-a-value'
+        pipeline:
+            -
+                $match:
+                    'item.name':
+                        $eq: 'ab'
+
+    -
+        name: 'Equals an Array Value'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/eq/#equals-an-array-value'
+        pipeline:
+            -
+                $match:
+                    tags:
+                        $eq: ['A', 'B']
+
+    -
+        name: 'Regex Match Behaviour'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/eq/#regex-match-behaviour'
+        pipeline:
+            -
+                $match:
+                    company: 'MongoDB'
+            -
+                $match:
+                    company:
+                        $eq: 'MongoDB'
+            -
+                $match:
+                    company:
+                        $regularExpression:
+                            options: ''
+                            pattern: '^MongoDB'
+            -
+                $match:
+                    company:
+                        $eq:
+                            $regularExpression:
+                                options: ''
+                                pattern: '^MongoDB'

--- a/generator/config/query/gt.yaml
+++ b/generator/config/query/gt.yaml
@@ -11,3 +11,12 @@ arguments:
         name: value
         type:
             - any
+tests:
+    -
+        name: 'Match Document Fields'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/gt/#match-document-fields'
+        pipeline:
+            -
+                $match:
+                    qty:
+                        $gt: 20

--- a/generator/config/query/gte.yaml
+++ b/generator/config/query/gte.yaml
@@ -11,3 +11,12 @@ arguments:
         name: value
         type:
             - any
+tests:
+    -
+        name: 'Match Document Fields'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/gte/#match-document-fields'
+        pipeline:
+            -
+                $match:
+                    qty:
+                        $gte: 20

--- a/generator/config/query/in.yaml
+++ b/generator/config/query/in.yaml
@@ -11,3 +11,28 @@ arguments:
         name: value
         type:
             - array # of expression
+tests:
+    -
+        name: 'Use the $in Operator to Match Values in an Array'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/in/#use-the--in-operator-to-match-values'
+        pipeline:
+            -
+                $match:
+                    tags:
+                        $in: ['home', 'school']
+    -
+        name: 'Use the $in Operator with a Regular Expression'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/in/#use-the--in-operator-with-a-regular-expression'
+        pipeline:
+            -
+                $match:
+                    tags:
+                        $in:
+                            -
+                                $regularExpression:
+                                    options: ''
+                                    pattern: '^be'
+                            -
+                                $regularExpression:
+                                    options: ''
+                                    pattern: '^st'

--- a/generator/config/query/lt.yaml
+++ b/generator/config/query/lt.yaml
@@ -11,3 +11,12 @@ arguments:
         name: value
         type:
             - any
+tests:
+    -
+        name: 'Match Document Fields'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/lt/#match-document-fields'
+        pipeline:
+            -
+                $match:
+                    qty:
+                        $lt: 20

--- a/generator/config/query/lte.yaml
+++ b/generator/config/query/lte.yaml
@@ -11,3 +11,12 @@ arguments:
         name: value
         type:
             - any
+tests:
+    -
+        name: 'Match Document Fields'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/lte/#match-document-fields'
+        pipeline:
+            -
+                $match:
+                    qty:
+                        $lte: 20

--- a/generator/config/query/ne.yaml
+++ b/generator/config/query/ne.yaml
@@ -11,3 +11,12 @@ arguments:
         name: value
         type:
             - any
+tests:
+    -
+        name: 'Match Document Fields'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/ne/#match-document-fields'
+        pipeline:
+            -
+                $match:
+                    quantity:
+                        $ne: 20

--- a/generator/config/query/nin.yaml
+++ b/generator/config/query/nin.yaml
@@ -11,3 +11,20 @@ arguments:
         name: value
         type:
             - array # of expression
+tests:
+    -
+        name: 'Select on Unmatching Documents'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/nin/#select-on-unmatching-documents'
+        pipeline:
+            -
+                $match:
+                    quantity:
+                        $nin: [5, 15]
+    -
+        name: 'Select on Elements Not in an Array'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/nin/#select-on-elements-not-in-an-array'
+        pipeline:
+            -
+                $match:
+                    tags:
+                        $nin: ['school']

--- a/tests/Builder/Query/EqOperatorTest.php
+++ b/tests/Builder/Query/EqOperatorTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\BSON\Regex;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $eq query
+ */
+class EqOperatorTest extends PipelineTestCase
+{
+    public function testEqualsASpecifiedValue(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                qty: Query::eq(20),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::EqEqualsASpecifiedValue, $pipeline);
+    }
+
+    public function testEqualsAnArrayValue(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                tags: Query::eq(['A', 'B']),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::EqEqualsAnArrayValue, $pipeline);
+    }
+
+    public function testFieldInEmbeddedDocumentEqualsAValue(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                ...['item.name' => Query::eq('ab')],
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::EqFieldInEmbeddedDocumentEqualsAValue, $pipeline);
+    }
+
+    public function testRegexMatchBehaviour(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                company: 'MongoDB',
+            ),
+            Stage::match(
+                company: Query::eq('MongoDB'),
+            ),
+            Stage::match(
+                company: new Regex('^MongoDB'),
+            ),
+            Stage::match(
+                company: Query::eq(new Regex('^MongoDB')),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::EqRegexMatchBehaviour, $pipeline);
+    }
+}

--- a/tests/Builder/Query/GtOperatorTest.php
+++ b/tests/Builder/Query/GtOperatorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $gt query
+ */
+class GtOperatorTest extends PipelineTestCase
+{
+    public function testMatchDocumentFields(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                qty: Query::gt(20),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GtMatchDocumentFields, $pipeline);
+    }
+}

--- a/tests/Builder/Query/GteOperatorTest.php
+++ b/tests/Builder/Query/GteOperatorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $gte query
+ */
+class GteOperatorTest extends PipelineTestCase
+{
+    public function testMatchDocumentFields(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                qty: Query::gte(20),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GteMatchDocumentFields, $pipeline);
+    }
+}

--- a/tests/Builder/Query/InOperatorTest.php
+++ b/tests/Builder/Query/InOperatorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\BSON\Regex;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $in query
+ */
+class InOperatorTest extends PipelineTestCase
+{
+    public function testUseTheInOperatorToMatchValuesInAnArray(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                tags: Query::in(['home', 'school']),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::InUseTheInOperatorToMatchValuesInAnArray, $pipeline);
+    }
+
+    public function testUseTheInOperatorWithARegularExpression(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                tags: Query::in([new Regex('^be'), new Regex('^st')]),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::InUseTheInOperatorWithARegularExpression, $pipeline);
+    }
+}

--- a/tests/Builder/Query/LtOperatorTest.php
+++ b/tests/Builder/Query/LtOperatorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $lt query
+ */
+class LtOperatorTest extends PipelineTestCase
+{
+    public function testMatchDocumentFields(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                qty: Query::lt(20),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::LtMatchDocumentFields, $pipeline);
+    }
+}

--- a/tests/Builder/Query/LteOperatorTest.php
+++ b/tests/Builder/Query/LteOperatorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $lte query
+ */
+class LteOperatorTest extends PipelineTestCase
+{
+    public function testMatchDocumentFields(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                qty: Query::lte(20),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::LteMatchDocumentFields, $pipeline);
+    }
+}

--- a/tests/Builder/Query/NeOperatorTest.php
+++ b/tests/Builder/Query/NeOperatorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $ne query
+ */
+class NeOperatorTest extends PipelineTestCase
+{
+    public function testMatchDocumentFields(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                quantity: Query::ne(20),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::NeMatchDocumentFields, $pipeline);
+    }
+}

--- a/tests/Builder/Query/NinOperatorTest.php
+++ b/tests/Builder/Query/NinOperatorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $nin query
+ */
+class NinOperatorTest extends PipelineTestCase
+{
+    public function testSelectOnElementsNotInAnArray(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                tags: Query::nin(['school']),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::NinSelectOnElementsNotInAnArray, $pipeline);
+    }
+
+    public function testSelectOnUnmatchingDocuments(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                quantity: Query::nin([5, 15]),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::NinSelectOnUnmatchingDocuments, $pipeline);
+    }
+}

--- a/tests/Builder/Query/Pipelines.php
+++ b/tests/Builder/Query/Pipelines.php
@@ -184,6 +184,106 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Equals a Specified Value
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/eq/#equals-a-specified-value
+     */
+    case EqEqualsASpecifiedValue = <<<'JSON'
+    [
+        {
+            "$match": {
+                "qty": {
+                    "$eq": {
+                        "$numberInt": "20"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Field in Embedded Document Equals a Value
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/eq/#field-in-embedded-document-equals-a-value
+     */
+    case EqFieldInEmbeddedDocumentEqualsAValue = <<<'JSON'
+    [
+        {
+            "$match": {
+                "item.name": {
+                    "$eq": "ab"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Equals an Array Value
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/eq/#equals-an-array-value
+     */
+    case EqEqualsAnArrayValue = <<<'JSON'
+    [
+        {
+            "$match": {
+                "tags": {
+                    "$eq": [
+                        "A",
+                        "B"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Regex Match Behaviour
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/eq/#regex-match-behaviour
+     */
+    case EqRegexMatchBehaviour = <<<'JSON'
+    [
+        {
+            "$match": {
+                "company": "MongoDB"
+            }
+        },
+        {
+            "$match": {
+                "company": {
+                    "$eq": "MongoDB"
+                }
+            }
+        },
+        {
+            "$match": {
+                "company": {
+                    "$regularExpression": {
+                        "options": "",
+                        "pattern": "^MongoDB"
+                    }
+                }
+            }
+        },
+        {
+            "$match": {
+                "company": {
+                    "$eq": {
+                        "$regularExpression": {
+                            "options": "",
+                            "pattern": "^MongoDB"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Compare Two Fields from A Single Document
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/expr/#compare-two-fields-from-a-single-document
@@ -245,6 +345,194 @@ enum Pipelines: string
                         {
                             "$numberInt": "5"
                         }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Match Document Fields
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/gt/#match-document-fields
+     */
+    case GtMatchDocumentFields = <<<'JSON'
+    [
+        {
+            "$match": {
+                "qty": {
+                    "$gt": {
+                        "$numberInt": "20"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Match Document Fields
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/gte/#match-document-fields
+     */
+    case GteMatchDocumentFields = <<<'JSON'
+    [
+        {
+            "$match": {
+                "qty": {
+                    "$gte": {
+                        "$numberInt": "20"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use the $in Operator to Match Values in an Array
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/in/#use-the--in-operator-to-match-values
+     */
+    case InUseTheInOperatorToMatchValuesInAnArray = <<<'JSON'
+    [
+        {
+            "$match": {
+                "tags": {
+                    "$in": [
+                        "home",
+                        "school"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use the $in Operator with a Regular Expression
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/in/#use-the--in-operator-with-a-regular-expression
+     */
+    case InUseTheInOperatorWithARegularExpression = <<<'JSON'
+    [
+        {
+            "$match": {
+                "tags": {
+                    "$in": [
+                        {
+                            "$regularExpression": {
+                                "options": "",
+                                "pattern": "^be"
+                            }
+                        },
+                        {
+                            "$regularExpression": {
+                                "options": "",
+                                "pattern": "^st"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Match Document Fields
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/lt/#match-document-fields
+     */
+    case LtMatchDocumentFields = <<<'JSON'
+    [
+        {
+            "$match": {
+                "qty": {
+                    "$lt": {
+                        "$numberInt": "20"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Match Document Fields
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/lte/#match-document-fields
+     */
+    case LteMatchDocumentFields = <<<'JSON'
+    [
+        {
+            "$match": {
+                "qty": {
+                    "$lte": {
+                        "$numberInt": "20"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Match Document Fields
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/ne/#match-document-fields
+     */
+    case NeMatchDocumentFields = <<<'JSON'
+    [
+        {
+            "$match": {
+                "quantity": {
+                    "$ne": {
+                        "$numberInt": "20"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Select on Unmatching Documents
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/nin/#select-on-unmatching-documents
+     */
+    case NinSelectOnUnmatchingDocuments = <<<'JSON'
+    [
+        {
+            "$match": {
+                "quantity": {
+                    "$nin": [
+                        {
+                            "$numberInt": "5"
+                        },
+                        {
+                            "$numberInt": "15"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Select on Elements Not in an Array
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/nin/#select-on-elements-not-in-an-array
+     */
+    case NinSelectOnElementsNotInAnArray = <<<'JSON'
+    [
+        {
+            "$match": {
+                "tags": {
+                    "$nin": [
+                        "school"
                     ]
                 }
             }


### PR DESCRIPTION
Fix [PHPLIB-1333](https://jira.mongodb.org/browse/PHPLIB-1333)

https://www.mongodb.com/docs/manual/reference/operator/query/#query-selectors

- `$eq` (skipped [Array Element Equals a Value](https://www.mongodb.com/docs/manual/reference/operator/query/eq/#array-element-equals-a-value) as redondant) 
- `$gt` (skipped [Perform an Update Based on Embedded Document Fields](https://www.mongodb.com/docs/manual/reference/operator/query/gt/#perform-an-update-based-on-embedded-document-fields))
- `$gte` (skipped [Perform an Update Based on Embedded Document Fields](https://www.mongodb.com/docs/manual/reference/operator/query/gte/#perform-an-update-based-on-embedded-document-fields))
- `$in`
- `$lt` (skipped [Perform an Update Based on Embedded Document Fields](https://www.mongodb.com/docs/manual/reference/operator/query/lt/#perform-an-update-based-on-embedded-document-fields))
- `$lte` (skipped [Perform an Update Based on Embedded Document Fields](https://www.mongodb.com/docs/manual/reference/operator/query/lte/#perform-an-update-based-on-embedded-document-fields))
- `$ne` (skipped [Perform an Update Based on Embedded Document Fields](https://www.mongodb.com/docs/manual/reference/operator/query/ne/#perform-an-update-based-on-embedded-document-fields))
- `$nin`
