### PR TITLE
PHPLIB-1336 Add tests on Evaluation Query Operators

### DIFF
--- a/generator/config/query/jsonSchema.yaml
+++ b/generator/config/query/jsonSchema.yaml
@@ -11,3 +11,29 @@ arguments:
         name: schema
         type:
             - object
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/jsonSchema/#syntax'
+        pipeline:
+            -
+                $match:
+                    $jsonSchema:
+                        required:
+                            - 'name'
+                            - 'major'
+                            - 'gpa'
+                            - 'address'
+                        properties:
+                            name:
+                                bsonType: 'string'
+                                description: 'must be a string and is required'
+                            address:
+                                bsonType: 'object'
+                                required:
+                                    - 'zipcode'
+                                properties:
+                                    street:
+                                        bsonType: 'string'
+                                    zipcode:
+                                        bsonType: 'string'

--- a/generator/config/query/mod.yaml
+++ b/generator/config/query/mod.yaml
@@ -10,8 +10,33 @@ arguments:
     -
         name: divisor
         type:
-            - int
+            - number
     -
         name: remainder
         type:
-            - int
+            - number
+tests:
+    -
+        name: 'Use $mod to Select Documents'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/mod/#use--mod-to-select-documents'
+        pipeline:
+            -
+                $match:
+                    qty:
+                        $mod: [4, 0]
+    -
+        name: 'Floating Point Arguments'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/mod/#floating-point-arguments'
+        pipeline:
+            -
+                $match:
+                    qty:
+                        $mod: [4.0, 0]
+            -
+                $match:
+                    qty:
+                        $mod: [4.5, 0]
+            -
+                $match:
+                    qty:
+                        $mod: [4.99, 0]

--- a/generator/config/query/text.yaml
+++ b/generator/config/query/text.yaml
@@ -3,7 +3,7 @@ name: $text
 link: 'https://www.mongodb.com/docs/manual/reference/operator/query/text/'
 type:
     - query
-encode: object
+encode: dollar_object
 description: |
     Performs text search.
 arguments:
@@ -36,3 +36,77 @@ arguments:
         description: |
             A boolean flag to enable or disable diacritic sensitive search against version 3 text indexes. Defaults to false; i.e. the search defers to the diacritic insensitivity of the text index.
             Text searches against earlier versions of the text index are inherently diacritic sensitive and cannot be diacritic insensitive. As such, the $diacriticSensitive option has no effect with earlier versions of the text index.
+tests:
+    -
+        name: 'Search for a Single Word'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/text/#search-for-a-single-word'
+        pipeline:
+            -
+                $match:
+                    $text:
+                        $search: 'coffee'
+    -
+        name: 'Match Any of the Search Terms'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/text/#search-for-a-single-word'
+        pipeline:
+            -
+                $match:
+                    $text:
+                        $search: 'bake coffee cake'
+    -
+        name: 'Search a Different Language'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/text/#search-a-different-language'
+        pipeline:
+            -
+                $match:
+                    $text:
+                        $search: 'leche'
+                        $language: 'es'
+    -
+        name: 'Case and Diacritic Insensitive Search'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/text/#case-and-diacritic-insensitive-search'
+        pipeline:
+            -
+                $match:
+                    $text:
+                        $search: 'сы́рники CAFÉS'
+    -
+        name: 'Perform Case Sensitive Search'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/text/#perform-case-sensitive-search'
+        pipeline:
+            -
+                $match:
+                    $text:
+                        $search: 'Coffee'
+                        $caseSensitive: true
+            -
+                $match:
+                    $text:
+                        $search: '\"Café Con Leche\"'
+                        $caseSensitive: true
+    -
+        name: 'Diacritic Sensitive Search'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/text/#perform-case-sensitive-search'
+        pipeline:
+            -
+                $match:
+                    $text:
+                        $search: 'CAFÉ'
+                        $diacriticSensitive: true
+    -
+        name: 'Text Search Score Examples'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/text/#perform-case-sensitive-search'
+        pipeline:
+            -
+                $match:
+                    $text:
+                        $search: 'CAFÉ'
+                        $diacriticSensitive: true
+                    score:
+                        $meta: 'textScore'
+            -
+                $sort:
+                    score:
+                        $meta: 'textScore'
+            -
+                $limit: 5

--- a/generator/config/query/where.yaml
+++ b/generator/config/query/where.yaml
@@ -11,3 +11,21 @@ arguments:
         name: function
         type:
             - javascript
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/where/#example'
+        pipeline:
+            -
+                $match:
+                    $where: 'function() { return hex_md5(this.name) == "9b53e667f30cd329dca1ec9e6a83e994" }'
+            -
+                $match:
+                    $expr:
+                        $function:
+                            body: |-
+                                function(name) {
+                                    return hex_md5(name) == "9b53e667f30cd329dca1ec9e6a83e994";
+                                }
+                            args: ['$name']
+                            lang: 'js'

--- a/generator/config/schema.json
+++ b/generator/config/schema.json
@@ -60,6 +60,7 @@
                     "enum": [
                         "array",
                         "object",
+                        "dollar_object",
                         "single",
                         "group"
                     ]

--- a/generator/src/Definition/OperatorDefinition.php
+++ b/generator/src/Definition/OperatorDefinition.php
@@ -38,6 +38,7 @@ final class OperatorDefinition
             'single' => Encode::Single,
             'array' => Encode::Array,
             'object' => Encode::Object,
+            'dollar_object' => Encode::DollarObject,
             'group' => Encode::Group,
             default => throw new UnexpectedValueException(sprintf('Unexpected "encode" value for operator "%s". Got "%s"', $name, $encode)),
         };

--- a/src/Builder/BuilderEncoder.php
+++ b/src/Builder/BuilderEncoder.php
@@ -111,6 +111,9 @@ class BuilderEncoder implements Encoder
             case Encode::Object:
                 return $this->encodeAsObject($value);
 
+            case Encode::DollarObject:
+                return $this->encodeAsDollarObject($value);
+
             case Encode::Group:
                 assert($value instanceof GroupStage);
 
@@ -165,6 +168,21 @@ class BuilderEncoder implements Encoder
             }
 
             $result->{$key} = $this->recursiveEncode($val);
+        }
+
+        return $this->wrap($value, $result);
+    }
+
+    private function encodeAsDollarObject(OperatorInterface $value): stdClass
+    {
+        $result = new stdClass();
+        foreach (get_object_vars($value) as $key => $val) {
+            // Skip optional arguments. If they have a default value, it is resolved by the server.
+            if ($val === Optional::Undefined) {
+                continue;
+            }
+
+            $result->{'$' . $key} = $this->recursiveEncode($val);
         }
 
         return $this->wrap($value, $result);

--- a/src/Builder/Query/FactoryTrait.php
+++ b/src/Builder/Query/FactoryTrait.php
@@ -327,10 +327,13 @@ trait FactoryTrait
      * Performs a modulo operation on the value of a field and selects documents with a specified result.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/mod/
-     * @param int $divisor
-     * @param int $remainder
+     * @param Decimal128|Int64|float|int $divisor
+     * @param Decimal128|Int64|float|int $remainder
      */
-    public static function mod(int $divisor, int $remainder): ModOperator
+    public static function mod(
+        Decimal128|Int64|float|int $divisor,
+        Decimal128|Int64|float|int $remainder,
+    ): ModOperator
     {
         return new ModOperator($divisor, $remainder);
     }

--- a/src/Builder/Query/ModOperator.php
+++ b/src/Builder/Query/ModOperator.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Query;
 
+use MongoDB\BSON\Decimal128;
+use MongoDB\BSON\Int64;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\FieldQueryInterface;
 use MongoDB\Builder\Type\OperatorInterface;
@@ -21,17 +23,17 @@ class ModOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 
-    /** @var int $divisor */
-    public readonly int $divisor;
+    /** @var Decimal128|Int64|float|int $divisor */
+    public readonly Decimal128|Int64|float|int $divisor;
 
-    /** @var int $remainder */
-    public readonly int $remainder;
+    /** @var Decimal128|Int64|float|int $remainder */
+    public readonly Decimal128|Int64|float|int $remainder;
 
     /**
-     * @param int $divisor
-     * @param int $remainder
+     * @param Decimal128|Int64|float|int $divisor
+     * @param Decimal128|Int64|float|int $remainder
      */
-    public function __construct(int $divisor, int $remainder)
+    public function __construct(Decimal128|Int64|float|int $divisor, Decimal128|Int64|float|int $remainder)
     {
         $this->divisor = $divisor;
         $this->remainder = $remainder;

--- a/src/Builder/Query/TextOperator.php
+++ b/src/Builder/Query/TextOperator.php
@@ -20,7 +20,7 @@ use MongoDB\Builder\Type\QueryInterface;
  */
 class TextOperator implements QueryInterface, OperatorInterface
 {
-    public const ENCODE = Encode::Object;
+    public const ENCODE = Encode::DollarObject;
 
     /** @var non-empty-string $search A string of terms that MongoDB parses and uses to query the text index. MongoDB performs a logical OR search of the terms unless specified as a phrase. */
     public readonly string $search;

--- a/src/Builder/Type/Encode.php
+++ b/src/Builder/Type/Encode.php
@@ -24,6 +24,11 @@ enum Encode
     case Object;
 
     /**
+     * Parameters are encoded as an object with keys matching the parameter names prefixed with a dollar sign ($)
+     */
+    case DollarObject;
+
+    /**
      * Get the single parameter value
      */
     case Single;

--- a/tests/Builder/Query/JsonSchemaOperatorTest.php
+++ b/tests/Builder/Query/JsonSchemaOperatorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $jsonSchema query
+ */
+class JsonSchemaOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::jsonSchema(object(
+                    required: ['name', 'major', 'gpa', 'address'],
+                    properties: object(
+                        name: object(
+                            bsonType: 'string',
+                            description: 'must be a string and is required',
+                        ),
+                        address: object(
+                            bsonType: 'object',
+                            required: ['zipcode'],
+                            properties: object(
+                                zipcode: object(bsonType: 'string'),
+                                street: object(bsonType: 'string'),
+                            ),
+                        ),
+                    ),
+                )),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::JsonSchemaExample, $pipeline);
+    }
+}

--- a/tests/Builder/Query/ModOperatorTest.php
+++ b/tests/Builder/Query/ModOperatorTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $mod query
+ */
+class ModOperatorTest extends PipelineTestCase
+{
+    public function testFloatingPointArguments(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                qty: Query::mod(4.0, 0),
+            ),
+            Stage::match(
+                qty: Query::mod(4.5, 0),
+            ),
+            Stage::match(
+                qty: Query::mod(4.99, 0),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ModFloatingPointArguments, $pipeline);
+    }
+
+    public function testUseModToSelectDocuments(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                qty: Query::mod(4, 0),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ModUseModToSelectDocuments, $pipeline);
+    }
+}

--- a/tests/Builder/Query/Pipelines.php
+++ b/tests/Builder/Query/Pipelines.php
@@ -517,6 +517,48 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/jsonSchema/#syntax
+     */
+    case JsonSchemaExample = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$jsonSchema": {
+                    "required": [
+                        "name",
+                        "major",
+                        "gpa",
+                        "address"
+                    ],
+                    "properties": {
+                        "name": {
+                            "bsonType": "string",
+                            "description": "must be a string and is required"
+                        },
+                        "address": {
+                            "bsonType": "object",
+                            "required": [
+                                "zipcode"
+                            ],
+                            "properties": {
+                                "street": {
+                                    "bsonType": "string"
+                                },
+                                "zipcode": {
+                                    "bsonType": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Match Document Fields
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/lt/#match-document-fields
@@ -548,6 +590,82 @@ enum Pipelines: string
                     "$lte": {
                         "$numberInt": "20"
                     }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use $mod to Select Documents
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/mod/#use--mod-to-select-documents
+     */
+    case ModUseModToSelectDocuments = <<<'JSON'
+    [
+        {
+            "$match": {
+                "qty": {
+                    "$mod": [
+                        {
+                            "$numberInt": "4"
+                        },
+                        {
+                            "$numberInt": "0"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Floating Point Arguments
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/mod/#floating-point-arguments
+     */
+    case ModFloatingPointArguments = <<<'JSON'
+    [
+        {
+            "$match": {
+                "qty": {
+                    "$mod": [
+                        {
+                            "$numberDouble": "4.0"
+                        },
+                        {
+                            "$numberInt": "0"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "$match": {
+                "qty": {
+                    "$mod": [
+                        {
+                            "$numberDouble": "4.5"
+                        },
+                        {
+                            "$numberInt": "0"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "$match": {
+                "qty": {
+                    "$mod": [
+                        {
+                            "$numberDouble": "4.9900000000000002132"
+                        },
+                        {
+                            "$numberInt": "0"
+                        }
+                    ]
                 }
             }
         }
@@ -853,6 +971,180 @@ enum Pipelines: string
                             "pattern": "^ABC",
                             "options": "i"
                         }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Search for a Single Word
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/text/#search-for-a-single-word
+     */
+    case TextSearchForASingleWord = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$text": {
+                    "$search": "coffee"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Match Any of the Search Terms
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/text/#search-for-a-single-word
+     */
+    case TextMatchAnyOfTheSearchTerms = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$text": {
+                    "$search": "bake coffee cake"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Search a Different Language
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/text/#search-a-different-language
+     */
+    case TextSearchADifferentLanguage = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$text": {
+                    "$search": "leche",
+                    "$language": "es"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Case and Diacritic Insensitive Search
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/text/#case-and-diacritic-insensitive-search
+     */
+    case TextCaseAndDiacriticInsensitiveSearch = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$text": {
+                    "$search": "\u0441\u044b\u0301\u0440\u043d\u0438\u043a\u0438 CAF\u00c9S"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Perform Case Sensitive Search
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/text/#perform-case-sensitive-search
+     */
+    case TextPerformCaseSensitiveSearch = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$text": {
+                    "$search": "Coffee",
+                    "$caseSensitive": true
+                }
+            }
+        },
+        {
+            "$match": {
+                "$text": {
+                    "$search": "\\\"Caf\u00e9 Con Leche\\\"",
+                    "$caseSensitive": true
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Diacritic Sensitive Search
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/text/#perform-case-sensitive-search
+     */
+    case TextDiacriticSensitiveSearch = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$text": {
+                    "$search": "CAF\u00c9",
+                    "$diacriticSensitive": true
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Text Search Score Examples
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/text/#perform-case-sensitive-search
+     */
+    case TextTextSearchScoreExamples = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$text": {
+                    "$search": "CAF\u00c9",
+                    "$diacriticSensitive": true
+                },
+                "score": {
+                    "$meta": "textScore"
+                }
+            }
+        },
+        {
+            "$sort": {
+                "score": {
+                    "$meta": "textScore"
+                }
+            }
+        },
+        {
+            "$limit": {
+                "$numberInt": "5"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/where/#example
+     */
+    case WhereExample = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$where": "function() { return hex_md5(this.name) == \"9b53e667f30cd329dca1ec9e6a83e994\" }"
+            }
+        },
+        {
+            "$match": {
+                "$expr": {
+                    "$function": {
+                        "body": "function(name) {\n    return hex_md5(name) == \"9b53e667f30cd329dca1ec9e6a83e994\";\n}",
+                        "args": [
+                            "$name"
+                        ],
+                        "lang": "js"
                     }
                 }
             }

--- a/tests/Builder/Query/TextOperatorTest.php
+++ b/tests/Builder/Query/TextOperatorTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $text query
+ */
+class TextOperatorTest extends PipelineTestCase
+{
+    public function testCaseAndDiacriticInsensitiveSearch(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::text('сы́рники CAFÉS'),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TextCaseAndDiacriticInsensitiveSearch, $pipeline);
+    }
+
+    public function testDiacriticSensitiveSearch(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::text(
+                    search: 'CAFÉ',
+                    diacriticSensitive: true,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TextDiacriticSensitiveSearch, $pipeline);
+    }
+
+    public function testMatchAnyOfTheSearchTerms(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::text('bake coffee cake'),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TextMatchAnyOfTheSearchTerms, $pipeline);
+    }
+
+    public function testPerformCaseSensitiveSearch(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::text(
+                    search: 'Coffee',
+                    caseSensitive: true,
+                ),
+            ),
+            Stage::match(
+                Query::text(
+                    search: '\"Café Con Leche\"',
+                    caseSensitive: true,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TextPerformCaseSensitiveSearch, $pipeline);
+    }
+
+    public function testSearchADifferentLanguage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::text(
+                    search: 'leche',
+                    language: 'es',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TextSearchADifferentLanguage, $pipeline);
+    }
+
+    public function testSearchForASingleWord(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::text('coffee'),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TextSearchForASingleWord, $pipeline);
+    }
+
+    public function testTextSearchScoreExamples(): void
+    {
+        /**
+         * @todo: add support for $meta: "textScore"
+         * @todo: add support for $sort spec with object
+         */
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::text(
+                    search: 'CAFÉ',
+                    diacriticSensitive: true,
+                ),
+                score: ['$meta' => 'textScore'],
+            ),
+            Stage::sort(
+                ['score' => ['$meta' => 'textScore']],
+            ),
+            Stage::limit(5),
+        );
+
+        $this->assertSamePipeline(Pipelines::TextTextSearchScoreExamples, $pipeline);
+    }
+}

--- a/tests/Builder/Query/WhereOperatorTest.php
+++ b/tests/Builder/Query/WhereOperatorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $where query
+ */
+class WhereOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::where('function() { return hex_md5(this.name) == "9b53e667f30cd329dca1ec9e6a83e994" }'),
+            ),
+            Stage::match(
+                Query::expr(
+                    Expression::function(
+                        body: <<<'JS'
+                            function(name) {
+                                return hex_md5(name) == "9b53e667f30cd329dca1ec9e6a83e994";
+                            }
+                            JS,
+                        args: [Expression::fieldPath('name')],
+                        lang: 'js',
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::WhereExample, $pipeline);
+    }
+}


### PR DESCRIPTION
Fix [PHPLIB-1336](https://jira.mongodb.org/browse/PHPLIB-1336)


https://www.mongodb.com/docs/manual/reference/operator/query/#evaluation

- ~`$expr`~ (already done)
- `$jsonSchema`
- `$mod` contains some [error examples](https://www.mongodb.com/docs/manual/reference/operator/query/mod/#not-enough-elements-error) that are not allowed by the function signature.
- ~`$regex`~ (already done)
- `$text` requires a specific encoding, to prefix properties with dollar sign (`$`)
- `$where` the alternative example using `$expr` and `$function` is also implemented
