### PR TITLE
PHPLIB-1345 Add tests on Boolean Expression Operators

### DIFF
--- a/generator/config/expression/and.yaml
+++ b/generator/config/expression/and.yaml
@@ -16,3 +16,22 @@ arguments:
             - resolvesToString
             - resolvesToNull
         variadic: array
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/and/#example'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    qty: 1
+                    result:
+                        $and:
+                            -
+                                $gt:
+                                    - '$qty'
+                                    - 100
+                            -
+                                $lt:
+                                    - '$qty'
+                                    - 250

--- a/generator/config/expression/not.yaml
+++ b/generator/config/expression/not.yaml
@@ -3,7 +3,7 @@ name: $not
 link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/not/'
 type:
     - resolvesToBool
-encode: single
+encode: array
 description: |
     Returns the boolean value that is the opposite of its argument expression. Accepts a single argument expression.
 arguments:
@@ -12,3 +12,17 @@ arguments:
         type:
             - expression
             - resolvesToBool
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/not/#example'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    result:
+                        $not:
+                            -
+                                $gt:
+                                    - '$qty'
+                                    - 250

--- a/generator/config/expression/or.yaml
+++ b/generator/config/expression/or.yaml
@@ -13,3 +13,21 @@ arguments:
             - expression
             - resolvesToBool
         variadic: array
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/or/#example'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    result:
+                        $or:
+                            -
+                                $gt:
+                                    - '$qty'
+                                    - 250
+                            -
+                                $lt:
+                                    - '$qty'
+                                    - 200

--- a/src/Builder/Expression/NotOperator.php
+++ b/src/Builder/Expression/NotOperator.php
@@ -21,7 +21,7 @@ use stdClass;
  */
 class NotOperator implements ResolvesToBool, OperatorInterface
 {
-    public const ENCODE = Encode::Single;
+    public const ENCODE = Encode::Array;
 
     /** @var ExpressionInterface|ResolvesToBool|Type|array|bool|float|int|non-empty-string|null|stdClass $expression */
     public readonly Type|ResolvesToBool|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/tests/Builder/Expression/AndOperatorTest.php
+++ b/tests/Builder/Expression/AndOperatorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $and expression
+ */
+class AndOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                qty: 1,
+                result: Expression::and(
+                    Expression::gt(
+                        Expression::numberFieldPath('qty'),
+                        100,
+                    ),
+                    Expression::lt(
+                        Expression::numberFieldPath('qty'),
+                        250,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::AndExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/NotOperatorTest.php
+++ b/tests/Builder/Expression/NotOperatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $not expression
+ */
+class NotOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                result: Expression::not(
+                    Expression::gt(
+                        Expression::numberFieldPath('qty'),
+                        250,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::NotExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/OrOperatorTest.php
+++ b/tests/Builder/Expression/OrOperatorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $or expression
+ */
+class OrOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                result: Expression::or(
+                    Expression::gt(
+                        Expression::numberFieldPath('qty'),
+                        250,
+                    ),
+                    Expression::lt(
+                        Expression::numberFieldPath('qty'),
+                        200,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::OrExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -61,6 +61,46 @@ enum Pipelines: string
     /**
      * Example
      *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/and/#example
+     */
+    case AndExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "qty": {
+                    "$numberInt": "1"
+                },
+                "result": {
+                    "$and": [
+                        {
+                            "$gt": [
+                                "$qty",
+                                {
+                                    "$numberInt": "100"
+                                }
+                            ]
+                        },
+                        {
+                            "$lt": [
+                                "$qty",
+                                {
+                                    "$numberInt": "250"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/arrayElemAt/#example
      */
     case ArrayElemAtExample = <<<'JSON'
@@ -669,6 +709,35 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/not/#example
+     */
+    case NotExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "result": {
+                    "$not": [
+                        {
+                            "$gt": [
+                                "$qty",
+                                {
+                                    "$numberInt": "250"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * $objectToArray Example
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/objectToArray/#-objecttoarray-example
@@ -712,6 +781,43 @@ enum Pipelines: string
                 "_id": "$warehouses.k",
                 "total": {
                     "$sum": "$warehouses.v"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/or/#example
+     */
+    case OrExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "result": {
+                    "$or": [
+                        {
+                            "$gt": [
+                                "$qty",
+                                {
+                                    "$numberInt": "250"
+                                }
+                            ]
+                        },
+                        {
+                            "$lt": [
+                                "$qty",
+                                {
+                                    "$numberInt": "200"
+                                }
+                            ]
+                        }
+                    ]
                 }
             }
         }


### PR DESCRIPTION
Fix [PHPLIB-1345](https://jira.mongodb.org/browse/PHPLIB-1345)

https://www.mongodb.com/docs/manual/reference/operator/aggregation/#boolean-expression-operators

- `$and`
- `$not` fixed encoding to a single value array
- `$or`