### PR TITLE
PHPLIB-1343 Add tests on Array Expression Operators

### DIFF
--- a/generator/config/expression/arrayElemAt.yaml
+++ b/generator/config/expression/arrayElemAt.yaml
@@ -15,3 +15,19 @@ arguments:
         name: idx
         type:
             - resolvesToInt
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/arrayElemAt/#example'
+        pipeline:
+            -
+                $project:
+                    name: 1
+                    first:
+                        $arrayElemAt:
+                            - '$favorites'
+                            - 0
+                    last:
+                        $arrayElemAt:
+                            - '$favorites'
+                            - -1

--- a/generator/config/expression/arrayToObject.yaml
+++ b/generator/config/expression/arrayToObject.yaml
@@ -11,3 +11,40 @@ arguments:
         name: array
         type:
             - resolvesToArray
+tests:
+    -
+        name: '$arrayToObject Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/arrayToObject/#-arraytoobject--example'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    dimensions:
+                        # The example renders a single value, but the builder generates an array for consistency
+                        # $arrayToObject: '$dimensions'
+                        $arrayToObject:
+                            - '$dimensions'
+    -
+        name: '$objectToArray and $arrayToObject Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/arrayToObject/#-objecttoarray----arraytoobject-example'
+        pipeline:
+            -
+                $addFields:
+                    instock:
+                        $objectToArray: '$instock'
+            -
+                $addFields:
+                    instock:
+                        $concatArrays:
+                            - '$instock'
+                            -
+                                -
+                                    k: 'total'
+                                    v:
+                                        $sum:
+                                            - '$instock.v'
+            -
+                $addFields:
+                    instock:
+                        $arrayToObject:
+                            - '$instock'

--- a/generator/config/expression/concatArrays.yaml
+++ b/generator/config/expression/concatArrays.yaml
@@ -12,3 +12,14 @@ arguments:
         type:
             - resolvesToArray
         variadic: array
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/concatArrays/#example'
+        pipeline:
+            -
+                $project:
+                    items:
+                        $concatArrays:
+                            - '$instock'
+                            - '$ordered'

--- a/generator/config/expression/filter.yaml
+++ b/generator/config/expression/filter.yaml
@@ -32,3 +32,63 @@ arguments:
         description: |
             A number expression that restricts the number of matching array elements that $filter returns. You cannot specify a limit less than 1. The matching array elements are returned in the order they appear in the input array.
             If the specified limit is greater than the number of matching array elements, $filter returns all matching array elements. If the limit is null, $filter returns all matching array elements.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/filter/#examples'
+        pipeline:
+            -
+                $project:
+                    items:
+                        $filter:
+                            input: '$items'
+                            as: 'item'
+                            cond:
+                                $gte:
+                                    - '$$item.price'
+                                    - 100
+    -
+        name: 'Using the limit field'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/filter/#using-the-limit-field'
+        pipeline:
+            -
+                $project:
+                    items:
+                        $filter:
+                            input: '$items'
+                            cond:
+                                $gte:
+                                    - '$$item.price'
+                                    - 100
+                            as: 'item'
+                            limit: 1
+    -
+        name: 'limit as a Numeric Expression'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/filter/#limit-as-a-numeric-expression'
+        pipeline:
+            -
+                $project:
+                    items:
+                        $filter:
+                            input: '$items'
+                            cond:
+                                $lte:
+                                    - '$$item.price'
+                                    - 150
+                            as: 'item'
+                            limit: 2
+    -
+        name: 'limit Greater than Possible Matches'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/filter/#limit-greater-than-possible-matches'
+        pipeline:
+            -
+                $project:
+                    items:
+                        $filter:
+                            input: '$items'
+                            cond:
+                                $gte:
+                                    - '$$item.price'
+                                    - 100
+                            as: 'item'
+                            limit: 5

--- a/generator/config/expression/in.yaml
+++ b/generator/config/expression/in.yaml
@@ -19,3 +19,15 @@ arguments:
             - resolvesToArray
         description: |
             Any valid expression that resolves to an array.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/in/#example'
+        pipeline:
+            -
+                $project:
+                    store location: '$location'
+                    has bananas:
+                        $in:
+                            - 'bananas'
+                            - '$in_stock'

--- a/generator/config/expression/indexOfArray.yaml
+++ b/generator/config/expression/indexOfArray.yaml
@@ -35,3 +35,14 @@ arguments:
         description: |
             An integer, or a number that can be represented as integers (such as 2.0), that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number. If you specify a <end> index value, you should also specify a <start> index value; otherwise, $indexOfArray uses the <end> value as the <start> index value instead of the <end> value.
             If unspecified, the ending index position for the search is the end of the string.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/indexOfArray/#example'
+        pipeline:
+            -
+                $project:
+                    index:
+                        $indexOfArray:
+                            - '$items'
+                            - 2

--- a/generator/config/expression/isArray.yaml
+++ b/generator/config/expression/isArray.yaml
@@ -3,7 +3,7 @@ name: $isArray
 link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/isArray/'
 type:
     - resolvesToBool
-encode: array
+encode: single
 description: |
     Determines if the operand is an array. Returns a boolean.
 arguments:
@@ -11,4 +11,23 @@ arguments:
         name: expression
         type:
             - expression
-        variadic: array
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/isArray/#example'
+        pipeline:
+            -
+                $project:
+                    items:
+                        $cond:
+                            if:
+                                $and:
+                                    -
+                                        $isArray: '$instock'
+                                    -
+                                        $isArray: '$ordered'
+                            then:
+                                $concatArrays:
+                                    - '$instock'
+                                    - '$ordered'
+                            else: 'One or more fields is not an array.'

--- a/generator/config/expression/isArray.yaml
+++ b/generator/config/expression/isArray.yaml
@@ -3,7 +3,7 @@ name: $isArray
 link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/isArray/'
 type:
     - resolvesToBool
-encode: single
+encode: array
 description: |
     Determines if the operand is an array. Returns a boolean.
 arguments:
@@ -22,10 +22,14 @@ tests:
                         $cond:
                             if:
                                 $and:
+                                    # The example in the docs uses the short syntax for $isArray,
+                                    # but the aggregation builder always uses the more verbose syntax.
                                     -
-                                        $isArray: '$instock'
+                                        $isArray:
+                                            - '$instock'
                                     -
-                                        $isArray: '$ordered'
+                                        $isArray:
+                                            - '$ordered'
                             then:
                                 $concatArrays:
                                     - '$instock'

--- a/generator/config/expression/map.yaml
+++ b/generator/config/expression/map.yaml
@@ -26,3 +26,51 @@ arguments:
             - expression
         description: |
             An expression that is applied to each element of the input array. The expression references each element individually with the variable name specified in as.
+tests:
+    -
+        name: 'Add to Each Element of an Array'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/map/#add-to-each-element-of-an-array'
+        pipeline:
+            -
+                $project:
+                    adjustedGrades:
+                        $map:
+                            input: '$quizzes'
+                            as: 'grade'
+                            in:
+                                $add:
+                                    - '$$grade'
+                                    - 2
+    -
+        name: 'Truncate Each Array Element'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/map/#truncate-each-array-element'
+        pipeline:
+            -
+                $project:
+                    city: '$city'
+                    integerValues:
+                        $map:
+                            input: '$distances'
+                            as: 'decimalValue'
+                            in:
+                                # The example renders a single value, but the builder generates an array for consistency
+                                # $trunc: '$$decimalValue'
+                                $trunc:
+                                    - '$$decimalValue'
+    -
+        name: 'Convert Celsius Temperatures to Fahrenheit'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/map/#convert-celsius-temperatures-to-fahrenheit'
+        pipeline:
+            -
+                $addFields:
+                    tempsF:
+                        $map:
+                            input: '$tempsC'
+                            as: 'tempInCelsius'
+                            in:
+                                $add:
+                                    -
+                                        $multiply:
+                                            - '$$tempInCelsius'
+                                            - 1.8
+                                    - 32

--- a/generator/config/expression/maxN.yaml
+++ b/generator/config/expression/maxN.yaml
@@ -19,3 +19,14 @@ arguments:
             - resolvesToInt
         description: |
             An expression that resolves to a positive integer. The integer specifies the number of array elements that $maxN returns.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/maxN-array-element/#example'
+        pipeline:
+            -
+                $addFields:
+                    maxScores:
+                        $maxN:
+                            n: 2
+                            input: '$score'

--- a/generator/config/expression/minN.yaml
+++ b/generator/config/expression/minN.yaml
@@ -19,3 +19,14 @@ arguments:
             - resolvesToInt
         description: |
             An expression that resolves to a positive integer. The integer specifies the number of array elements that $maxN returns.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/minN-array-element/#example'
+        pipeline:
+            -
+                $addFields:
+                    minScores:
+                        $minN:
+                            n: 2
+                            input: '$score'

--- a/generator/config/expression/objectToArray.yaml
+++ b/generator/config/expression/objectToArray.yaml
@@ -13,3 +13,33 @@ arguments:
             - resolvesToObject
         description: |
             Any valid expression as long as it resolves to a document object. $objectToArray applies to the top-level fields of its argument. If the argument is a document that itself contains embedded document fields, the $objectToArray does not recursively apply to the embedded document fields.
+tests:
+    # "$objectToArray and $arrayToObject Example" omitted as it's already in arrayToObject.yaml
+    -
+        name: '$objectToArray Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/objectToArray/#-objecttoarray-example'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    dimensions:
+                        $objectToArray: '$dimensions'
+    -
+        name: '$objectToArray to Sum Nested Fields'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/objectToArray/#-objecttoarray-to-sum-nested-fields'
+        pipeline:
+            -
+                $project:
+                    warehouses:
+                        $objectToArray: '$instock'
+            -
+                # The example in the docs uses the short syntax for $unwind,
+                # but the aggregation builder always uses the more verbose syntax.
+                # $unwind: '$warehouses'
+                $unwind:
+                    path: '$warehouses'
+            -
+                $group:
+                    _id: '$warehouses.k'
+                    total:
+                        $sum: '$warehouses.v'

--- a/generator/config/expression/range.yaml
+++ b/generator/config/expression/range.yaml
@@ -26,3 +26,17 @@ arguments:
         optional: true
         description: |
             An integer that specifies the increment value. Can be any valid expression that resolves to a non-zero integer. Defaults to 1.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/range/#example'
+        pipeline:
+            -
+                $project:
+                    _id: 0
+                    city: 1
+                    Rest stops:
+                        $range:
+                            - 0
+                            - '$distance'
+                            - 25

--- a/generator/config/expression/reduce.yaml
+++ b/generator/config/expression/reduce.yaml
@@ -30,3 +30,105 @@ arguments:
             During evaluation of the in expression, two variables will be available:
             - value is the variable that represents the cumulative value of the expression.
             - this is the variable that refers to the element being processed.
+tests:
+    -
+        name: 'Multiplication'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/reduce/#multiplication'
+        pipeline:
+            -
+                $group:
+                    _id: '$experimentId'
+                    probabilityArr:
+                        $push: '$probability'
+            -
+                $project:
+                    description: 1
+                    results:
+                        $reduce:
+                            input: '$probabilityArr'
+                            initialValue: 1
+                            in:
+                                $multiply:
+                                    - '$$value'
+                                    - '$$this'
+    -
+        name: 'Discounted Merchandise'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/reduce/#discounted-merchandise'
+        pipeline:
+            -
+                $project:
+                    discountedPrice:
+                        $reduce:
+                            input: '$discounts'
+                            initialValue: '$price'
+                            in:
+                                $multiply:
+                                    - '$$value'
+                                    -
+                                        $subtract:
+                                            - 1
+                                            - '$$this'
+    -
+        name: 'String Concatenation'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/reduce/#string-concatenation'
+        pipeline:
+            # Filter to return only non-empty arrays
+            -
+                $match:
+                    hobbies:
+                        $gt: []
+            -
+                $project:
+                    name: 1
+                    bio:
+                        $reduce:
+                            input: '$hobbies'
+                            initialValue: 'My hobbies include:'
+                            in:
+                                $concat:
+                                    - '$$value'
+                                    -
+                                        $cond:
+                                            if:
+                                                $eq:
+                                                    - '$$value'
+                                                    - 'My hobbies include:'
+                                            then: ' '
+                                            else: ', '
+                                    - '$$this'
+    -
+        name: 'Array Concatenation'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/reduce/#array-concatenation'
+        pipeline:
+            -
+                $project:
+                    collapsed:
+                        $reduce:
+                            input: '$arr'
+                            initialValue: []
+                            in:
+                                $concatArrays:
+                                    - '$$value'
+                                    - '$$this'
+    -
+        name: 'Computing a Multiple Reductions'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/reduce/#computing-a-multiple-reductions'
+        pipeline:
+            -
+                $project:
+                    results:
+                        $reduce:
+                            input: '$arr'
+                            initialValue: []
+                            in:
+                                collapsed:
+                                    $concatArrays:
+                                        - '$$value.collapsed'
+                                        - '$$this'
+                                firstValues:
+                                    $concatArrays:
+                                        - '$$value.firstValues'
+                                        -
+                                            $slice:
+                                                - '$$this'
+                                                - 1

--- a/generator/config/expression/reverseArray.yaml
+++ b/generator/config/expression/reverseArray.yaml
@@ -13,3 +13,13 @@ arguments:
             - resolvesToArray
         description: |
             The argument can be any valid expression as long as it resolves to an array.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/reverseArray/#example'
+        pipeline:
+            -
+                $project:
+                    name: 1
+                    reverseFavorites:
+                        $reverseArray: '$favorites'

--- a/generator/config/expression/size.yaml
+++ b/generator/config/expression/size.yaml
@@ -13,3 +13,18 @@ arguments:
             - resolvesToArray
         description: |
             The argument for $size can be any expression as long as it resolves to an array.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/size/#example'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    numberOfColors:
+                        $cond:
+                            if:
+                                $isArray: '$colors'
+                            then:
+                                $size: '$colors'
+                            else: 'NA'

--- a/generator/config/expression/size.yaml
+++ b/generator/config/expression/size.yaml
@@ -24,7 +24,11 @@ tests:
                     numberOfColors:
                         $cond:
                             if:
-                                $isArray: '$colors'
+                                # The example in the docs uses the short syntax for $isArray,
+                                # but the aggregation builder always uses the more verbose syntax.
+                                # $isArray: '$colors'
+                                $isArray:
+                                    - '$colors'
                             then:
                                 $size: '$colors'
                             else: 'NA'

--- a/generator/config/expression/slice.yaml
+++ b/generator/config/expression/slice.yaml
@@ -31,3 +31,15 @@ arguments:
             Any valid expression as long as it resolves to an integer. If position is specified, n must resolve to a positive integer.
             If positive, $slice returns up to the first n elements in the array. If the position is specified, $slice returns the first n elements starting from the position.
             If negative, $slice returns up to the last n elements in the array. n cannot resolve to a negative number if <position> is specified.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/slice/#example'
+        pipeline:
+            -
+                $project:
+                    name: 1
+                    threeFavorites:
+                        $slice:
+                            - '$favorites'
+                            - 3

--- a/generator/config/expression/sortArray.yaml
+++ b/generator/config/expression/sortArray.yaml
@@ -19,5 +19,90 @@ arguments:
         name: sortBy
         type:
             - object # SortSpec
+            - int
         description: |
             The document specifies a sort ordering.
+tests:
+    -
+        name: 'Sort on a Field'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/sortArray/#sort-on-a-field'
+        pipeline:
+            -
+                $project:
+                    _id: 0
+                    result:
+                        $sortArray:
+                            input: '$team'
+                            sortBy:
+                                name: 1
+    -
+        name: 'Sort on a Subfield'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/sortArray/#sort-on-a-subfield'
+        pipeline:
+            -
+                $project:
+                    _id: 0
+                    result:
+                        $sortArray:
+                            input: '$team'
+                            sortBy:
+                                address.city: -1
+    -
+        name: 'Sort on Multiple Fields'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/sortArray/#sort-on-multiple-fields'
+        pipeline:
+            -
+                $project:
+                    _id: 0
+                    result:
+                        $sortArray:
+                            input: '$team'
+                            sortBy:
+                                age: -1
+                                name: 1
+    -
+        name: 'Sort an Array of Integers'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/sortArray/#sort-an-array-of-integers'
+        pipeline:
+            -
+                $project:
+                    _id: 0
+                    result:
+                        $sortArray:
+                            input:
+                                - 1
+                                - 4
+                                - 1
+                                - 6
+                                - 12
+                                - 5
+                            sortBy: 1
+    -
+        name: 'Sort on Mixed Type Fields'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/sortArray/#sort-on-mixed-type-fields'
+        pipeline:
+            -
+                $project:
+                    _id: 0
+                    result:
+                        $sortArray:
+                            input:
+                                - 20
+                                - 4
+                                -
+                                    a: 'Free'
+                                - 6
+                                - 21
+                                - 5
+                                - 'Gratis'
+                                -
+                                    a: ~
+                                -
+                                    a:
+                                        sale: true
+                                        price: 19
+                                # Decimal128( "10.23" )
+                                - 10.23
+                                -
+                                    a: 'On sale'
+                            sortBy: 1

--- a/src/Builder/BuilderEncoder.php
+++ b/src/Builder/BuilderEncoder.php
@@ -278,6 +278,8 @@ class BuilderEncoder implements Encoder
             foreach (get_object_vars($value) as $key => $val) {
                 $value->{$key} = $this->recursiveEncode($val);
             }
+
+            return $value;
         }
 
         return $this->encodeIfSupported($value);

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -956,14 +956,13 @@ trait FactoryTrait
      * Determines if the operand is an array. Returns a boolean.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/isArray/
-     * @no-named-arguments
-     * @param ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass ...$expression
+     * @param ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass $expression
      */
     public static function isArray(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
+        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): IsArrayOperator
     {
-        return new IsArrayOperator(...$expression);
+        return new IsArrayOperator($expression);
     }
 
     /**
@@ -1868,11 +1867,11 @@ trait FactoryTrait
      * @param BSONArray|PackedArray|ResolvesToArray|array $input The array to be sorted.
      * The result is null if the expression: is missing, evaluates to null, or evaluates to undefined
      * If the expression evaluates to any other non-array value, the document returns an error.
-     * @param Document|Serializable|array|stdClass $sortBy The document specifies a sort ordering.
+     * @param Document|Serializable|array|int|stdClass $sortBy The document specifies a sort ordering.
      */
     public static function sortArray(
         PackedArray|ResolvesToArray|BSONArray|array $input,
-        Document|Serializable|stdClass|array $sortBy,
+        Document|Serializable|stdClass|array|int $sortBy,
     ): SortArrayOperator
     {
         return new SortArrayOperator($input, $sortBy);

--- a/src/Builder/Expression/IsArrayOperator.php
+++ b/src/Builder/Expression/IsArrayOperator.php
@@ -21,7 +21,7 @@ use stdClass;
  */
 class IsArrayOperator implements ResolvesToBool, OperatorInterface
 {
-    public const ENCODE = Encode::Single;
+    public const ENCODE = Encode::Array;
 
     /** @var ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Expression/IsArrayOperator.php
+++ b/src/Builder/Expression/IsArrayOperator.php
@@ -12,10 +12,7 @@ use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
 use MongoDB\Builder\Type\OperatorInterface;
-use MongoDB\Exception\InvalidArgumentException;
 use stdClass;
-
-use function array_is_list;
 
 /**
  * Determines if the operand is an array. Returns a boolean.
@@ -24,25 +21,16 @@ use function array_is_list;
  */
 class IsArrayOperator implements ResolvesToBool, OperatorInterface
 {
-    public const ENCODE = Encode::Array;
+    public const ENCODE = Encode::Single;
 
-    /** @var list<ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass> $expression */
-    public readonly array $expression;
+    /** @var ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass $expression */
+    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass ...$expression
-     * @no-named-arguments
+     * @param ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression)
+    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
-        if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
-        }
-
-        if (! array_is_list($expression)) {
-            throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
-        }
-
         $this->expression = $expression;
     }
 

--- a/src/Builder/Expression/SortArrayOperator.php
+++ b/src/Builder/Expression/SortArrayOperator.php
@@ -36,18 +36,18 @@ class SortArrayOperator implements ResolvesToArray, OperatorInterface
      */
     public readonly PackedArray|ResolvesToArray|BSONArray|array $input;
 
-    /** @var Document|Serializable|array|stdClass $sortBy The document specifies a sort ordering. */
-    public readonly Document|Serializable|stdClass|array $sortBy;
+    /** @var Document|Serializable|array|int|stdClass $sortBy The document specifies a sort ordering. */
+    public readonly Document|Serializable|stdClass|array|int $sortBy;
 
     /**
      * @param BSONArray|PackedArray|ResolvesToArray|array $input The array to be sorted.
      * The result is null if the expression: is missing, evaluates to null, or evaluates to undefined
      * If the expression evaluates to any other non-array value, the document returns an error.
-     * @param Document|Serializable|array|stdClass $sortBy The document specifies a sort ordering.
+     * @param Document|Serializable|array|int|stdClass $sortBy The document specifies a sort ordering.
      */
     public function __construct(
         PackedArray|ResolvesToArray|BSONArray|array $input,
-        Document|Serializable|stdClass|array $sortBy,
+        Document|Serializable|stdClass|array|int $sortBy,
     ) {
         if (is_array($input) && ! array_is_list($input)) {
             throw new InvalidArgumentException('Expected $input argument to be a list, got an associative array.');

--- a/tests/Builder/Expression/ArrayElemAtOperatorTest.php
+++ b/tests/Builder/Expression/ArrayElemAtOperatorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $arrayElemAt expression
+ */
+class ArrayElemAtOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                name: 1,
+                first: Expression::arrayElemAt(
+                    array: Expression::arrayFieldPath('favorites'),
+                    idx: 0,
+                ),
+                last: Expression::arrayElemAt(
+                    array: Expression::arrayFieldPath('favorites'),
+                    idx: -1,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ArrayElemAtExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/ArrayToObjectOperatorTest.php
+++ b/tests/Builder/Expression/ArrayToObjectOperatorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $arrayToObject expression
+ */
+class ArrayToObjectOperatorTest extends PipelineTestCase
+{
+    public function testArrayToObjectExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                dimensions: Expression::arrayToObject(
+                    Expression::arrayFieldPath('dimensions'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ArrayToObjectArrayToObjectExample, $pipeline);
+    }
+
+    public function testObjectToArrayAndArrayToObjectExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                instock: Expression::objectToArray(
+                    Expression::objectFieldPath('instock'),
+                ),
+            ),
+            Stage::addFields(
+                instock: Expression::concatArrays(
+                    Expression::arrayFieldPath('instock'),
+                    [
+                        object(k: 'total', v: Expression::sum(
+                            Expression::fieldPath('instock.v'),
+                        )),
+                    ],
+                ),
+            ),
+            Stage::addFields(
+                instock: Expression::arrayToObject(
+                    Expression::arrayFieldPath('instock'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ArrayToObjectObjectToArrayAndArrayToObjectExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/ConcatArraysOperatorTest.php
+++ b/tests/Builder/Expression/ConcatArraysOperatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $concatArrays expression
+ */
+class ConcatArraysOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                items: Expression::concatArrays(
+                    Expression::arrayFieldPath('instock'),
+                    Expression::arrayFieldPath('ordered'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ConcatArraysExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/FilterOperatorTest.php
+++ b/tests/Builder/Expression/FilterOperatorTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $filter expression
+ */
+class FilterOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                items: Expression::filter(
+                    input: Expression::arrayFieldPath('items'),
+                    as: 'item',
+                    cond: Expression::gte(
+                        Expression::variable('item.price'),
+                        100,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::FilterExample, $pipeline);
+    }
+
+    public function testLimitAsANumericExpression(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                items: Expression::filter(
+                    input: Expression::arrayFieldPath('items'),
+                    cond: Expression::lte(
+                        Expression::variable('item.price'),
+                        150,
+                    ),
+                    as: 'item',
+                    limit: 2,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::FilterLimitAsANumericExpression, $pipeline);
+    }
+
+    public function testLimitGreaterThanPossibleMatches(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                items: Expression::filter(
+                    input: Expression::arrayFieldPath('items'),
+                    cond: Expression::gte(
+                        Expression::variable('item.price'),
+                        100,
+                    ),
+                    as: 'item',
+                    limit: 5,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::FilterLimitGreaterThanPossibleMatches, $pipeline);
+    }
+
+    public function testUsingTheLimitField(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                items: Expression::filter(
+                    input: Expression::arrayFieldPath('items'),
+                    cond: Expression::gte(
+                        Expression::variable('item.price'),
+                        100,
+                    ),
+                    as: 'item',
+                    limit: 1,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::FilterUsingTheLimitField, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/InOperatorTest.php
+++ b/tests/Builder/Expression/InOperatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $in expression
+ */
+class InOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                ...[
+                    'store location' => Expression::fieldPath('location'),
+                    'has bananas' => Expression::in(
+                        'bananas',
+                        Expression::arrayFieldPath('in_stock'),
+                    ),
+                ],
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::InExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/IndexOfArrayOperatorTest.php
+++ b/tests/Builder/Expression/IndexOfArrayOperatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $indexOfArray expression
+ */
+class IndexOfArrayOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                index: Expression::indexOfArray(
+                    array: Expression::arrayFieldPath('items'),
+                    search: 2,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::IndexOfArrayExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/IsArrayOperatorTest.php
+++ b/tests/Builder/Expression/IsArrayOperatorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $isArray expression
+ */
+class IsArrayOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                items: Expression::cond(
+                    if: Expression::and(
+                        Expression::isArray(Expression::fieldPath('instock')),
+                        Expression::isArray(Expression::fieldPath('ordered')),
+                    ),
+                    then: Expression::concatArrays(
+                        Expression::arrayFieldPath('instock'),
+                        Expression::arrayFieldPath('ordered'),
+                    ),
+                    else: 'One or more fields is not an array.',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::IsArrayExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/MapOperatorTest.php
+++ b/tests/Builder/Expression/MapOperatorTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $map expression
+ */
+class MapOperatorTest extends PipelineTestCase
+{
+    public function testAddToEachElementOfAnArray(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                adjustedGrades: Expression::map(
+                    input: Expression::arrayFieldPath('quizzes'),
+                    as: 'grade',
+                    in: [
+                        '$add' => [
+                            '$$grade',
+                            2,
+                        ],
+                    ],
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MapAddToEachElementOfAnArray, $pipeline);
+    }
+
+    public function testConvertCelsiusTemperaturesToFahrenheit(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                tempsF: Expression::map(
+                    input: Expression::arrayFieldPath('tempsC'),
+                    as: 'tempInCelsius',
+                    in: Expression::add(
+                        Expression::multiply(
+                            Expression::variable('tempInCelsius'),
+                            1.8,
+                        ),
+                        32,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MapConvertCelsiusTemperaturesToFahrenheit, $pipeline);
+    }
+
+    public function testTruncateEachArrayElement(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                city: Expression::stringFieldPath('city'),
+                integerValues: Expression::map(
+                    input: Expression::arrayFieldPath('distances'),
+                    as: 'decimalValue',
+                    in: Expression::trunc(
+                        Expression::variable('decimalValue'),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MapTruncateEachArrayElement, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/MaxNOperatorTest.php
+++ b/tests/Builder/Expression/MaxNOperatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $maxN expression
+ */
+class MaxNOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                maxScores: Expression::maxN(
+                    n: 2,
+                    input: Expression::arrayFieldPath('score'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MaxNExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/MinNOperatorTest.php
+++ b/tests/Builder/Expression/MinNOperatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $minN expression
+ */
+class MinNOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                minScores: Expression::minN(
+                    n: 2,
+                    input: Expression::arrayFieldPath('score'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MinNExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/ObjectToArrayOperatorTest.php
+++ b/tests/Builder/Expression/ObjectToArrayOperatorTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $objectToArray expression
+ */
+class ObjectToArrayOperatorTest extends PipelineTestCase
+{
+    public function testObjectToArrayExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                dimensions: Expression::objectToArray(
+                    Expression::fieldPath('dimensions'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ObjectToArrayObjectToArrayExample, $pipeline);
+    }
+
+    public function testObjectToArrayToSumNestedFields(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                warehouses: Expression::objectToArray(
+                    Expression::objectFieldPath('instock'),
+                ),
+            ),
+            Stage::unwind(
+                Expression::arrayFieldPath('warehouses'),
+            ),
+            Stage::group(
+                _id: Expression::fieldPath('warehouses.k'),
+                total: Accumulator::sum(
+                    Expression::fieldPath('warehouses.v'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ObjectToArrayObjectToArrayToSumNestedFields, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -391,10 +391,14 @@ enum Pipelines: string
                         "if": {
                             "$and": [
                                 {
-                                    "$isArray": "$instock"
+                                    "$isArray": [
+                                        "$instock"
+                                    ]
                                 },
                                 {
-                                    "$isArray": "$ordered"
+                                    "$isArray": [
+                                        "$ordered"
+                                    ]
                                 }
                             ]
                         },
@@ -967,7 +971,9 @@ enum Pipelines: string
                 "numberOfColors": {
                     "$cond": {
                         "if": {
-                            "$isArray": "$colors"
+                            "$isArray": [
+                                "$colors"
+                            ]
                         },
                         "then": {
                             "$size": "$colors"

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -58,6 +58,247 @@ enum Pipelines: string
     ]
     JSON;
 
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/arrayElemAt/#example
+     */
+    case ArrayElemAtExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "name": {
+                    "$numberInt": "1"
+                },
+                "first": {
+                    "$arrayElemAt": [
+                        "$favorites",
+                        {
+                            "$numberInt": "0"
+                        }
+                    ]
+                },
+                "last": {
+                    "$arrayElemAt": [
+                        "$favorites",
+                        {
+                            "$numberInt": "-1"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * $arrayToObject Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/arrayToObject/#-arraytoobject--example
+     */
+    case ArrayToObjectArrayToObjectExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "dimensions": {
+                    "$arrayToObject": [
+                        "$dimensions"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * $objectToArray and $arrayToObject Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/arrayToObject/#-objecttoarray----arraytoobject-example
+     */
+    case ArrayToObjectObjectToArrayAndArrayToObjectExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "instock": {
+                    "$objectToArray": "$instock"
+                }
+            }
+        },
+        {
+            "$addFields": {
+                "instock": {
+                    "$concatArrays": [
+                        "$instock",
+                        [
+                            {
+                                "k": "total",
+                                "v": {
+                                    "$sum": [
+                                        "$instock.v"
+                                    ]
+                                }
+                            }
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "$addFields": {
+                "instock": {
+                    "$arrayToObject": [
+                        "$instock"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/concatArrays/#example
+     */
+    case ConcatArraysExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "items": {
+                    "$concatArrays": [
+                        "$instock",
+                        "$ordered"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/filter/#examples
+     */
+    case FilterExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "items": {
+                    "$filter": {
+                        "input": "$items",
+                        "as": "item",
+                        "cond": {
+                            "$gte": [
+                                "$$item.price",
+                                {
+                                    "$numberInt": "100"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Using the limit field
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/filter/#using-the-limit-field
+     */
+    case FilterUsingTheLimitField = <<<'JSON'
+    [
+        {
+            "$project": {
+                "items": {
+                    "$filter": {
+                        "input": "$items",
+                        "cond": {
+                            "$gte": [
+                                "$$item.price",
+                                {
+                                    "$numberInt": "100"
+                                }
+                            ]
+                        },
+                        "as": "item",
+                        "limit": {
+                            "$numberInt": "1"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * limit as a Numeric Expression
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/filter/#limit-as-a-numeric-expression
+     */
+    case FilterLimitAsANumericExpression = <<<'JSON'
+    [
+        {
+            "$project": {
+                "items": {
+                    "$filter": {
+                        "input": "$items",
+                        "cond": {
+                            "$lte": [
+                                "$$item.price",
+                                {
+                                    "$numberInt": "150"
+                                }
+                            ]
+                        },
+                        "as": "item",
+                        "limit": {
+                            "$numberInt": "2"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * limit Greater than Possible Matches
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/filter/#limit-greater-than-possible-matches
+     */
+    case FilterLimitGreaterThanPossibleMatches = <<<'JSON'
+    [
+        {
+            "$project": {
+                "items": {
+                    "$filter": {
+                        "input": "$items",
+                        "cond": {
+                            "$gte": [
+                                "$$item.price",
+                                {
+                                    "$numberInt": "100"
+                                }
+                            ]
+                        },
+                        "as": "item",
+                        "limit": {
+                            "$numberInt": "5"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
     /** Use in $addFields Stage */
     case FirstUseInAddFieldsStage = <<<'JSON'
     [
@@ -86,6 +327,84 @@ enum Pipelines: string
                             "$numberInt": "3"
                         },
                         "input": "$score"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/in/#example
+     */
+    case InExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "store location": "$location",
+                "has bananas": {
+                    "$in": [
+                        "bananas",
+                        "$in_stock"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/indexOfArray/#example
+     */
+    case IndexOfArrayExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "index": {
+                    "$indexOfArray": [
+                        "$items",
+                        {
+                            "$numberInt": "2"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/isArray/#example
+     */
+    case IsArrayExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "items": {
+                    "$cond": {
+                        "if": {
+                            "$and": [
+                                {
+                                    "$isArray": "$instock"
+                                },
+                                {
+                                    "$isArray": "$ordered"
+                                }
+                            ]
+                        },
+                        "then": {
+                            "$concatArrays": [
+                                "$instock",
+                                "$ordered"
+                            ]
+                        },
+                        "else": "One or more fields is not an array."
                     }
                 }
             }
@@ -171,6 +490,117 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Add to Each Element of an Array
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/map/#add-to-each-element-of-an-array
+     */
+    case MapAddToEachElementOfAnArray = <<<'JSON'
+    [
+        {
+            "$project": {
+                "adjustedGrades": {
+                    "$map": {
+                        "input": "$quizzes",
+                        "as": "grade",
+                        "in": {
+                            "$add": [
+                                "$$grade",
+                                {
+                                    "$numberInt": "2"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Truncate Each Array Element
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/map/#truncate-each-array-element
+     */
+    case MapTruncateEachArrayElement = <<<'JSON'
+    [
+        {
+            "$project": {
+                "city": "$city",
+                "integerValues": {
+                    "$map": {
+                        "input": "$distances",
+                        "as": "decimalValue",
+                        "in": {
+                            "$trunc": [
+                                "$$decimalValue"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Convert Celsius Temperatures to Fahrenheit
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/map/#convert-celsius-temperatures-to-fahrenheit
+     */
+    case MapConvertCelsiusTemperaturesToFahrenheit = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "tempsF": {
+                    "$map": {
+                        "input": "$tempsC",
+                        "as": "tempInCelsius",
+                        "in": {
+                            "$add": [
+                                {
+                                    "$multiply": [
+                                        "$$tempInCelsius",
+                                        {
+                                            "$numberDouble": "1.8000000000000000444"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "$numberInt": "32"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/maxN-array-element/#example
+     */
+    case MaxNExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "maxScores": {
+                    "$maxN": {
+                        "n": {
+                            "$numberInt": "2"
+                        },
+                        "input": "$score"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * $mergeObjects
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/mergeObjects/#-mergeobjects
@@ -206,6 +636,559 @@ enum Pipelines: string
             "$project": {
                 "fromItems": {
                     "$numberInt": "0"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/minN-array-element/#example
+     */
+    case MinNExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "minScores": {
+                    "$minN": {
+                        "n": {
+                            "$numberInt": "2"
+                        },
+                        "input": "$score"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * $objectToArray Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/objectToArray/#-objecttoarray-example
+     */
+    case ObjectToArrayObjectToArrayExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "dimensions": {
+                    "$objectToArray": "$dimensions"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * $objectToArray to Sum Nested Fields
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/objectToArray/#-objecttoarray-to-sum-nested-fields
+     */
+    case ObjectToArrayObjectToArrayToSumNestedFields = <<<'JSON'
+    [
+        {
+            "$project": {
+                "warehouses": {
+                    "$objectToArray": "$instock"
+                }
+            }
+        },
+        {
+            "$unwind": {
+                "path": "$warehouses"
+            }
+        },
+        {
+            "$group": {
+                "_id": "$warehouses.k",
+                "total": {
+                    "$sum": "$warehouses.v"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/range/#example
+     */
+    case RangeExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "city": {
+                    "$numberInt": "1"
+                },
+                "Rest stops": {
+                    "$range": [
+                        {
+                            "$numberInt": "0"
+                        },
+                        "$distance",
+                        {
+                            "$numberInt": "25"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Multiplication
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/reduce/#multiplication
+     */
+    case ReduceMultiplication = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": "$experimentId",
+                "probabilityArr": {
+                    "$push": "$probability"
+                }
+            }
+        },
+        {
+            "$project": {
+                "description": {
+                    "$numberInt": "1"
+                },
+                "results": {
+                    "$reduce": {
+                        "input": "$probabilityArr",
+                        "initialValue": {
+                            "$numberInt": "1"
+                        },
+                        "in": {
+                            "$multiply": [
+                                "$$value",
+                                "$$this"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Discounted Merchandise
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/reduce/#discounted-merchandise
+     */
+    case ReduceDiscountedMerchandise = <<<'JSON'
+    [
+        {
+            "$project": {
+                "discountedPrice": {
+                    "$reduce": {
+                        "input": "$discounts",
+                        "initialValue": "$price",
+                        "in": {
+                            "$multiply": [
+                                "$$value",
+                                {
+                                    "$subtract": [
+                                        {
+                                            "$numberInt": "1"
+                                        },
+                                        "$$this"
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * String Concatenation
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/reduce/#string-concatenation
+     */
+    case ReduceStringConcatenation = <<<'JSON'
+    [
+        {
+            "$match": {
+                "hobbies": {
+                    "$gt": []
+                }
+            }
+        },
+        {
+            "$project": {
+                "name": {
+                    "$numberInt": "1"
+                },
+                "bio": {
+                    "$reduce": {
+                        "input": "$hobbies",
+                        "initialValue": "My hobbies include:",
+                        "in": {
+                            "$concat": [
+                                "$$value",
+                                {
+                                    "$cond": {
+                                        "if": {
+                                            "$eq": [
+                                                "$$value",
+                                                "My hobbies include:"
+                                            ]
+                                        },
+                                        "then": " ",
+                                        "else": ", "
+                                    }
+                                },
+                                "$$this"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Array Concatenation
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/reduce/#array-concatenation
+     */
+    case ReduceArrayConcatenation = <<<'JSON'
+    [
+        {
+            "$project": {
+                "collapsed": {
+                    "$reduce": {
+                        "input": "$arr",
+                        "initialValue": [],
+                        "in": {
+                            "$concatArrays": [
+                                "$$value",
+                                "$$this"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Computing a Multiple Reductions
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/reduce/#computing-a-multiple-reductions
+     */
+    case ReduceComputingAMultipleReductions = <<<'JSON'
+    [
+        {
+            "$project": {
+                "results": {
+                    "$reduce": {
+                        "input": "$arr",
+                        "initialValue": [],
+                        "in": {
+                            "collapsed": {
+                                "$concatArrays": [
+                                    "$$value.collapsed",
+                                    "$$this"
+                                ]
+                            },
+                            "firstValues": {
+                                "$concatArrays": [
+                                    "$$value.firstValues",
+                                    {
+                                        "$slice": [
+                                            "$$this",
+                                            {
+                                                "$numberInt": "1"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/reverseArray/#example
+     */
+    case ReverseArrayExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "name": {
+                    "$numberInt": "1"
+                },
+                "reverseFavorites": {
+                    "$reverseArray": "$favorites"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/size/#example
+     */
+    case SizeExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "numberOfColors": {
+                    "$cond": {
+                        "if": {
+                            "$isArray": "$colors"
+                        },
+                        "then": {
+                            "$size": "$colors"
+                        },
+                        "else": "NA"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/slice/#example
+     */
+    case SliceExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "name": {
+                    "$numberInt": "1"
+                },
+                "threeFavorites": {
+                    "$slice": [
+                        "$favorites",
+                        {
+                            "$numberInt": "3"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Sort on a Field
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sortArray/#sort-on-a-field
+     */
+    case SortArraySortOnAField = <<<'JSON'
+    [
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "result": {
+                    "$sortArray": {
+                        "input": "$team",
+                        "sortBy": {
+                            "name": {
+                                "$numberInt": "1"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Sort on a Subfield
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sortArray/#sort-on-a-subfield
+     */
+    case SortArraySortOnASubfield = <<<'JSON'
+    [
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "result": {
+                    "$sortArray": {
+                        "input": "$team",
+                        "sortBy": {
+                            "address.city": {
+                                "$numberInt": "-1"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Sort on Multiple Fields
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sortArray/#sort-on-multiple-fields
+     */
+    case SortArraySortOnMultipleFields = <<<'JSON'
+    [
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "result": {
+                    "$sortArray": {
+                        "input": "$team",
+                        "sortBy": {
+                            "age": {
+                                "$numberInt": "-1"
+                            },
+                            "name": {
+                                "$numberInt": "1"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Sort an Array of Integers
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sortArray/#sort-an-array-of-integers
+     */
+    case SortArraySortAnArrayOfIntegers = <<<'JSON'
+    [
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "result": {
+                    "$sortArray": {
+                        "input": [
+                            {
+                                "$numberInt": "1"
+                            },
+                            {
+                                "$numberInt": "4"
+                            },
+                            {
+                                "$numberInt": "1"
+                            },
+                            {
+                                "$numberInt": "6"
+                            },
+                            {
+                                "$numberInt": "12"
+                            },
+                            {
+                                "$numberInt": "5"
+                            }
+                        ],
+                        "sortBy": {
+                            "$numberInt": "1"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Sort on Mixed Type Fields
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sortArray/#sort-on-mixed-type-fields
+     */
+    case SortArraySortOnMixedTypeFields = <<<'JSON'
+    [
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "result": {
+                    "$sortArray": {
+                        "input": [
+                            {
+                                "$numberInt": "20"
+                            },
+                            {
+                                "$numberInt": "4"
+                            },
+                            {
+                                "a": "Free"
+                            },
+                            {
+                                "$numberInt": "6"
+                            },
+                            {
+                                "$numberInt": "21"
+                            },
+                            {
+                                "$numberInt": "5"
+                            },
+                            "Gratis",
+                            {
+                                "a": null
+                            },
+                            {
+                                "a": {
+                                    "sale": true,
+                                    "price": {
+                                        "$numberInt": "19"
+                                    }
+                                }
+                            },
+                            {
+                                "$numberDouble": "10.230000000000000426"
+                            },
+                            {
+                                "a": "On sale"
+                            }
+                        ],
+                        "sortBy": {
+                            "$numberInt": "1"
+                        }
+                    }
                 }
             }
         }

--- a/tests/Builder/Expression/RangeOperatorTest.php
+++ b/tests/Builder/Expression/RangeOperatorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $range expression
+ */
+class RangeOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                // fields order doesn't matter, array unpacking must be before named arguments
+                ...[
+                    'Rest stops' => Expression::range(
+                        0,
+                        Expression::intFieldPath('distance'),
+                        25,
+                    ),
+                ],
+                _id: 0,
+                city: 1,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::RangeExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/ReduceOperatorTest.php
+++ b/tests/Builder/Expression/ReduceOperatorTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $reduce expression
+ */
+class ReduceOperatorTest extends PipelineTestCase
+{
+    public function testArrayConcatenation(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                collapsed: Expression::reduce(
+                    input: Expression::arrayFieldPath('arr'),
+                    initialValue: [],
+                    in: Expression::concatArrays(
+                        Expression::variable('value'),
+                        Expression::variable('this'),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ReduceArrayConcatenation, $pipeline);
+    }
+
+    public function testComputingAMultipleReductions(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                results: Expression::reduce(
+                    Expression::arrayFieldPath('arr'),
+                    [],
+                    object(
+                        collapsed: Expression::concatArrays(
+                            Expression::variable('value.collapsed'),
+                            Expression::variable('this'),
+                        ),
+                        firstValues: Expression::concatArrays(
+                            Expression::variable('value.firstValues'),
+                            Expression::slice(
+                                Expression::variable('this'),
+                                1,
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ReduceComputingAMultipleReductions, $pipeline);
+    }
+
+    public function testDiscountedMerchandise(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                discountedPrice: Expression::reduce(
+                    input: Expression::arrayFieldPath('discounts'),
+                    initialValue: Expression::numberFieldPath('price'),
+                    in: Expression::multiply(
+                        Expression::variable('value'),
+                        Expression::subtract(
+                            1,
+                            Expression::variable('this'),
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ReduceDiscountedMerchandise, $pipeline);
+    }
+
+    public function testMultiplication(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: Expression::objectIdFieldPath('experimentId'),
+                probabilityArr: Accumulator::push(
+                    Expression::fieldPath('probability'),
+                ),
+            ),
+            Stage::project(
+                description: 1,
+                results: Expression::reduce(
+                    input: Expression::arrayFieldPath('probabilityArr'),
+                    initialValue: 1,
+                    in: Expression::multiply(
+                        Expression::variable('value'),
+                        Expression::variable('this'),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ReduceMultiplication, $pipeline);
+    }
+
+    public function testStringConcatenation(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                hobbies: Query::gt([]),
+            ),
+            Stage::project(
+                name: 1,
+                bio: Expression::reduce(
+                    input: Expression::arrayFieldPath('hobbies'),
+                    initialValue: 'My hobbies include:',
+                    in: Expression::concat(
+                        Expression::variable('value'),
+                        Expression::cond(
+                            if: Expression::eq(
+                                Expression::variable('value'),
+                                'My hobbies include:',
+                            ),
+                            then: ' ',
+                            else: ', ',
+                        ),
+                        Expression::variable('this'),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ReduceStringConcatenation, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/ReverseArrayOperatorTest.php
+++ b/tests/Builder/Expression/ReverseArrayOperatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $reverseArray expression
+ */
+class ReverseArrayOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                name: 1,
+                reverseFavorites: Expression::reverseArray(
+                    Expression::arrayFieldPath('favorites'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ReverseArrayExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/SizeOperatorTest.php
+++ b/tests/Builder/Expression/SizeOperatorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $size expression
+ */
+class SizeOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                numberOfColors: Expression::cond(
+                    if: Expression::isArray(
+                        Expression::fieldPath('colors'),
+                    ),
+                    then: Expression::size(
+                        Expression::arrayFieldPath('colors'),
+                    ),
+                    else: 'NA',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SizeExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/SliceOperatorTest.php
+++ b/tests/Builder/Expression/SliceOperatorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $slice expression
+ */
+class SliceOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                name: 1,
+                threeFavorites: Expression::slice(
+                    Expression::arrayFieldPath('favorites'),
+                    n: 3,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SliceExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/SortArrayOperatorTest.php
+++ b/tests/Builder/Expression/SortArrayOperatorTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $sortArray expression
+ */
+class SortArrayOperatorTest extends PipelineTestCase
+{
+    public function testSortAnArrayOfIntegers(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                _id: 0,
+                result: Expression::sortArray(
+                    input: [1, 4, 1, 6, 12, 5],
+                    sortBy: 1,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SortArraySortAnArrayOfIntegers, $pipeline);
+    }
+
+    public function testSortOnAField(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                _id: 0,
+                result: Expression::sortArray(
+                    input: Expression::arrayFieldPath('team'),
+                    // @todo This object should be typed as "sort spec"
+                    sortBy: object(
+                        name: 1,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SortArraySortOnAField, $pipeline);
+    }
+
+    public function testSortOnASubfield(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                _id: 0,
+                result: Expression::sortArray(
+                    input: Expression::arrayFieldPath('team'),
+                    // @todo This array should be typed as "sort spec"
+                    sortBy: [
+                        'address.city' => -1,
+                    ],
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SortArraySortOnASubfield, $pipeline);
+    }
+
+    public function testSortOnMixedTypeFields(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                _id: 0,
+                result: Expression::sortArray(
+                    input: [
+                        20,
+                        4,
+                        object(a: 'Free'),
+                        6,
+                        21,
+                        5,
+                        'Gratis',
+                        ['a' => null],
+                        object(a: object(sale: true, price: 19)),
+                        10.23,
+                        ['a' => 'On sale'],
+                    ],
+                    sortBy: 1,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SortArraySortOnMixedTypeFields, $pipeline);
+    }
+
+    public function testSortOnMultipleFields(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                _id: 0,
+                result: Expression::sortArray(
+                    input: Expression::arrayFieldPath('team'),
+                    // @todo This array should be typed as "sort spec"
+                    sortBy: object(
+                        age: -1,
+                        name: 1,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SortArraySortOnMultipleFields, $pipeline);
+    }
+}


### PR DESCRIPTION
Fix [PHPLIB-1343](https://jira.mongodb.org/browse/PHPLIB-1343)

- `$arrayElemAt`
- `$arrayToObject`
- `$concatArrays`
- `$filter`
- ~`$firstN`~ (already done)
- `$in`
- `$indexOfArray`
- `$isArray`
- ~`$lastN`~ (already done)
- `$map`
- `$maxN`
- `$minN`
- `$objectToArray` (skipped duplicate example with `$arrayToObject`)
- `$range`
- `$reduce`
- `$reverseArray`
- `$size`
- `$slice`
- `$sortArray`
- ~`$zip`~ (already done)