### PR TITLE
PHPLIB-1335 Add tests on Element Query Operators

### DIFF
--- a/generator/config/query/exists.yaml
+++ b/generator/config/query/exists.yaml
@@ -11,3 +11,21 @@ arguments:
         name: exists
         type:
             - bool
+tests:
+    -
+        name: 'Exists and Not Equal To'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/exists/#exists-and-not-equal-to'
+        pipeline:
+            -
+                $match:
+                    qty:
+                        $exists: true
+                        $nin: [5, 15]
+    -
+        name: 'Null Values'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/exists/#null-values'
+        pipeline:
+            -
+                $match:
+                    qty:
+                        $exists: true

--- a/generator/config/query/type.yaml
+++ b/generator/config/query/type.yaml
@@ -13,3 +13,60 @@ arguments:
             - int
             - string
             - array # of int or string
+tests:
+    -
+        name: 'Querying by Data Type'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/type/#querying-by-data-type'
+        pipeline:
+            -
+                $match:
+                    zipCode:
+                        $type: 2
+            -
+                $match:
+                    zipCode:
+                        $type: 'string'
+            -
+                $match:
+                    zipCode:
+                        $type: 1
+            -
+                $match:
+                    zipCode:
+                        $type: 'double'
+            -
+                $match:
+                    zipCode:
+                        $type: 'number'
+    -
+        name: 'Querying by Multiple Data Type'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/type/#querying-by-multiple-data-type'
+        pipeline:
+            -
+                $match:
+                    zipCode:
+                        $type: [2, 1]
+            -
+                $match:
+                    zipCode:
+                        $type: ['string', 'double']
+    -
+        name: 'Querying by MinKey and MaxKey'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/type/#querying-by-minkey-and-maxkey'
+        pipeline:
+            -
+                $match:
+                    zipCode:
+                        $type: 'minKey'
+            -
+                $match:
+                    zipCode:
+                        $type: 'maxKey'
+    -
+        name: 'Querying by Array Type'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/type/#querying-by-array-type'
+        pipeline:
+            -
+                $match:
+                    zipCode:
+                        $type: 'array'

--- a/generator/config/query/type.yaml
+++ b/generator/config/query/type.yaml
@@ -12,7 +12,7 @@ arguments:
         type:
             - int
             - string
-            - array # of int or string
+        variadic: array
 tests:
     -
         name: 'Querying by Data Type'
@@ -21,23 +21,33 @@ tests:
             -
                 $match:
                     zipCode:
-                        $type: 2
+                        # Example uses the short form, the builder always generated the verbose form
+                        # $type: 2
+                        $type: [2]
             -
                 $match:
                     zipCode:
-                        $type: 'string'
+                        # Example uses the short form, the builder always generated the verbose form
+                        # $type: 'string'
+                        $type: ['string']
             -
                 $match:
                     zipCode:
-                        $type: 1
+                        # Example uses the short form, the builder always generated the verbose form
+                        # $type: 1
+                        $type: [1]
             -
                 $match:
                     zipCode:
-                        $type: 'double'
+                        # Example uses the short form, the builder always generated the verbose form
+                        # $type: 'double'
+                        $type: ['double']
             -
                 $match:
                     zipCode:
-                        $type: 'number'
+                        # Example uses the short form, the builder always generated the verbose form
+                        # $type: 'number'
+                        $type: ['number']
     -
         name: 'Querying by Multiple Data Type'
         link: 'https://www.mongodb.com/docs/manual/reference/operator/query/type/#querying-by-multiple-data-type'
@@ -57,11 +67,15 @@ tests:
             -
                 $match:
                     zipCode:
-                        $type: 'minKey'
+                        # Example uses the short form, the builder always generated the verbose form
+                        # $type: 'minKey'
+                        $type: ['minKey']
             -
                 $match:
                     zipCode:
-                        $type: 'maxKey'
+                        # Example uses the short form, the builder always generated the verbose form
+                        # $type: 'maxKey'
+                        $type: ['maxKey']
     -
         name: 'Querying by Array Type'
         link: 'https://www.mongodb.com/docs/manual/reference/operator/query/type/#querying-by-array-type'
@@ -69,4 +83,6 @@ tests:
             -
                 $match:
                     zipCode:
-                        $type: 'array'
+                        # Example uses the short form, the builder always generated the verbose form
+                        # $type: 'array'
+                        $type: ['array']

--- a/src/Builder/Query/FactoryTrait.php
+++ b/src/Builder/Query/FactoryTrait.php
@@ -509,11 +509,12 @@ trait FactoryTrait
      * Selects documents if a field is of the specified type.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/type/
-     * @param BSONArray|PackedArray|array|int|non-empty-string $type
+     * @no-named-arguments
+     * @param int|non-empty-string ...$type
      */
-    public static function type(PackedArray|BSONArray|array|int|string $type): TypeOperator
+    public static function type(int|string ...$type): TypeOperator
     {
-        return new TypeOperator($type);
+        return new TypeOperator(...$type);
     }
 
     /**

--- a/src/Builder/Query/TypeOperator.php
+++ b/src/Builder/Query/TypeOperator.php
@@ -8,15 +8,12 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Query;
 
-use MongoDB\BSON\PackedArray;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\FieldQueryInterface;
 use MongoDB\Builder\Type\OperatorInterface;
 use MongoDB\Exception\InvalidArgumentException;
-use MongoDB\Model\BSONArray;
 
 use function array_is_list;
-use function is_array;
 
 /**
  * Selects documents if a field is of the specified type.
@@ -27,16 +24,21 @@ class TypeOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 
-    /** @var BSONArray|PackedArray|array|int|non-empty-string $type */
-    public readonly PackedArray|BSONArray|array|int|string $type;
+    /** @var list<int|non-empty-string> $type */
+    public readonly array $type;
 
     /**
-     * @param BSONArray|PackedArray|array|int|non-empty-string $type
+     * @param int|non-empty-string ...$type
+     * @no-named-arguments
      */
-    public function __construct(PackedArray|BSONArray|array|int|string $type)
+    public function __construct(int|string ...$type)
     {
-        if (is_array($type) && ! array_is_list($type)) {
-            throw new InvalidArgumentException('Expected $type argument to be a list, got an associative array.');
+        if (\count($type) < 1) {
+            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $type, got %d.', 1, \count($type)));
+        }
+
+        if (! array_is_list($type)) {
+            throw new InvalidArgumentException('Expected $type arguments to be a list (array), named arguments are not supported');
         }
 
         $this->type = $type;

--- a/tests/Builder/Query/ExistsOperatorTest.php
+++ b/tests/Builder/Query/ExistsOperatorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $exists query
+ */
+class ExistsOperatorTest extends PipelineTestCase
+{
+    public function testExistsAndNotEqualTo(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                qty: [
+                    Query::exists(true),
+                    Query::nin([5, 15]),
+                ],
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ExistsExistsAndNotEqualTo, $pipeline);
+    }
+
+    public function testNullValues(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                qty: [
+                    Query::exists(true),
+                ],
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ExistsNullValues, $pipeline);
+    }
+}

--- a/tests/Builder/Query/Pipelines.php
+++ b/tests/Builder/Query/Pipelines.php
@@ -360,6 +360,48 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Exists and Not Equal To
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/exists/#exists-and-not-equal-to
+     */
+    case ExistsExistsAndNotEqualTo = <<<'JSON'
+    [
+        {
+            "$match": {
+                "qty": {
+                    "$exists": true,
+                    "$nin": [
+                        {
+                            "$numberInt": "5"
+                        },
+                        {
+                            "$numberInt": "15"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Null Values
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/exists/#null-values
+     */
+    case ExistsNullValues = <<<'JSON'
+    [
+        {
+            "$match": {
+                "qty": {
+                    "$exists": true
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Compare Two Fields from A Single Document
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/expr/#compare-two-fields-from-a-single-document
@@ -1119,6 +1161,130 @@ enum Pipelines: string
         {
             "$limit": {
                 "$numberInt": "5"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Querying by Data Type
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/type/#querying-by-data-type
+     */
+    case TypeQueryingByDataType = <<<'JSON'
+    [
+        {
+            "$match": {
+                "zipCode": {
+                    "$type": {
+                        "$numberInt": "2"
+                    }
+                }
+            }
+        },
+        {
+            "$match": {
+                "zipCode": {
+                    "$type": "string"
+                }
+            }
+        },
+        {
+            "$match": {
+                "zipCode": {
+                    "$type": {
+                        "$numberInt": "1"
+                    }
+                }
+            }
+        },
+        {
+            "$match": {
+                "zipCode": {
+                    "$type": "double"
+                }
+            }
+        },
+        {
+            "$match": {
+                "zipCode": {
+                    "$type": "number"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Querying by Multiple Data Type
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/type/#querying-by-multiple-data-type
+     */
+    case TypeQueryingByMultipleDataType = <<<'JSON'
+    [
+        {
+            "$match": {
+                "zipCode": {
+                    "$type": [
+                        {
+                            "$numberInt": "2"
+                        },
+                        {
+                            "$numberInt": "1"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "$match": {
+                "zipCode": {
+                    "$type": [
+                        "string",
+                        "double"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Querying by MinKey and MaxKey
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/type/#querying-by-minkey-and-maxkey
+     */
+    case TypeQueryingByMinKeyAndMaxKey = <<<'JSON'
+    [
+        {
+            "$match": {
+                "zipCode": {
+                    "$type": "minKey"
+                }
+            }
+        },
+        {
+            "$match": {
+                "zipCode": {
+                    "$type": "maxKey"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Querying by Array Type
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/type/#querying-by-array-type
+     */
+    case TypeQueryingByArrayType = <<<'JSON'
+    [
+        {
+            "$match": {
+                "zipCode": {
+                    "$type": "array"
+                }
             }
         }
     ]

--- a/tests/Builder/Query/Pipelines.php
+++ b/tests/Builder/Query/Pipelines.php
@@ -1176,39 +1176,49 @@ enum Pipelines: string
         {
             "$match": {
                 "zipCode": {
-                    "$type": {
-                        "$numberInt": "2"
-                    }
+                    "$type": [
+                        {
+                            "$numberInt": "2"
+                        }
+                    ]
                 }
             }
         },
         {
             "$match": {
                 "zipCode": {
-                    "$type": "string"
+                    "$type": [
+                        "string"
+                    ]
                 }
             }
         },
         {
             "$match": {
                 "zipCode": {
-                    "$type": {
-                        "$numberInt": "1"
-                    }
+                    "$type": [
+                        {
+                            "$numberInt": "1"
+                        }
+                    ]
                 }
             }
         },
         {
             "$match": {
                 "zipCode": {
-                    "$type": "double"
+                    "$type": [
+                        "double"
+                    ]
                 }
             }
         },
         {
             "$match": {
                 "zipCode": {
-                    "$type": "number"
+                    "$type": [
+                        "number"
+                    ]
                 }
             }
         }
@@ -1259,14 +1269,18 @@ enum Pipelines: string
         {
             "$match": {
                 "zipCode": {
-                    "$type": "minKey"
+                    "$type": [
+                        "minKey"
+                    ]
                 }
             }
         },
         {
             "$match": {
                 "zipCode": {
-                    "$type": "maxKey"
+                    "$type": [
+                        "maxKey"
+                    ]
                 }
             }
         }
@@ -1283,7 +1297,9 @@ enum Pipelines: string
         {
             "$match": {
                 "zipCode": {
-                    "$type": "array"
+                    "$type": [
+                        "array"
+                    ]
                 }
             }
         }

--- a/tests/Builder/Query/TypeOperatorTest.php
+++ b/tests/Builder/Query/TypeOperatorTest.php
@@ -66,10 +66,10 @@ class TypeOperatorTest extends PipelineTestCase
     {
         $pipeline = new Pipeline(
             Stage::match(
-                zipCode: Query::type([2, 1]),
+                zipCode: Query::type(2, 1),
             ),
             Stage::match(
-                zipCode: Query::type(['string', 'double']),
+                zipCode: Query::type('string', 'double'),
             ),
         );
 

--- a/tests/Builder/Query/TypeOperatorTest.php
+++ b/tests/Builder/Query/TypeOperatorTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $type query
+ */
+class TypeOperatorTest extends PipelineTestCase
+{
+    public function testQueryingByArrayType(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                zipCode: Query::type('array'),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TypeQueryingByArrayType, $pipeline);
+    }
+
+    public function testQueryingByDataType(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                zipCode: Query::type(2),
+            ),
+            Stage::match(
+                zipCode: Query::type('string'),
+            ),
+            Stage::match(
+                zipCode: Query::type(1),
+            ),
+            Stage::match(
+                zipCode: Query::type('double'),
+            ),
+            Stage::match(
+                zipCode: Query::type('number'),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TypeQueryingByDataType, $pipeline);
+    }
+
+    public function testQueryingByMinKeyAndMaxKey(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                zipCode: Query::type('minKey'),
+            ),
+            Stage::match(
+                zipCode: Query::type('maxKey'),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TypeQueryingByMinKeyAndMaxKey, $pipeline);
+    }
+
+    public function testQueryingByMultipleDataType(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                zipCode: Query::type([2, 1]),
+            ),
+            Stage::match(
+                zipCode: Query::type(['string', 'double']),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TypeQueryingByMultipleDataType, $pipeline);
+    }
+}


### PR DESCRIPTION
Fix [PHPLIB-1335](https://jira.mongodb.org/browse/PHPLIB-1335)

https://www.mongodb.com/docs/manual/reference/operator/query/#element

- `$exists` (skipped the last redundant test)
- `$type`
