### PR TITLE
PHPLIB-1346 Add tests on Comparison Expression Operators

### DIFF
--- a/generator/config/expression/cmp.yaml
+++ b/generator/config/expression/cmp.yaml
@@ -15,3 +15,17 @@ arguments:
         name: expression2
         type:
             - expression
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/cmp/#example'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    qty: 1
+                    cmpTo250:
+                        $cmp:
+                            - '$qty'
+                            - 250
+                    _id: 0

--- a/generator/config/expression/eq.yaml
+++ b/generator/config/expression/eq.yaml
@@ -15,3 +15,17 @@ arguments:
         name: expression2
         type:
             - expression
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/eq/#example'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    qty: 1
+                    qtyEq250:
+                        $eq:
+                            - '$qty'
+                            - 250
+                    _id: 0

--- a/generator/config/expression/gt.yaml
+++ b/generator/config/expression/gt.yaml
@@ -15,3 +15,17 @@ arguments:
         name: expression2
         type:
             - expression
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/gt/#example'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    qty: 1
+                    qtyGt250:
+                        $gt:
+                            - '$qty'
+                            - 250
+                    _id: 0

--- a/generator/config/expression/gte.yaml
+++ b/generator/config/expression/gte.yaml
@@ -15,3 +15,17 @@ arguments:
         name: expression2
         type:
             - expression
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/gte/#example'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    qty: 1
+                    qtyGte250:
+                        $gte:
+                            - '$qty'
+                            - 250
+                    _id: 0

--- a/generator/config/expression/lt.yaml
+++ b/generator/config/expression/lt.yaml
@@ -15,3 +15,17 @@ arguments:
         name: expression2
         type:
             - expression
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/lt/#example'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    qty: 1
+                    qtyLt250:
+                        $lt:
+                            - '$qty'
+                            - 250
+                    _id: 0

--- a/generator/config/expression/lte.yaml
+++ b/generator/config/expression/lte.yaml
@@ -15,3 +15,17 @@ arguments:
         name: expression2
         type:
             - expression
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/lte/#example'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    qty: 1
+                    qtyLte250:
+                        $lte:
+                            - '$qty'
+                            - 250
+                    _id: 0

--- a/generator/config/expression/ne.yaml
+++ b/generator/config/expression/ne.yaml
@@ -15,3 +15,17 @@ arguments:
         name: expression2
         type:
             - expression
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/ne/#example'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    qty: 1
+                    qtyNe250:
+                        $ne:
+                            - '$qty'
+                            - 250
+                    _id: 0

--- a/tests/Builder/Expression/CmpOperatorTest.php
+++ b/tests/Builder/Expression/CmpOperatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $cmp expression
+ */
+class CmpOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                qty: 1,
+                cmpTo250: Expression::cmp(
+                    Expression::numberFieldPath('qty'),
+                    250,
+                ),
+                _id: 0,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::CmpExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/EqOperatorTest.php
+++ b/tests/Builder/Expression/EqOperatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $eq expression
+ */
+class EqOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                qty: 1,
+                qtyEq250: Expression::eq(
+                    Expression::numberFieldPath('qty'),
+                    250,
+                ),
+                _id: 0,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::EqExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/GtOperatorTest.php
+++ b/tests/Builder/Expression/GtOperatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $gt expression
+ */
+class GtOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                qty: 1,
+                qtyGt250: Expression::gt(
+                    Expression::numberFieldPath('qty'),
+                    250,
+                ),
+                _id: 0,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GtExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/GteOperatorTest.php
+++ b/tests/Builder/Expression/GteOperatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $gte expression
+ */
+class GteOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                qty: 1,
+                qtyGte250: Expression::gte(
+                    Expression::numberFieldPath('qty'),
+                    250,
+                ),
+                _id: 0,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GteExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/LtOperatorTest.php
+++ b/tests/Builder/Expression/LtOperatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $lt expression
+ */
+class LtOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                qty: 1,
+                qtyLt250: Expression::lt(
+                    Expression::numberFieldPath('qty'),
+                    250,
+                ),
+                _id: 0,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::LtExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/LteOperatorTest.php
+++ b/tests/Builder/Expression/LteOperatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $lte expression
+ */
+class LteOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                qty: 1,
+                qtyLte250: Expression::lte(
+                    Expression::numberFieldPath('qty'),
+                    250,
+                ),
+                _id: 0,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::LteExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/NeOperatorTest.php
+++ b/tests/Builder/Expression/NeOperatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $ne expression
+ */
+class NeOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                qty: 1,
+                qtyNe250: Expression::ne(
+                    Expression::numberFieldPath('qty'),
+                    250,
+                ),
+                _id: 0,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::NeExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -322,6 +322,37 @@ enum Pipelines: string
     /**
      * Example
      *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/cmp/#example
+     */
+    case CmpExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "qty": {
+                    "$numberInt": "1"
+                },
+                "cmpTo250": {
+                    "$cmp": [
+                        "$qty",
+                        {
+                            "$numberInt": "250"
+                        }
+                    ]
+                },
+                "_id": {
+                    "$numberInt": "0"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/concatArrays/#example
      */
     case ConcatArraysExample = <<<'JSON'
@@ -333,6 +364,37 @@ enum Pipelines: string
                         "$instock",
                         "$ordered"
                     ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/eq/#example
+     */
+    case EqExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "qty": {
+                    "$numberInt": "1"
+                },
+                "qtyEq250": {
+                    "$eq": [
+                        "$qty",
+                        {
+                            "$numberInt": "250"
+                        }
+                    ]
+                },
+                "_id": {
+                    "$numberInt": "0"
                 }
             }
         }
@@ -498,6 +560,68 @@ enum Pipelines: string
     /**
      * Example
      *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/gt/#example
+     */
+    case GtExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "qty": {
+                    "$numberInt": "1"
+                },
+                "qtyGt250": {
+                    "$gt": [
+                        "$qty",
+                        {
+                            "$numberInt": "250"
+                        }
+                    ]
+                },
+                "_id": {
+                    "$numberInt": "0"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/gte/#example
+     */
+    case GteExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "qty": {
+                    "$numberInt": "1"
+                },
+                "qtyGte250": {
+                    "$gte": [
+                        "$qty",
+                        {
+                            "$numberInt": "250"
+                        }
+                    ]
+                },
+                "_id": {
+                    "$numberInt": "0"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/in/#example
      */
     case InExample = <<<'JSON'
@@ -648,6 +772,68 @@ enum Pipelines: string
                             "$numberInt": "3"
                         }
                     }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/lt/#example
+     */
+    case LtExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "qty": {
+                    "$numberInt": "1"
+                },
+                "qtyLt250": {
+                    "$lt": [
+                        "$qty",
+                        {
+                            "$numberInt": "250"
+                        }
+                    ]
+                },
+                "_id": {
+                    "$numberInt": "0"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/lte/#example
+     */
+    case LteExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "qty": {
+                    "$numberInt": "1"
+                },
+                "qtyLte250": {
+                    "$lte": [
+                        "$qty",
+                        {
+                            "$numberInt": "250"
+                        }
+                    ]
+                },
+                "_id": {
+                    "$numberInt": "0"
                 }
             }
         }
@@ -823,6 +1009,37 @@ enum Pipelines: string
                         },
                         "input": "$score"
                     }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/ne/#example
+     */
+    case NeExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "qty": {
+                    "$numberInt": "1"
+                },
+                "qtyNe250": {
+                    "$ne": [
+                        "$qty",
+                        {
+                            "$numberInt": "250"
+                        }
+                    ]
+                },
+                "_id": {
+                    "$numberInt": "0"
                 }
             }
         }


### PR DESCRIPTION
Fix [PHPLIB-1346](https://jira.mongodb.org/browse/PHPLIB-1346)

All the same examples.

https://www.mongodb.com/docs/manual/reference/operator/aggregation/#comparison-expression-operators

- `$cmp`
- `$eq`
- `$gt`
- `$gte`
- `$lt`
- `$lte`
- `$ne`