### PR TITLE
PHPLIB-1337 Add tests on Geospatial Query Operators

### DIFF
--- a/generator/config/query/geoIntersects.yaml
+++ b/generator/config/query/geoIntersects.yaml
@@ -11,3 +11,42 @@ arguments:
         name: geometry
         type:
             - geometry
+tests:
+    -
+        name: 'Intersects a Polygon'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/geoIntersects/#intersects-a-polygon'
+        pipeline:
+            -
+                $match:
+                    loc:
+                        $geoIntersects:
+                            $geometry:
+                                type: 'Polygon'
+                                coordinates:
+                                    -
+                                        - [ 0, 0 ]
+                                        - [ 3, 6 ]
+                                        - [ 6, 1 ]
+                                        - [ 0, 0 ]
+    -
+        name: 'Intersects a Big Polygon'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/geoIntersects/#intersects-a--big--polygon'
+        pipeline:
+            -
+                $match:
+                    loc:
+                        $geoIntersects:
+                            $geometry:
+                                type: 'Polygon'
+                                coordinates:
+                                    -
+                                        - [ -100, 60 ]
+                                        - [ -100, 0 ]
+                                        - [ -100, -60 ]
+                                        - [ 100, -60 ]
+                                        - [ 100, 60 ]
+                                        - [ -100, 60 ]
+                                crs:
+                                    type: 'name'
+                                    properties:
+                                        name: 'urn:x-mongodb:crs:strictwinding:EPSG:4326'

--- a/generator/config/query/geoWithin.yaml
+++ b/generator/config/query/geoWithin.yaml
@@ -11,3 +11,42 @@ arguments:
         name: geometry
         type:
             - geometry
+tests:
+    -
+        name: 'Within a Polygon'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/geoWithin/#within-a-polygon'
+        pipeline:
+            -
+                $match:
+                    loc:
+                        $geoWithin:
+                            $geometry:
+                                type: 'Polygon'
+                                coordinates:
+                                    -
+                                        - [ 0, 0 ]
+                                        - [ 3, 6 ]
+                                        - [ 6, 1 ]
+                                        - [ 0, 0 ]
+    -
+        name: 'Within a Big Polygon'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/geoWithin/#within-a--big--polygon'
+        pipeline:
+            -
+                $match:
+                    loc:
+                        $geoWithin:
+                            $geometry:
+                                type: 'Polygon'
+                                coordinates:
+                                    -
+                                        - [ -100, 60 ]
+                                        - [ -100, 0 ]
+                                        - [ -100, -60 ]
+                                        - [ 100, -60 ]
+                                        - [ 100, 60 ]
+                                        - [ -100, 60 ]
+                                crs:
+                                    type: 'name'
+                                    properties:
+                                        name: 'urn:x-mongodb:crs:strictwinding:EPSG:4326'

--- a/generator/config/query/geometry.yaml
+++ b/generator/config/query/geometry.yaml
@@ -19,3 +19,4 @@ arguments:
         name: crs
         type:
             - object
+        optional: true

--- a/generator/config/query/near.yaml
+++ b/generator/config/query/near.yaml
@@ -14,14 +14,42 @@ arguments:
     -
         name: maxDistance
         type:
-            - int
+            - number
         optional: true
         description: |
             Distance in meters. Limits the results to those documents that are at most the specified distance from the center point.
     -
         name: minDistance
         type:
-            - int
+            - number
         optional: true
         description: |
             Distance in meters. Limits the results to those documents that are at least the specified distance from the center point.
+tests:
+    -
+        name: 'Query on GeoJSON Data'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/near/#query-on-geojson-data'
+        pipeline:
+            -
+                $match:
+                    location:
+                        $near:
+                            $geometry:
+                                type: 'Point'
+                                coordinates:
+                                    - -73.9667
+                                    - 40.78
+                            $minDistance: 1000
+                            $maxDistance: 5000
+
+    -
+        name: 'Query on Legacy Coordinates'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/near/#query-on-legacy-coordinates'
+        pipeline:
+            -
+                $match:
+                    location:
+                        $near:
+                            - -73.9667
+                            - 40.78
+                        $maxDistance: 0.1

--- a/generator/config/query/near.yaml
+++ b/generator/config/query/near.yaml
@@ -3,7 +3,7 @@ name: $near
 link: 'https://www.mongodb.com/docs/manual/reference/operator/query/near/'
 type:
     - fieldQuery
-encode: object
+encode: dollar_object
 description: |
     Returns geospatial objects in proximity to a point. Requires a geospatial index. The 2dsphere and 2d indexes support $near.
 arguments:
@@ -41,15 +41,3 @@ tests:
                                     - 40.78
                             $minDistance: 1000
                             $maxDistance: 5000
-
-    -
-        name: 'Query on Legacy Coordinates'
-        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/near/#query-on-legacy-coordinates'
-        pipeline:
-            -
-                $match:
-                    location:
-                        $near:
-                            - -73.9667
-                            - 40.78
-                        $maxDistance: 0.1

--- a/generator/config/query/nearSphere.yaml
+++ b/generator/config/query/nearSphere.yaml
@@ -14,14 +14,41 @@ arguments:
     -
         name: maxDistance
         type:
-            - int
+            - number
         optional: true
         description: |
             Distance in meters.
     -
         name: minDistance
         type:
-            - int
+            - number
         optional: true
         description: |
             Distance in meters. Limits the results to those documents that are at least the specified distance from the center point.
+tests:
+    -
+        name: 'Specify Center Point Using GeoJSON'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/nearSphere/#specify-center-point-using-geojson'
+        pipeline:
+            -
+                $match:
+                    location:
+                        $nearSphere:
+                            $geometry:
+                                type: 'Point'
+                                coordinates:
+                                    - -73.9667
+                                    - 40.78
+                            $minDistance: 1000
+                            $maxDistance: 5000
+    -
+        name: 'Specify Center Point Using Legacy Coordinates'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/nearSphere/#specify-center-point-using-legacy-coordinates'
+        pipeline:
+            -
+                $match:
+                    location:
+                        $nearSphere:
+                            - -73.9667
+                            - 40.78
+                        $maxDistance: 0.1

--- a/generator/config/query/nearSphere.yaml
+++ b/generator/config/query/nearSphere.yaml
@@ -3,7 +3,7 @@ name: $nearSphere
 link: 'https://www.mongodb.com/docs/manual/reference/operator/query/nearSphere/'
 type:
     - fieldQuery
-encode: object
+encode: dollar_object
 description: |
     Returns geospatial objects in proximity to a point on a sphere. Requires a geospatial index. The 2dsphere and 2d indexes support $nearSphere.
 arguments:
@@ -36,19 +36,6 @@ tests:
                         $nearSphere:
                             $geometry:
                                 type: 'Point'
-                                coordinates:
-                                    - -73.9667
-                                    - 40.78
+                                coordinates: [-73.9667, 40.78]
                             $minDistance: 1000
                             $maxDistance: 5000
-    -
-        name: 'Specify Center Point Using Legacy Coordinates'
-        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/nearSphere/#specify-center-point-using-legacy-coordinates'
-        pipeline:
-            -
-                $match:
-                    location:
-                        $nearSphere:
-                            - -73.9667
-                            - 40.78
-                        $maxDistance: 0.1

--- a/src/Builder/BuilderEncoder.php
+++ b/src/Builder/BuilderEncoder.php
@@ -26,6 +26,7 @@ use MongoDB\Codec\Encoder;
 use MongoDB\Exception\UnsupportedValueException;
 use stdClass;
 
+use function array_key_exists;
 use function array_key_first;
 use function assert;
 use function get_debug_type;
@@ -182,7 +183,19 @@ class BuilderEncoder implements Encoder
                 continue;
             }
 
-            $result->{'$' . $key} = $this->recursiveEncode($val);
+            $val = $this->recursiveEncode($val);
+
+            if ($key === 'geometry') {
+                if (is_object($val) && property_exists($val, '$geometry')) {
+                    $result->{'$geometry'} = $val->{'$geometry'};
+                } elseif (is_array($val) && array_key_exists('$geometry', $val)) {
+                    $result->{'$geometry'} = $val->{'$geometry'};
+                } else {
+                    $result->{'$geometry'} = $val;
+                }
+            } else {
+                $result->{'$' . $key} = $val;
+            }
         }
 
         return $this->wrap($value, $result);

--- a/src/Builder/Query/FactoryTrait.php
+++ b/src/Builder/Query/FactoryTrait.php
@@ -211,12 +211,12 @@ trait FactoryTrait
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/geometry/
      * @param non-empty-string $type
      * @param BSONArray|PackedArray|array $coordinates
-     * @param Document|Serializable|array|stdClass $crs
+     * @param Optional|Document|Serializable|array|stdClass $crs
      */
     public static function geometry(
         string $type,
         PackedArray|BSONArray|array $coordinates,
-        Document|Serializable|stdClass|array $crs,
+        Optional|Document|Serializable|stdClass|array $crs = Optional::Undefined,
     ): GeometryOperator
     {
         return new GeometryOperator($type, $coordinates, $crs);
@@ -364,13 +364,13 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/near/
      * @param Document|GeometryInterface|Serializable|array|stdClass $geometry
-     * @param Optional|int $maxDistance Distance in meters. Limits the results to those documents that are at most the specified distance from the center point.
-     * @param Optional|int $minDistance Distance in meters. Limits the results to those documents that are at least the specified distance from the center point.
+     * @param Optional|Decimal128|Int64|float|int $maxDistance Distance in meters. Limits the results to those documents that are at most the specified distance from the center point.
+     * @param Optional|Decimal128|Int64|float|int $minDistance Distance in meters. Limits the results to those documents that are at least the specified distance from the center point.
      */
     public static function near(
         Document|Serializable|GeometryInterface|stdClass|array $geometry,
-        Optional|int $maxDistance = Optional::Undefined,
-        Optional|int $minDistance = Optional::Undefined,
+        Optional|Decimal128|Int64|float|int $maxDistance = Optional::Undefined,
+        Optional|Decimal128|Int64|float|int $minDistance = Optional::Undefined,
     ): NearOperator
     {
         return new NearOperator($geometry, $maxDistance, $minDistance);
@@ -381,13 +381,13 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/nearSphere/
      * @param Document|GeometryInterface|Serializable|array|stdClass $geometry
-     * @param Optional|int $maxDistance Distance in meters.
-     * @param Optional|int $minDistance Distance in meters. Limits the results to those documents that are at least the specified distance from the center point.
+     * @param Optional|Decimal128|Int64|float|int $maxDistance Distance in meters.
+     * @param Optional|Decimal128|Int64|float|int $minDistance Distance in meters. Limits the results to those documents that are at least the specified distance from the center point.
      */
     public static function nearSphere(
         Document|Serializable|GeometryInterface|stdClass|array $geometry,
-        Optional|int $maxDistance = Optional::Undefined,
-        Optional|int $minDistance = Optional::Undefined,
+        Optional|Decimal128|Int64|float|int $maxDistance = Optional::Undefined,
+        Optional|Decimal128|Int64|float|int $minDistance = Optional::Undefined,
     ): NearSphereOperator
     {
         return new NearSphereOperator($geometry, $maxDistance, $minDistance);

--- a/src/Builder/Query/GeometryOperator.php
+++ b/src/Builder/Query/GeometryOperator.php
@@ -14,6 +14,7 @@ use MongoDB\BSON\Serializable;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\GeometryInterface;
 use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\Optional;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\BSONArray;
 use stdClass;
@@ -36,18 +37,18 @@ class GeometryOperator implements GeometryInterface, OperatorInterface
     /** @var BSONArray|PackedArray|array $coordinates */
     public readonly PackedArray|BSONArray|array $coordinates;
 
-    /** @var Document|Serializable|array|stdClass $crs */
-    public readonly Document|Serializable|stdClass|array $crs;
+    /** @var Optional|Document|Serializable|array|stdClass $crs */
+    public readonly Optional|Document|Serializable|stdClass|array $crs;
 
     /**
      * @param non-empty-string $type
      * @param BSONArray|PackedArray|array $coordinates
-     * @param Document|Serializable|array|stdClass $crs
+     * @param Optional|Document|Serializable|array|stdClass $crs
      */
     public function __construct(
         string $type,
         PackedArray|BSONArray|array $coordinates,
-        Document|Serializable|stdClass|array $crs,
+        Optional|Document|Serializable|stdClass|array $crs = Optional::Undefined,
     ) {
         $this->type = $type;
         if (is_array($coordinates) && ! array_is_list($coordinates)) {

--- a/src/Builder/Query/NearOperator.php
+++ b/src/Builder/Query/NearOperator.php
@@ -8,7 +8,9 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Query;
 
+use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Document;
+use MongoDB\BSON\Int64;
 use MongoDB\BSON\Serializable;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\FieldQueryInterface;
@@ -29,21 +31,21 @@ class NearOperator implements FieldQueryInterface, OperatorInterface
     /** @var Document|GeometryInterface|Serializable|array|stdClass $geometry */
     public readonly Document|Serializable|GeometryInterface|stdClass|array $geometry;
 
-    /** @var Optional|int $maxDistance Distance in meters. Limits the results to those documents that are at most the specified distance from the center point. */
-    public readonly Optional|int $maxDistance;
+    /** @var Optional|Decimal128|Int64|float|int $maxDistance Distance in meters. Limits the results to those documents that are at most the specified distance from the center point. */
+    public readonly Optional|Decimal128|Int64|float|int $maxDistance;
 
-    /** @var Optional|int $minDistance Distance in meters. Limits the results to those documents that are at least the specified distance from the center point. */
-    public readonly Optional|int $minDistance;
+    /** @var Optional|Decimal128|Int64|float|int $minDistance Distance in meters. Limits the results to those documents that are at least the specified distance from the center point. */
+    public readonly Optional|Decimal128|Int64|float|int $minDistance;
 
     /**
      * @param Document|GeometryInterface|Serializable|array|stdClass $geometry
-     * @param Optional|int $maxDistance Distance in meters. Limits the results to those documents that are at most the specified distance from the center point.
-     * @param Optional|int $minDistance Distance in meters. Limits the results to those documents that are at least the specified distance from the center point.
+     * @param Optional|Decimal128|Int64|float|int $maxDistance Distance in meters. Limits the results to those documents that are at most the specified distance from the center point.
+     * @param Optional|Decimal128|Int64|float|int $minDistance Distance in meters. Limits the results to those documents that are at least the specified distance from the center point.
      */
     public function __construct(
         Document|Serializable|GeometryInterface|stdClass|array $geometry,
-        Optional|int $maxDistance = Optional::Undefined,
-        Optional|int $minDistance = Optional::Undefined,
+        Optional|Decimal128|Int64|float|int $maxDistance = Optional::Undefined,
+        Optional|Decimal128|Int64|float|int $minDistance = Optional::Undefined,
     ) {
         $this->geometry = $geometry;
         $this->maxDistance = $maxDistance;

--- a/src/Builder/Query/NearOperator.php
+++ b/src/Builder/Query/NearOperator.php
@@ -26,7 +26,7 @@ use stdClass;
  */
 class NearOperator implements FieldQueryInterface, OperatorInterface
 {
-    public const ENCODE = Encode::Object;
+    public const ENCODE = Encode::DollarObject;
 
     /** @var Document|GeometryInterface|Serializable|array|stdClass $geometry */
     public readonly Document|Serializable|GeometryInterface|stdClass|array $geometry;

--- a/src/Builder/Query/NearSphereOperator.php
+++ b/src/Builder/Query/NearSphereOperator.php
@@ -26,7 +26,7 @@ use stdClass;
  */
 class NearSphereOperator implements FieldQueryInterface, OperatorInterface
 {
-    public const ENCODE = Encode::Object;
+    public const ENCODE = Encode::DollarObject;
 
     /** @var Document|GeometryInterface|Serializable|array|stdClass $geometry */
     public readonly Document|Serializable|GeometryInterface|stdClass|array $geometry;

--- a/src/Builder/Query/NearSphereOperator.php
+++ b/src/Builder/Query/NearSphereOperator.php
@@ -8,7 +8,9 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Query;
 
+use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Document;
+use MongoDB\BSON\Int64;
 use MongoDB\BSON\Serializable;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\FieldQueryInterface;
@@ -29,21 +31,21 @@ class NearSphereOperator implements FieldQueryInterface, OperatorInterface
     /** @var Document|GeometryInterface|Serializable|array|stdClass $geometry */
     public readonly Document|Serializable|GeometryInterface|stdClass|array $geometry;
 
-    /** @var Optional|int $maxDistance Distance in meters. */
-    public readonly Optional|int $maxDistance;
+    /** @var Optional|Decimal128|Int64|float|int $maxDistance Distance in meters. */
+    public readonly Optional|Decimal128|Int64|float|int $maxDistance;
 
-    /** @var Optional|int $minDistance Distance in meters. Limits the results to those documents that are at least the specified distance from the center point. */
-    public readonly Optional|int $minDistance;
+    /** @var Optional|Decimal128|Int64|float|int $minDistance Distance in meters. Limits the results to those documents that are at least the specified distance from the center point. */
+    public readonly Optional|Decimal128|Int64|float|int $minDistance;
 
     /**
      * @param Document|GeometryInterface|Serializable|array|stdClass $geometry
-     * @param Optional|int $maxDistance Distance in meters.
-     * @param Optional|int $minDistance Distance in meters. Limits the results to those documents that are at least the specified distance from the center point.
+     * @param Optional|Decimal128|Int64|float|int $maxDistance Distance in meters.
+     * @param Optional|Decimal128|Int64|float|int $minDistance Distance in meters. Limits the results to those documents that are at least the specified distance from the center point.
      */
     public function __construct(
         Document|Serializable|GeometryInterface|stdClass|array $geometry,
-        Optional|int $maxDistance = Optional::Undefined,
-        Optional|int $minDistance = Optional::Undefined,
+        Optional|Decimal128|Int64|float|int $maxDistance = Optional::Undefined,
+        Optional|Decimal128|Int64|float|int $minDistance = Optional::Undefined,
     ) {
         $this->geometry = $geometry;
         $this->maxDistance = $maxDistance;

--- a/tests/Builder/Query/GeoIntersectsOperatorTest.php
+++ b/tests/Builder/Query/GeoIntersectsOperatorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $geoIntersects query
+ */
+class GeoIntersectsOperatorTest extends PipelineTestCase
+{
+    public function testIntersectsABigPolygon(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                loc: Query::geoIntersects(
+                    Query::geometry(
+                        type: 'Polygon',
+                        coordinates: [[[-100, 60], [-100, 0], [-100, -60], [100, -60], [100, 60], [-100, 60]]],
+                        crs: object(
+                            type: 'name',
+                            properties: object(
+                                name: 'urn:x-mongodb:crs:strictwinding:EPSG:4326',
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GeoIntersectsIntersectsABigPolygon, $pipeline);
+    }
+
+    public function testIntersectsAPolygon(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                loc: Query::geoIntersects(
+                    Query::geometry(
+                        type: 'Polygon',
+                        coordinates: [[[0, 0], [3, 6], [6, 1], [0, 0]]],
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GeoIntersectsIntersectsAPolygon, $pipeline);
+    }
+}

--- a/tests/Builder/Query/GeoWithinOperatorTest.php
+++ b/tests/Builder/Query/GeoWithinOperatorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $geoWithin query
+ */
+class GeoWithinOperatorTest extends PipelineTestCase
+{
+    public function testWithinABigPolygon(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                loc: Query::geoWithin(
+                    Query::geometry(
+                        type: 'Polygon',
+                        coordinates: [[[-100, 60], [-100, 0], [-100, -60], [100, -60], [100, 60], [-100, 60]]],
+                        crs: object(
+                            type: 'name',
+                            properties: object(
+                                name: 'urn:x-mongodb:crs:strictwinding:EPSG:4326',
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GeoWithinWithinABigPolygon, $pipeline);
+    }
+
+    public function testWithinAPolygon(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                loc: Query::geoWithin(
+                    Query::geometry(
+                        type: 'Polygon',
+                        coordinates: [[[0, 0], [3, 6], [6, 1], [0, 0]]],
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GeoWithinWithinAPolygon, $pipeline);
+    }
+}

--- a/tests/Builder/Query/NearOperatorTest.php
+++ b/tests/Builder/Query/NearOperatorTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $near query
+ */
+class NearOperatorTest extends PipelineTestCase
+{
+    public function testQueryOnGeoJSONData(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                location: Query::near(
+                    Query::geometry(
+                        type: 'Point',
+                        coordinates: [-73.9667, 40.78],
+                    ),
+                    minDistance: 1000,
+                    maxDistance: 5000,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::NearQueryOnGeoJSONData, $pipeline);
+    }
+
+    public function testQueryOnLegacyCoordinates(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                location: Query::near(
+                    [-73.9667, 40.78],
+                    maxDistance: 0.10,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::NearQueryOnLegacyCoordinates, $pipeline);
+    }
+}

--- a/tests/Builder/Query/NearOperatorTest.php
+++ b/tests/Builder/Query/NearOperatorTest.php
@@ -31,18 +31,4 @@ class NearOperatorTest extends PipelineTestCase
 
         $this->assertSamePipeline(Pipelines::NearQueryOnGeoJSONData, $pipeline);
     }
-
-    public function testQueryOnLegacyCoordinates(): void
-    {
-        $pipeline = new Pipeline(
-            Stage::match(
-                location: Query::near(
-                    [-73.9667, 40.78],
-                    maxDistance: 0.10,
-                ),
-            ),
-        );
-
-        $this->assertSamePipeline(Pipelines::NearQueryOnLegacyCoordinates, $pipeline);
-    }
 }

--- a/tests/Builder/Query/NearSphereOperatorTest.php
+++ b/tests/Builder/Query/NearSphereOperatorTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace MongoDB\Tests\Builder\Query;
 
 use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 /**
@@ -14,15 +16,19 @@ class NearSphereOperatorTest extends PipelineTestCase
 {
     public function testSpecifyCenterPointUsingGeoJSON(): void
     {
-        $pipeline = new Pipeline();
+        $pipeline = new Pipeline(
+            Stage::match(
+                location: Query::nearSphere(
+                    Query::geometry(
+                        type: 'Point',
+                        coordinates: [-73.9667, 40.78],
+                    ),
+                    minDistance: 1000,
+                    maxDistance: 5000,
+                ),
+            ),
+        );
 
         $this->assertSamePipeline(Pipelines::NearSphereSpecifyCenterPointUsingGeoJSON, $pipeline);
-    }
-
-    public function testSpecifyCenterPointUsingLegacyCoordinates(): void
-    {
-        $pipeline = new Pipeline();
-
-        $this->assertSamePipeline(Pipelines::NearSphereSpecifyCenterPointUsingLegacyCoordinates, $pipeline);
     }
 }

--- a/tests/Builder/Query/NearSphereOperatorTest.php
+++ b/tests/Builder/Query/NearSphereOperatorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $nearSphere query
+ */
+class NearSphereOperatorTest extends PipelineTestCase
+{
+    public function testSpecifyCenterPointUsingGeoJSON(): void
+    {
+        $pipeline = new Pipeline();
+
+        $this->assertSamePipeline(Pipelines::NearSphereSpecifyCenterPointUsingGeoJSON, $pipeline);
+    }
+
+    public function testSpecifyCenterPointUsingLegacyCoordinates(): void
+    {
+        $pipeline = new Pipeline();
+
+        $this->assertSamePipeline(Pipelines::NearSphereSpecifyCenterPointUsingLegacyCoordinates, $pipeline);
+    }
+}

--- a/tests/Builder/Query/Pipelines.php
+++ b/tests/Builder/Query/Pipelines.php
@@ -471,6 +471,278 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Intersects a Polygon
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/geoIntersects/#intersects-a-polygon
+     */
+    case GeoIntersectsIntersectsAPolygon = <<<'JSON'
+    [
+        {
+            "$match": {
+                "loc": {
+                    "$geoIntersects": {
+                        "$geometry": {
+                            "type": "Polygon",
+                            "coordinates": [
+                                [
+                                    [
+                                        {
+                                            "$numberInt": "0"
+                                        },
+                                        {
+                                            "$numberInt": "0"
+                                        }
+                                    ],
+                                    [
+                                        {
+                                            "$numberInt": "3"
+                                        },
+                                        {
+                                            "$numberInt": "6"
+                                        }
+                                    ],
+                                    [
+                                        {
+                                            "$numberInt": "6"
+                                        },
+                                        {
+                                            "$numberInt": "1"
+                                        }
+                                    ],
+                                    [
+                                        {
+                                            "$numberInt": "0"
+                                        },
+                                        {
+                                            "$numberInt": "0"
+                                        }
+                                    ]
+                                ]
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Intersects a Big Polygon
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/geoIntersects/#intersects-a--big--polygon
+     */
+    case GeoIntersectsIntersectsABigPolygon = <<<'JSON'
+    [
+        {
+            "$match": {
+                "loc": {
+                    "$geoIntersects": {
+                        "$geometry": {
+                            "type": "Polygon",
+                            "coordinates": [
+                                [
+                                    [
+                                        {
+                                            "$numberInt": "-100"
+                                        },
+                                        {
+                                            "$numberInt": "60"
+                                        }
+                                    ],
+                                    [
+                                        {
+                                            "$numberInt": "-100"
+                                        },
+                                        {
+                                            "$numberInt": "0"
+                                        }
+                                    ],
+                                    [
+                                        {
+                                            "$numberInt": "-100"
+                                        },
+                                        {
+                                            "$numberInt": "-60"
+                                        }
+                                    ],
+                                    [
+                                        {
+                                            "$numberInt": "100"
+                                        },
+                                        {
+                                            "$numberInt": "-60"
+                                        }
+                                    ],
+                                    [
+                                        {
+                                            "$numberInt": "100"
+                                        },
+                                        {
+                                            "$numberInt": "60"
+                                        }
+                                    ],
+                                    [
+                                        {
+                                            "$numberInt": "-100"
+                                        },
+                                        {
+                                            "$numberInt": "60"
+                                        }
+                                    ]
+                                ]
+                            ],
+                            "crs": {
+                                "type": "name",
+                                "properties": {
+                                    "name": "urn:x-mongodb:crs:strictwinding:EPSG:4326"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Within a Polygon
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/geoWithin/#within-a-polygon
+     */
+    case GeoWithinWithinAPolygon = <<<'JSON'
+    [
+        {
+            "$match": {
+                "loc": {
+                    "$geoWithin": {
+                        "$geometry": {
+                            "type": "Polygon",
+                            "coordinates": [
+                                [
+                                    [
+                                        {
+                                            "$numberInt": "0"
+                                        },
+                                        {
+                                            "$numberInt": "0"
+                                        }
+                                    ],
+                                    [
+                                        {
+                                            "$numberInt": "3"
+                                        },
+                                        {
+                                            "$numberInt": "6"
+                                        }
+                                    ],
+                                    [
+                                        {
+                                            "$numberInt": "6"
+                                        },
+                                        {
+                                            "$numberInt": "1"
+                                        }
+                                    ],
+                                    [
+                                        {
+                                            "$numberInt": "0"
+                                        },
+                                        {
+                                            "$numberInt": "0"
+                                        }
+                                    ]
+                                ]
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Within a Big Polygon
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/geoWithin/#within-a--big--polygon
+     */
+    case GeoWithinWithinABigPolygon = <<<'JSON'
+    [
+        {
+            "$match": {
+                "loc": {
+                    "$geoWithin": {
+                        "$geometry": {
+                            "type": "Polygon",
+                            "coordinates": [
+                                [
+                                    [
+                                        {
+                                            "$numberInt": "-100"
+                                        },
+                                        {
+                                            "$numberInt": "60"
+                                        }
+                                    ],
+                                    [
+                                        {
+                                            "$numberInt": "-100"
+                                        },
+                                        {
+                                            "$numberInt": "0"
+                                        }
+                                    ],
+                                    [
+                                        {
+                                            "$numberInt": "-100"
+                                        },
+                                        {
+                                            "$numberInt": "-60"
+                                        }
+                                    ],
+                                    [
+                                        {
+                                            "$numberInt": "100"
+                                        },
+                                        {
+                                            "$numberInt": "-60"
+                                        }
+                                    ],
+                                    [
+                                        {
+                                            "$numberInt": "100"
+                                        },
+                                        {
+                                            "$numberInt": "60"
+                                        }
+                                    ],
+                                    [
+                                        {
+                                            "$numberInt": "-100"
+                                        },
+                                        {
+                                            "$numberInt": "60"
+                                        }
+                                    ]
+                                ]
+                            ],
+                            "crs": {
+                                "type": "name",
+                                "properties": {
+                                    "name": "urn:x-mongodb:crs:strictwinding:EPSG:4326"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Match Document Fields
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/gt/#match-document-fields
@@ -726,6 +998,130 @@ enum Pipelines: string
                 "quantity": {
                     "$ne": {
                         "$numberInt": "20"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Query on GeoJSON Data
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/near/#query-on-geojson-data
+     */
+    case NearQueryOnGeoJSONData = <<<'JSON'
+    [
+        {
+            "$match": {
+                "location": {
+                    "$near": {
+                        "$geometry": {
+                            "type": "Point",
+                            "coordinates": [
+                                {
+                                    "$numberDouble": "-73.966700000000003001"
+                                },
+                                {
+                                    "$numberDouble": "40.780000000000001137"
+                                }
+                            ]
+                        },
+                        "$minDistance": {
+                            "$numberInt": "1000"
+                        },
+                        "$maxDistance": {
+                            "$numberInt": "5000"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Query on Legacy Coordinates
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/near/#query-on-legacy-coordinates
+     */
+    case NearQueryOnLegacyCoordinates = <<<'JSON'
+    [
+        {
+            "$match": {
+                "location": {
+                    "$near": [
+                        {
+                            "$numberDouble": "-73.966700000000003001"
+                        },
+                        {
+                            "$numberDouble": "40.780000000000001137"
+                        }
+                    ],
+                    "$maxDistance": {
+                        "$numberDouble": "0.10000000000000000555"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Specify Center Point Using GeoJSON
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/nearSphere/#specify-center-point-using-geojson
+     */
+    case NearSphereSpecifyCenterPointUsingGeoJSON = <<<'JSON'
+    [
+        {
+            "$match": {
+                "location": {
+                    "$nearSphere": {
+                        "$geometry": {
+                            "type": "Point",
+                            "coordinates": [
+                                {
+                                    "$numberDouble": "-73.966700000000003001"
+                                },
+                                {
+                                    "$numberDouble": "40.780000000000001137"
+                                }
+                            ]
+                        },
+                        "$minDistance": {
+                            "$numberInt": "1000"
+                        },
+                        "$maxDistance": {
+                            "$numberInt": "5000"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Specify Center Point Using Legacy Coordinates
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/nearSphere/#specify-center-point-using-legacy-coordinates
+     */
+    case NearSphereSpecifyCenterPointUsingLegacyCoordinates = <<<'JSON'
+    [
+        {
+            "$match": {
+                "location": {
+                    "$nearSphere": [
+                        {
+                            "$numberDouble": "-73.966700000000003001"
+                        },
+                        {
+                            "$numberDouble": "40.780000000000001137"
+                        }
+                    ],
+                    "$maxDistance": {
+                        "$numberDouble": "0.10000000000000000555"
                     }
                 }
             }


### PR DESCRIPTION
Fix [PHPLIB-1337](https://jira.mongodb.org/browse/PHPLIB-1337)

https://www.mongodb.com/docs/manual/reference/operator/query/#geospatial

- `$geoIntersects`
- `$geoWithin`
- `$near` skipped "legacy coordinate", not supported
- `$nearSphere` skipped "legacy coordinate", not supported
