### PR TITLE
PHPLIB-1334 Add tests on Logical Query Operators

### DIFF
--- a/generator/config/query/and.yaml
+++ b/generator/config/query/and.yaml
@@ -13,3 +13,39 @@ arguments:
             - query
         variadic: array
         variadicMin: 1
+tests:
+    -
+        name: 'AND Queries With Multiple Expressions Specifying the Same Field'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/and/#and-queries-with-multiple-expressions-specifying-the-same-field'
+        pipeline:
+            -
+                $match:
+                    $and:
+                        -
+                            price:
+                                $ne: 1.99
+                        -
+                            price:
+                                $exists: true
+    -
+        name: 'AND Queries With Multiple Expressions Specifying the Same Operator'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/and/#and-queries-with-multiple-expressions-specifying-the-same-operator'
+        pipeline:
+            -
+                $match:
+                    $and:
+                        -
+                            $or:
+                                -
+                                    qty:
+                                        $lt: 10
+                                -
+                                    qty:
+                                        $gt: 50
+                        -
+                            $or:
+                                -
+                                    sale: true
+                                -
+                                    price:
+                                        $lt: 5

--- a/generator/config/query/nor.yaml
+++ b/generator/config/query/nor.yaml
@@ -13,3 +13,46 @@ arguments:
             - query
         variadic: array
         variadicMin: 1
+tests:
+    -
+        name: 'Query with Two Expressions'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/nor/#-nor-query-with-two-expressions'
+        pipeline:
+            -
+                $match:
+                    $nor:
+                        -
+                            price: 1.99
+                        -
+                            sale: true
+    -
+        name: 'Additional Comparisons'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/nor/#-nor-and-additional-comparisons'
+        pipeline:
+            -
+                $match:
+                    $nor:
+                        -
+                            price: 1.99
+                        -
+                            qty:
+                                $lt: 20
+                        -
+                            sale: true
+    -
+        name: '$nor and $exists'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/nor/#-nor-and--exists'
+        pipeline:
+            -
+                $match:
+                    $nor:
+                        -
+                            price: 1.99
+                        -
+                            price:
+                                $exists: false
+                        -
+                            sale: true
+                        -
+                            sale:
+                                $exists: false

--- a/generator/config/query/not.yaml
+++ b/generator/config/query/not.yaml
@@ -11,3 +11,24 @@ arguments:
         name: expression
         type:
             - fieldQuery
+tests:
+    -
+        name: 'Syntax'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/not/#syntax'
+        pipeline:
+            -
+                $match:
+                    price:
+                        $not:
+                            $gt: 1.99
+    -
+        name: 'Regular Expressions'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/not/#-not-and-regular-expressions'
+        pipeline:
+            -
+                $match:
+                    price:
+                        $not:
+                            $regularExpression:
+                                pattern: '^p.*'
+                                options: ''

--- a/generator/config/query/or.yaml
+++ b/generator/config/query/or.yaml
@@ -13,3 +13,35 @@ arguments:
             - query
         variadic: array
         variadicMin: 1
+tests:
+    -
+        name: '$or Clauses'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/or/#-or-clauses-and-indexes'
+        pipeline:
+            -
+                $match:
+                    $or:
+                        -
+                            quantity:
+                                $lt: 20
+                        -
+                            price: 10
+
+    -
+        name: 'Error Handling'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/or/#error-handling'
+        pipeline:
+            -
+                $match:
+                    $or:
+                        -
+                            x:
+                                $eq: 0
+                        -
+                            $expr:
+                                $eq:
+                                    -
+                                        $divide:
+                                            - 1
+                                            - '$x'
+                                    - 3

--- a/tests/Builder/Query/AndOperatorTest.php
+++ b/tests/Builder/Query/AndOperatorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $and query
+ */
+class AndOperatorTest extends PipelineTestCase
+{
+    public function testANDQueriesWithMultipleExpressionsSpecifyingTheSameField(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::and(
+                    Query::query(
+                        price: Query::ne(1.99),
+                    ),
+                    Query::query(
+                        price: Query::exists(true),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::AndANDQueriesWithMultipleExpressionsSpecifyingTheSameField, $pipeline);
+    }
+
+    public function testANDQueriesWithMultipleExpressionsSpecifyingTheSameOperator(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::and(
+                    Query::or(
+                        Query::query(
+                            qty: Query::lt(10),
+                        ),
+                        Query::query(
+                            qty: Query::gt(50),
+                        ),
+                    ),
+                    Query::or(
+                        Query::query(
+                            sale: true,
+                        ),
+                        Query::query(
+                            price: Query::lt(5),
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::AndANDQueriesWithMultipleExpressionsSpecifyingTheSameOperator, $pipeline);
+    }
+}

--- a/tests/Builder/Query/NorOperatorTest.php
+++ b/tests/Builder/Query/NorOperatorTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $nor query
+ */
+class NorOperatorTest extends PipelineTestCase
+{
+    public function testAdditionalComparisons(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::nor(
+                    Query::query(
+                        price: 1.99,
+                    ),
+                    Query::query(
+                        qty: Query::lt(20),
+                    ),
+                    Query::query(
+                        sale: true,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::NorAdditionalComparisons, $pipeline);
+    }
+
+    public function testNorAndExists(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::nor(
+                    Query::query(
+                        price: 1.99,
+                    ),
+                    Query::query(
+                        price: Query::exists(false),
+                    ),
+                    Query::query(
+                        sale: true,
+                    ),
+                    Query::query(
+                        sale: Query::exists(false),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::NorNorAndExists, $pipeline);
+    }
+
+    public function testQueryWithTwoExpressions(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::nor(
+                    Query::query(
+                        price: 1.99,
+                    ),
+                    Query::query(
+                        sale: true,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::NorQueryWithTwoExpressions, $pipeline);
+    }
+}

--- a/tests/Builder/Query/NotOperatorTest.php
+++ b/tests/Builder/Query/NotOperatorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\BSON\Regex;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $not query
+ */
+class NotOperatorTest extends PipelineTestCase
+{
+    public function testRegularExpressions(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                price: Query::not(
+                    new Regex('^p.*'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::NotRegularExpressions, $pipeline);
+    }
+
+    public function testSyntax(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                price: Query::not(
+                    Query::gt(1.99),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::NotSyntax, $pipeline);
+    }
+}

--- a/tests/Builder/Query/OrOperatorTest.php
+++ b/tests/Builder/Query/OrOperatorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $or query
+ */
+class OrOperatorTest extends PipelineTestCase
+{
+    public function testErrorHandling(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::or(
+                    Query::query(
+                        x: Query::eq(0),
+                    ),
+                    Query::expr(
+                        Expression::eq(
+                            Expression::divide(
+                                1,
+                                Expression::intFieldPath('x'),
+                            ),
+                            3,
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::OrErrorHandling, $pipeline);
+    }
+
+    public function testOrClauses(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::or(
+                    Query::query(
+                        quantity: Query::lt(20),
+                    ),
+                    Query::query(
+                        price: 10,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::OrOrClauses, $pipeline);
+    }
+}

--- a/tests/Builder/Query/Pipelines.php
+++ b/tests/Builder/Query/Pipelines.php
@@ -68,6 +68,82 @@ enum Pipelines: string
     JSON;
 
     /**
+     * AND Queries With Multiple Expressions Specifying the Same Field
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/and/#and-queries-with-multiple-expressions-specifying-the-same-field
+     */
+    case AndANDQueriesWithMultipleExpressionsSpecifyingTheSameField = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$and": [
+                    {
+                        "price": {
+                            "$ne": {
+                                "$numberDouble": "1.9899999999999999911"
+                            }
+                        }
+                    },
+                    {
+                        "price": {
+                            "$exists": true
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * AND Queries With Multiple Expressions Specifying the Same Operator
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/and/#and-queries-with-multiple-expressions-specifying-the-same-operator
+     */
+    case AndANDQueriesWithMultipleExpressionsSpecifyingTheSameOperator = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$and": [
+                    {
+                        "$or": [
+                            {
+                                "qty": {
+                                    "$lt": {
+                                        "$numberInt": "10"
+                                    }
+                                }
+                            },
+                            {
+                                "qty": {
+                                    "$gt": {
+                                        "$numberInt": "50"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "$or": [
+                            {
+                                "sale": true
+                            },
+                            {
+                                "price": {
+                                    "$lt": {
+                                        "$numberInt": "5"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Element Match
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/elemMatch/#element-match
@@ -535,6 +611,206 @@ enum Pipelines: string
                         "school"
                     ]
                 }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Query with Two Expressions
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/nor/#-nor-query-with-two-expressions
+     */
+    case NorQueryWithTwoExpressions = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$nor": [
+                    {
+                        "price": {
+                            "$numberDouble": "1.9899999999999999911"
+                        }
+                    },
+                    {
+                        "sale": true
+                    }
+                ]
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Additional Comparisons
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/nor/#-nor-and-additional-comparisons
+     */
+    case NorAdditionalComparisons = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$nor": [
+                    {
+                        "price": {
+                            "$numberDouble": "1.9899999999999999911"
+                        }
+                    },
+                    {
+                        "qty": {
+                            "$lt": {
+                                "$numberInt": "20"
+                            }
+                        }
+                    },
+                    {
+                        "sale": true
+                    }
+                ]
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * $nor and $exists
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/nor/#-nor-and--exists
+     */
+    case NorNorAndExists = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$nor": [
+                    {
+                        "price": {
+                            "$numberDouble": "1.9899999999999999911"
+                        }
+                    },
+                    {
+                        "price": {
+                            "$exists": false
+                        }
+                    },
+                    {
+                        "sale": true
+                    },
+                    {
+                        "sale": {
+                            "$exists": false
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Syntax
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/not/#syntax
+     */
+    case NotSyntax = <<<'JSON'
+    [
+        {
+            "$match": {
+                "price": {
+                    "$not": {
+                        "$gt": {
+                            "$numberDouble": "1.9899999999999999911"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Regular Expressions
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/not/#-not-and-regular-expressions
+     */
+    case NotRegularExpressions = <<<'JSON'
+    [
+        {
+            "$match": {
+                "price": {
+                    "$not": {
+                        "$regularExpression": {
+                            "pattern": "^p.*",
+                            "options": ""
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * $or Clauses
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/or/#-or-clauses-and-indexes
+     */
+    case OrOrClauses = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$or": [
+                    {
+                        "quantity": {
+                            "$lt": {
+                                "$numberInt": "20"
+                            }
+                        }
+                    },
+                    {
+                        "price": {
+                            "$numberInt": "10"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Error Handling
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/or/#error-handling
+     */
+    case OrErrorHandling = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$or": [
+                    {
+                        "x": {
+                            "$eq": {
+                                "$numberInt": "0"
+                            }
+                        }
+                    },
+                    {
+                        "$expr": {
+                            "$eq": [
+                                {
+                                    "$divide": [
+                                        {
+                                            "$numberInt": "1"
+                                        },
+                                        "$x"
+                                    ]
+                                },
+                                {
+                                    "$numberInt": "3"
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
         }
     ]


### PR DESCRIPTION
Fix [PHPLIB-1334](https://jira.mongodb.org/browse/PHPLIB-1334)

https://www.mongodb.com/docs/manual/reference/operator/query/#logical

- `$and` 
- `$not` (using the [syntax](https://www.mongodb.com/docs/manual/reference/operator/query/not/#mongodb-query-op.-not), as there is no example)
- `$nor`
- `$or`