### PR TITLE
PHPLIB-1359 Add tests on Accumulators ($group, $bucket, $bucketAuto, $setWindowFields)

### DIFF
--- a/generator/config/accumulator/avg.yaml
+++ b/generator/config/accumulator/avg.yaml
@@ -13,3 +13,33 @@ arguments:
         name: expression
         type:
             - resolvesToNumber
+tests:
+    -
+        name: 'Use in $group Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/avg/#use-in--group-stage'
+        pipeline:
+            - $group:
+                    _id: '$item'
+                    avgAmount:
+                        $avg:
+                            $multiply:
+                                - '$price'
+                                - '$quantity'
+                    avgQuantity:
+                        $avg: '$quantity'
+    -
+        name: 'Use in $setWindowFields Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/avg/#use-in--setwindowfields-stage'
+        pipeline:
+            -
+                $setWindowFields:
+                    partitionBy: '$state'
+                    sortBy:
+                        orderDate: 1
+                    output:
+                        averageQuantityForState:
+                            $avg: '$quantity'
+                            window:
+                                documents:
+                                    - 'unbounded'
+                                    - 'current'

--- a/generator/config/accumulator/bottom.yaml
+++ b/generator/config/accumulator/bottom.yaml
@@ -21,3 +21,35 @@ arguments:
             - expression
         description: |
             Represents the output for each element in the group and can be any expression.
+tests:
+    -
+        name: 'Find the Bottom Score'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottom/#find-the-bottom-score'
+        pipeline:
+            -
+                $match:
+                    gameId: 'G1'
+            -
+                $group:
+                    _id: '$gameId'
+                    playerId:
+                        $bottom:
+                            output:
+                                - '$playerId'
+                                - '$score'
+                            sortBy:
+                                score: -1
+    -
+        name: 'Finding the Bottom Score Across Multiple Games'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottom/#finding-the-bottom-score-across-multiple-games'
+        pipeline:
+            -
+                $group:
+                    _id: '$gameId'
+                    playerId:
+                        $bottom:
+                            output:
+                                - '$playerId'
+                                - '$score'
+                            sortBy:
+                                score: -1

--- a/generator/config/accumulator/bottomN.yaml
+++ b/generator/config/accumulator/bottomN.yaml
@@ -28,3 +28,58 @@ arguments:
             - expression
         description: |
             Represents the output for each element in the group and can be any expression.
+tests:
+    -
+        name: 'Find the Three Lowest Scores'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottomN/#find-the-three-lowest-scores'
+        pipeline:
+            -
+                $match:
+                    gameId: 'G1'
+            -
+                $group:
+                    _id: '$gameId'
+                    playerId:
+                        $bottomN:
+                            output:
+                                - '$playerId'
+                                - '$score'
+                            sortBy:
+                                score: -1
+                            n: 3
+    -
+        name: 'Finding the Three Lowest Score Documents Across Multiple Games'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottomN/#finding-the-three-lowest-score-documents-across-multiple-games'
+        pipeline:
+            -
+                $group:
+                    _id: '$gameId'
+                    playerId:
+                        $bottomN:
+                            output:
+                                - '$playerId'
+                                - '$score'
+                            sortBy:
+                                score: -1
+                            n: 3
+    -
+        name: 'Computing n Based on the Group Key for $group'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottomN/#computing-n-based-on-the-group-key-for--group'
+        pipeline:
+            -
+                $group:
+                    _id:
+                        gameId: '$gameId'
+                    gamescores:
+                        $bottomN:
+                            output: '$score'
+                            n:
+                                $cond:
+                                    if:
+                                        $eq:
+                                            - '$gameId'
+                                            - 'G2'
+                                    then: 1
+                                    else: 3
+                            sortBy:
+                                score: -1

--- a/generator/config/accumulator/count.yaml
+++ b/generator/config/accumulator/count.yaml
@@ -9,3 +9,29 @@ description: |
     Returns the number of documents in the group or window.
     Distinct from the $count pipeline stage.
     New in MongoDB 5.0.
+tests:
+    -
+        name: 'Use in $group Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/count-accumulator/#use-in--group-stage'
+        pipeline:
+            -
+                $group:
+                    _id: '$state'
+                    countNumberOfDocumentsForState:
+                        $count: {}
+    -
+        name: 'Use in $setWindowFields Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/count-accumulator/#use-in--setwindowfields-stage'
+        pipeline:
+            -
+                $setWindowFields:
+                    partitionBy: '$state'
+                    sortBy:
+                        orderDate: 1
+                    output:
+                        countNumberOfDocumentsForState:
+                            $count: {}
+                            window:
+                                documents:
+                                    - 'unbounded'
+                                    - 'current'

--- a/generator/config/accumulator/firstN.yaml
+++ b/generator/config/accumulator/firstN.yaml
@@ -55,3 +55,68 @@ tests:
                         $firstN:
                             input: '$score'
                             n: 5
+    -
+        name: 'Find the First Three Player Scores for a Single Game'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/firstN/#find-the-first-three-player-scores-for-a-single-game'
+        pipeline:
+            -
+                $match:
+                    gameId: 'G1'
+            -
+                $group:
+                    _id: '$gameId'
+                    firstThreeScores:
+                        $firstN:
+                            input:
+                                - '$playerId'
+                                - '$score'
+                            n: 3
+    -
+        name: 'Finding the First Three Player Scores Across Multiple Games'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/firstN/#finding-the-first-three-player-scores-across-multiple-games'
+        pipeline:
+            -
+                $group:
+                    _id: '$gameId'
+                    playerId:
+                        $firstN:
+                            input:
+                                - '$playerId'
+                                - '$score'
+                            n: 3
+    -
+        name: 'Using $sort With $firstN'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/firstN/#using--sort-with--firstn'
+        pipeline:
+            -
+                $sort:
+                    score: -1
+            -
+                $group:
+                    _id: '$gameId'
+                    playerId:
+                        $firstN:
+                            input:
+                                - '$playerId'
+                                - '$score'
+                            n: 3
+    -
+        name: 'Computing n Based on the Group Key for $group'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/firstN/#computing-n-based-on-the-group-key-for--group'
+        pipeline:
+            -
+                $group:
+                    _id:
+                        gameId: '$gameId'
+                    gamescores:
+                        $firstN:
+                            input: '$score'
+                            n:
+                                $cond:
+                                    if:
+                                        $eq:
+                                            - '$gameId'
+                                            - 'G2'
+                                    then: 1
+                                    else: 3
+

--- a/generator/config/accumulator/max.yaml
+++ b/generator/config/accumulator/max.yaml
@@ -13,3 +13,34 @@ arguments:
         name: expression
         type:
             - expression
+tests:
+    -
+        name: 'Use in $group Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/max/#use-in--group-stage'
+        pipeline:
+            -
+                $group:
+                    _id: '$item'
+                    maxTotalAmount:
+                        $max:
+                            $multiply:
+                                - '$price'
+                                - '$quantity'
+                    maxQuantity:
+                        $max: '$quantity'
+    -
+        name: 'Use in $setWindowFields Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/max/#use-in--setwindowfields-stage'
+        pipeline:
+            -
+                $setWindowFields:
+                    partitionBy: '$state'
+                    sortBy:
+                        orderDate: 1
+                    output:
+                        maximumQuantityForState:
+                            $max: '$quantity'
+                            window:
+                                documents:
+                                    - 'unbounded'
+                                    - 'current'

--- a/generator/config/accumulator/maxN.yaml
+++ b/generator/config/accumulator/maxN.yaml
@@ -20,3 +20,54 @@ arguments:
             - resolvesToInt
         description: |
             An expression that resolves to a positive integer. The integer specifies the number of array elements that $maxN returns.
+tests:
+    -
+        name: 'Find the Maximum Three Scores for a Single Game'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/maxN/#find-the-maximum-three-scores-for-a-single-game'
+        pipeline:
+            -
+                $match:
+                    gameId: 'G1'
+            -
+                $group:
+                    _id: '$gameId'
+                    maxThreeScores:
+                        $maxN:
+                            input:
+                                - '$score'
+                                - '$playerId'
+                            n: 3
+    -
+        name: 'Finding the Maximum Three Scores Across Multiple Games'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/maxN/#finding-the-maximum-three-scores-across-multiple-games'
+        pipeline:
+            -
+                $group:
+                    _id: '$gameId'
+                    maxScores:
+                        $maxN:
+                            input:
+                                - '$score'
+                                - '$playerId'
+                            n: 3
+    -
+        name: 'Computing n Based on the Group Key for $group'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/maxN/#computing-n-based-on-the-group-key-for--group'
+        pipeline:
+            -
+                $group:
+                    _id:
+                        gameId: '$gameId'
+                    gamescores:
+                        $maxN:
+                            input:
+                                - '$score'
+                                - '$playerId'
+                            n:
+                                $cond:
+                                    if:
+                                        $eq:
+                                            - '$gameId'
+                                            - 'G2'
+                                    then: 1
+                                    else: 3

--- a/generator/config/accumulator/median.yaml
+++ b/generator/config/accumulator/median.yaml
@@ -25,3 +25,37 @@ arguments:
             - string # AccumulatorPercentile
         description: |
             The method that mongod uses to calculate the 50th percentile value. The method must be 'approximate'.
+tests:
+    -
+        name: 'Use $median as an Accumulator'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/median/#use-operatorname-as-an-accumulator'
+        pipeline:
+            -
+                $group:
+                    _id: ~
+                    test01_median:
+                        $median:
+                            input: '$test01'
+                            method: 'approximate'
+    -
+        name: 'Use $median in a $setWindowField Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/median/#use-operatorname-in-a--setwindowfield-stage'
+        pipeline:
+            -
+                $setWindowFields:
+                    sortBy:
+                        test01: 1
+                    output:
+                        test01_median:
+                            $median:
+                                input: '$test01'
+                                method: 'approximate'
+                            window:
+                                range:
+                                    - -3
+                                    - 3
+            -
+                $project:
+                    _id: 0
+                    studentId: 1
+                    test01_median: 1

--- a/generator/config/accumulator/mergeObjects.yaml
+++ b/generator/config/accumulator/mergeObjects.yaml
@@ -11,6 +11,15 @@ arguments:
         name: document
         type:
             - resolvesToObject
-        variadic: array
         description: |
             Any valid expression that resolves to a document.
+tests:
+    -
+        name: '$mergeObjects as an Accumulator'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/mergeObjects/#-mergeobjects-as-an-accumulator'
+        pipeline:
+            -
+                $group:
+                    _id: '$item'
+                    mergedSales:
+                        $mergeObjects: '$quantity'

--- a/generator/config/accumulator/min.yaml
+++ b/generator/config/accumulator/min.yaml
@@ -13,3 +13,29 @@ arguments:
         name: expression
         type:
             - expression
+tests:
+    -
+        name: 'Use in $group Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/min/#use-in--group-stage'
+        pipeline:
+            -
+                $group:
+                    _id: '$item'
+                    minQuantity:
+                        $min: '$quantity'
+    -
+        name: 'Use in $setWindowFields Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/min/#use-in--setwindowfields-stage'
+        pipeline:
+            -
+                $setWindowFields:
+                    partitionBy: '$state'
+                    sortBy:
+                        orderDate: 1
+                    output:
+                        minimumQuantityForState:
+                            $min: '$quantity'
+                            window:
+                                documents:
+                                    - 'unbounded'
+                                    - 'current'

--- a/generator/config/accumulator/percentile.yaml
+++ b/generator/config/accumulator/percentile.yaml
@@ -35,3 +35,68 @@ arguments:
             - string # AccumulatorPercentile
         description: |
             The method that mongod uses to calculate the percentile value. The method must be 'approximate'.
+tests:
+    -
+        name: 'Calculate a Single Value as an Accumulator'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/percentile/#calculate-a-single-value-as-an-accumulator'
+        pipeline:
+            -
+                $group:
+                    _id: ~
+                    test01_percentiles:
+                        $percentile:
+                            input: '$test01'
+                            p:
+                                - 0.95
+                            method: 'approximate'
+    -
+        name: 'Calculate Multiple Values as an Accumulator'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/percentile/#calculate-multiple-values-as-an-accumulator'
+        pipeline:
+            -
+                $group:
+                    _id: ~
+                    test01_percentiles:
+                        $percentile:
+                            input: '$test01'
+                            p: [0.5, 0.75, 0.9, 0.95]
+                            method: 'approximate'
+                    test02_percentiles:
+                        $percentile:
+                            input: '$test02'
+                            p: [0.5, 0.75, 0.9, 0.95]
+                            method: 'approximate'
+                    test03_percentiles:
+                        $percentile:
+                            input: '$test03'
+                            p: [0.5, 0.75, 0.9, 0.95]
+                            method: 'approximate'
+                    test03_percent_alt:
+                        $percentile:
+                            input: '$test03'
+                            p: [0.9, 0.5, 0.75, 0.95]
+                            method: 'approximate'
+    -
+        name: 'Use $percentile in a $setWindowField Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/percentile/#use-operatorname-in-a--setwindowfield-stage'
+        pipeline:
+            -
+                $setWindowFields:
+                    sortBy:
+                        test01: 1
+                    output:
+                        test01_95percentile:
+                            $percentile:
+                                input: '$test01'
+                                p:
+                                    - 0.95
+                                method: 'approximate'
+                            window:
+                                range:
+                                    - -3
+                                    - 3
+            -
+                $project:
+                    _id: 0
+                    studentId: 1
+                    test01_95percentile: 1

--- a/generator/config/accumulator/push.yaml
+++ b/generator/config/accumulator/push.yaml
@@ -13,3 +13,41 @@ arguments:
         name: expression
         type:
             - expression
+tests:
+    -
+        name: 'Use in $group Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/push/#use-in--group-stage'
+        pipeline:
+            -
+                $sort:
+                    date: 1
+                    item: 1
+            -
+                $group:
+                    _id:
+                        day:
+                            # $dayOfYear: '$date'
+                            $dayOfYear:
+                                date: '$date'
+                        year:
+                            # $year: '$date'
+                            $year:
+                                date: '$date'
+                    itemsSold:
+                        $push:
+                            item: '$item'
+                            quantity: '$quantity'
+    -
+        name: 'Use in $setWindowFields Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/push/#use-in--setwindowfields-stage'
+        pipeline:
+            -
+                $setWindowFields:
+                    partitionBy: '$state'
+                    sortBy:
+                        orderDate: 1
+                    output:
+                        quantitiesForState:
+                            $push: '$quantity'
+                            window:
+                                documents: ['unbounded', 'current']

--- a/generator/config/accumulator/stdDevPop.yaml
+++ b/generator/config/accumulator/stdDevPop.yaml
@@ -3,6 +3,7 @@ name: $stdDevPop
 link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/stdDevPop/'
 type:
     - accumulator
+    - window
 encode: single
 description: |
     Calculates the population standard deviation of the input values. Use if the values encompass the entire population of data you want to represent and do not wish to generalize about a larger population. $stdDevPop ignores non-numeric values.
@@ -13,3 +14,27 @@ arguments:
         name: expression
         type:
             - resolvesToNumber
+tests:
+    -
+        name: 'Use in $group Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/stdDevPop/#use-in--group-stage'
+        pipeline:
+            -
+                $group:
+                    _id: '$quiz'
+                    stdDev:
+                        $stdDevPop: '$score'
+    -
+        name: 'Use in $setWindowFields Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/stdDevPop/#use-in--setwindowfields-stage'
+        pipeline:
+            -
+                $setWindowFields:
+                    partitionBy: '$state'
+                    sortBy:
+                        orderDate: 1
+                    output:
+                        stdDevPopQuantityForState:
+                            $stdDevPop: '$quantity'
+                            window:
+                                documents: ['unbounded', 'current']

--- a/generator/config/accumulator/stdDevSamp.yaml
+++ b/generator/config/accumulator/stdDevSamp.yaml
@@ -3,6 +3,7 @@ name: $stdDevSamp
 link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/stdDevSamp/'
 type:
     - accumulator
+    - window
 encode: single
 description: |
     Calculates the sample standard deviation of the input values. Use if the values encompass a sample of a population of data from which to generalize about the population. $stdDevSamp ignores non-numeric values.
@@ -13,3 +14,30 @@ arguments:
         name: expression
         type:
             - resolvesToNumber
+tests:
+    -
+        name: 'Use in $group Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/stdDevSamp/#use-in--group-stage'
+        pipeline:
+            -
+                $sample:
+                    size: 100
+            -
+                $group:
+                    _id: ~
+                    ageStdDev:
+                        $stdDevSamp: '$age'
+    -
+        name: 'Use in $setWindowFields Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/stdDevSamp/#use-in--setwindowfields-stage'
+        pipeline:
+            -
+                $setWindowFields:
+                    partitionBy: '$state'
+                    sortBy:
+                        orderDate: 1
+                    output:
+                        stdDevSampQuantityForState:
+                            $stdDevSamp: '$quantity'
+                            window:
+                                documents: ['unbounded', 'current']

--- a/generator/config/accumulator/sum.yaml
+++ b/generator/config/accumulator/sum.yaml
@@ -13,3 +13,42 @@ arguments:
         name: expression
         type:
             - resolvesToNumber
+tests:
+    -
+        name: 'Use in $group Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/sum/#use-in--group-stage'
+        pipeline:
+            -
+                $group:
+                    _id:
+                        day:
+                            # $dayOfYear: '$date'
+                            $dayOfYear:
+                                date: '$date'
+                        year:
+                            # $year: '$date'
+                            $year:
+                                date: '$date'
+                    totalAmount:
+                        $sum:
+                            $multiply:
+                                - '$price'
+                                - '$quantity'
+                    count:
+                        $sum: 1
+    -
+        name: 'Use in $setWindowFields Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/sum/#use-in--setwindowfields-stage'
+        pipeline:
+            -
+                $setWindowFields:
+                    partitionBy: '$state'
+                    sortBy:
+                        orderDate: 1
+                    output:
+                        sumQuantityForState:
+                            $sum: '$quantity'
+                            window:
+                                documents:
+                                    - 'unbounded'
+                                    - 'current'

--- a/generator/config/accumulator/top.yaml
+++ b/generator/config/accumulator/top.yaml
@@ -22,3 +22,35 @@ arguments:
             - expression
         description: |
             Represents the output for each element in the group and can be any expression.
+tests:
+    -
+        name: 'Find the Top Score'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/top/#find-the-top-score'
+        pipeline:
+            -
+                $match:
+                    gameId: 'G1'
+            -
+                $group:
+                    _id: '$gameId'
+                    playerId:
+                        $top:
+                            output:
+                                - '$playerId'
+                                - '$score'
+                            sortBy:
+                                score: -1
+    -
+        name: 'Find the Top Score Across Multiple Games'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/top/#find-the-top-score-across-multiple-games'
+        pipeline:
+            -
+                $group:
+                    _id: '$gameId'
+                    playerId:
+                        $top:
+                            output:
+                                - '$playerId'
+                                - '$score'
+                            sortBy:
+                                score: -1

--- a/generator/config/accumulator/topN.yaml
+++ b/generator/config/accumulator/topN.yaml
@@ -28,3 +28,58 @@ arguments:
             - expression
         description: |
             Represents the output for each element in the group and can be any expression.
+tests:
+    -
+        name: 'Find the Three Highest Scores'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/topN/#find-the-three-highest-scores'
+        pipeline:
+            -
+                $match:
+                    gameId: 'G1'
+            -
+                $group:
+                    _id: '$gameId'
+                    playerId:
+                        $topN:
+                            output:
+                                - '$playerId'
+                                - '$score'
+                            sortBy:
+                                score: -1
+                            n: 3
+    -
+        name: 'Finding the Three Highest Score Documents Across Multiple Games'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/topN/#finding-the-three-highest-score-documents-across-multiple-games'
+        pipeline:
+            -
+                $group:
+                    _id: '$gameId'
+                    playerId:
+                        $topN:
+                            output:
+                                - '$playerId'
+                                - '$score'
+                            sortBy:
+                                score: -1
+                            n: 3
+    -
+        name: 'Computing n Based on the Group Key for $group'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/topN/#computing-n-based-on-the-group-key-for--group'
+        pipeline:
+            -
+                $group:
+                    _id:
+                        gameId: '$gameId'
+                    gamescores:
+                        $topN:
+                            output: '$score'
+                            n:
+                                $cond:
+                                    if:
+                                        $eq:
+                                            - '$gameId'
+                                            - 'G2'
+                                    then: 1
+                                    else: 3
+                            sortBy:
+                                score: -1

--- a/generator/config/expression/avg.yaml
+++ b/generator/config/expression/avg.yaml
@@ -13,3 +13,22 @@ arguments:
         type:
             - resolvesToNumber
         variadic: array
+tests:
+    -
+        name: 'Use in $project Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/avg/#use-in--project-stage'
+        pipeline:
+            -
+                $project:
+                    quizAvg:
+                        # $avg: '$quizzes'
+                        $avg:
+                            - '$quizzes'
+                    labAvg:
+                        # $avg: '$labs'
+                        $avg:
+                            - '$labs'
+                    examAvg:
+                        $avg:
+                            - '$final'
+                            - '$midterm'

--- a/generator/config/expression/firstN.yaml
+++ b/generator/config/expression/firstN.yaml
@@ -22,8 +22,8 @@ arguments:
 
 tests:
     -
-        name: Example
-        link: https://www.mongodb.com/docs/manual/reference/operator/aggregation/firstN-array-element/#example
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/firstN-array-element/#example'
         pipeline:
             -
                 $addFields:
@@ -31,3 +31,17 @@ tests:
                         $firstN:
                             n: 3
                             input: '$score'
+    -
+        name: 'Using $firstN as an Aggregation Expression'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/firstN/#using--firstn-as-an-aggregation-expression'
+        pipeline:
+            -
+                $documents:
+                    -
+                        array: [10, 20, 30, 40]
+            -
+                $project:
+                    firstThreeElements:
+                        $firstN:
+                            input: '$array'
+                            n: 3

--- a/generator/config/expression/max.yaml
+++ b/generator/config/expression/max.yaml
@@ -13,3 +13,22 @@ arguments:
         type:
             - expression
         variadic: array
+tests:
+    -
+        name: 'Use in $project Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/max/#use-in--project-stage'
+        pipeline:
+            -
+                $project:
+                    quizMax:
+                        # $max: '$quizzes'
+                        $max:
+                            - '$quizzes'
+                    labMax:
+                        # $max: '$labs'
+                        $max:
+                            - '$labs'
+                    examMax:
+                        $max:
+                            - '$final'
+                            - '$midterm'

--- a/generator/config/expression/median.yaml
+++ b/generator/config/expression/median.yaml
@@ -16,6 +16,7 @@ arguments:
         name: input
         type:
             - resolvesToNumber
+            - array # of number
         description: |
             $median calculates the 50th percentile value of this data. input must be a field name or an expression that evaluates to a numeric type. If the expression cannot be converted to a numeric type, the $median calculation ignores it.
     -
@@ -24,3 +25,19 @@ arguments:
             - string # AccumulatorPercentile
         description: |
             The method that mongod uses to calculate the 50th percentile value. The method must be 'approximate'.
+tests:
+    -
+        name: 'Use $median in a $project Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/median/#use-operatorname-in-a--project-stage'
+        pipeline:
+            -
+                $project:
+                    _id: 0
+                    studentId: 1
+                    testMedians:
+                        $median:
+                            input:
+                                - '$test01'
+                                - '$test02'
+                                - '$test03'
+                            method: 'approximate'

--- a/generator/config/expression/min.yaml
+++ b/generator/config/expression/min.yaml
@@ -13,3 +13,22 @@ arguments:
         type:
             - expression
         variadic: array
+tests:
+    -
+        name: 'Use in $project Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/min/#use-in--project-stage'
+        pipeline:
+            -
+                $project:
+                    quizMin:
+                        # $min: '$quizzes'
+                        $min:
+                            - '$quizzes'
+                    labMin:
+                        # $min: '$labs'
+                        $min:
+                            - '$labs'
+                    examMin:
+                        $min:
+                            - '$final'
+                            - '$midterm'

--- a/generator/config/expression/percentile.yaml
+++ b/generator/config/expression/percentile.yaml
@@ -19,6 +19,7 @@ arguments:
         name: input
         type:
             - resolvesToNumber
+            - array # of number
         description: |
             $percentile calculates the percentile values of this data. input must be a field name or an expression that evaluates to a numeric type. If the expression cannot be converted to a numeric type, the $percentile calculation ignores it.
     -
@@ -34,3 +35,17 @@ arguments:
             - string # AccumulatorPercentile
         description: |
             The method that mongod uses to calculate the percentile value. The method must be 'approximate'.
+tests:
+    -
+        name: 'Use $percentile in a $project Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/percentile/#use-operatorname-in-a--project-stage'
+        pipeline:
+            -
+                $project:
+                    _id: 0
+                    studentId: 1
+                    testPercentiles:
+                        $percentile:
+                            input: ['$test01', '$test02', '$test03']
+                            p: [0.5, 0.95]
+                            method: 'approximate'

--- a/generator/config/expression/stdDevPop.yaml
+++ b/generator/config/expression/stdDevPop.yaml
@@ -14,3 +14,13 @@ arguments:
         type:
             - resolvesToNumber
         variadic: array
+tests:
+    -
+        name: 'Use in $project Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/stdDevPop/#use-in--project-stage'
+        pipeline:
+            -
+                $project:
+                    stdDev:
+                        # $stdDevPop: '$scores.score'
+                        $stdDevPop: ['$scores.score']

--- a/generator/config/expression/sum.yaml
+++ b/generator/config/expression/sum.yaml
@@ -13,3 +13,22 @@ arguments:
         type:
             - resolvesToNumber
         variadic: array
+tests:
+    -
+        name: 'Use in $project Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/sum/#use-in--project-stage'
+        pipeline:
+            -
+                $project:
+                    quizTotal:
+                        # $sum: '$quizzes'
+                        $sum:
+                            - '$quizzes'
+                    labTotal:
+                        # $sum: '$labs'
+                        $sum:
+                            - '$labs'
+                    examTotal:
+                        $sum:
+                            - '$final'
+                            - '$midterm'

--- a/generator/config/stage/setWindowFields.yaml
+++ b/generator/config/stage/setWindowFields.yaml
@@ -9,12 +9,6 @@ description: |
     New in MongoDB 5.0.
 arguments:
     -
-        name: partitionBy
-        type:
-            - expression
-        description: |
-            Specifies an expression to group the documents. In the $setWindowFields stage, the group of documents is known as a partition. Default is one partition for the entire collection.
-    -
         name: sortBy
         type:
             - object # SortSpec
@@ -27,3 +21,10 @@ arguments:
         description: |
             Specifies the field(s) to append to the documents in the output returned by the $setWindowFields stage. Each field is set to the result returned by the window operator.
             A field can contain dots to specify embedded document fields and array fields. The semantics for the embedded document dotted notation in the $setWindowFields stage are the same as the $addFields and $set stages.
+    -
+        name: partitionBy
+        type:
+            - expression
+        description: |
+            Specifies an expression to group the documents. In the $setWindowFields stage, the group of documents is known as a partition. Default is one partition for the entire collection.
+        optional: true

--- a/generator/src/Definition/OperatorDefinition.php
+++ b/generator/src/Definition/OperatorDefinition.php
@@ -12,6 +12,7 @@ use function array_merge;
 use function array_values;
 use function assert;
 use function count;
+use function get_object_vars;
 use function sprintf;
 
 final class OperatorDefinition
@@ -47,7 +48,7 @@ final class OperatorDefinition
         // Optional arguments must be after required arguments
         $requiredArgs = $optionalArgs = [];
         foreach ($arguments as $arg) {
-            $arg = new ArgumentDefinition(...$arg);
+            $arg = new ArgumentDefinition(...get_object_vars($arg));
             if ($arg->optional) {
                 $optionalArgs[] = $arg;
             } else {
@@ -63,6 +64,9 @@ final class OperatorDefinition
 
         $this->arguments = array_merge($requiredArgs, $optionalArgs);
 
-        $this->tests = array_map(static fn (array $test): TestDefinition => new TestDefinition(...$test), array_values($tests));
+        $this->tests = array_map(
+            static fn (object $test): TestDefinition => new TestDefinition(...get_object_vars($test)),
+            array_values($tests),
+        );
     }
 }

--- a/generator/src/Definition/YamlReader.php
+++ b/generator/src/Definition/YamlReader.php
@@ -7,8 +7,7 @@ namespace MongoDB\CodeGenerator\Definition;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
 
-use function assert;
-use function is_array;
+use function get_object_vars;
 
 final class YamlReader
 {
@@ -20,9 +19,8 @@ final class YamlReader
 
         $definitions = [];
         foreach ($finder as $file) {
-            $operator = Yaml::parseFile($file->getPathname());
-            assert(is_array($operator));
-            $definitions[] = new OperatorDefinition(...$operator);
+            $operator = Yaml::parseFile($file->getPathname(), Yaml::PARSE_OBJECT | Yaml::PARSE_OBJECT_FOR_MAP);
+            $definitions[] = new OperatorDefinition(...get_object_vars($operator));
         }
 
         return $definitions;

--- a/src/Builder/Accumulator/FactoryTrait.php
+++ b/src/Builder/Accumulator/FactoryTrait.php
@@ -337,14 +337,13 @@ trait FactoryTrait
      * Combines multiple documents into a single document.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/mergeObjects/
-     * @no-named-arguments
-     * @param Document|ResolvesToObject|Serializable|array|stdClass ...$document Any valid expression that resolves to a document.
+     * @param Document|ResolvesToObject|Serializable|array|stdClass $document Any valid expression that resolves to a document.
      */
     public static function mergeObjects(
-        Document|Serializable|ResolvesToObject|stdClass|array ...$document,
+        Document|Serializable|ResolvesToObject|stdClass|array $document,
     ): MergeObjectsAccumulator
     {
-        return new MergeObjectsAccumulator(...$document);
+        return new MergeObjectsAccumulator($document);
     }
 
     /**

--- a/src/Builder/Accumulator/MergeObjectsAccumulator.php
+++ b/src/Builder/Accumulator/MergeObjectsAccumulator.php
@@ -14,10 +14,7 @@ use MongoDB\Builder\Expression\ResolvesToObject;
 use MongoDB\Builder\Type\AccumulatorInterface;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
-use MongoDB\Exception\InvalidArgumentException;
 use stdClass;
-
-use function array_is_list;
 
 /**
  * Combines multiple documents into a single document.
@@ -28,23 +25,14 @@ class MergeObjectsAccumulator implements AccumulatorInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 
-    /** @var list<Document|ResolvesToObject|Serializable|array|stdClass> $document Any valid expression that resolves to a document. */
-    public readonly array $document;
+    /** @var Document|ResolvesToObject|Serializable|array|stdClass $document Any valid expression that resolves to a document. */
+    public readonly Document|Serializable|ResolvesToObject|stdClass|array $document;
 
     /**
-     * @param Document|ResolvesToObject|Serializable|array|stdClass ...$document Any valid expression that resolves to a document.
-     * @no-named-arguments
+     * @param Document|ResolvesToObject|Serializable|array|stdClass $document Any valid expression that resolves to a document.
      */
-    public function __construct(Document|Serializable|ResolvesToObject|stdClass|array ...$document)
+    public function __construct(Document|Serializable|ResolvesToObject|stdClass|array $document)
     {
-        if (\count($document) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $document, got %d.', 1, \count($document)));
-        }
-
-        if (! array_is_list($document)) {
-            throw new InvalidArgumentException('Expected $document arguments to be a list (array), named arguments are not supported');
-        }
-
         $this->document = $document;
     }
 

--- a/src/Builder/Accumulator/StdDevPopAccumulator.php
+++ b/src/Builder/Accumulator/StdDevPopAccumulator.php
@@ -14,6 +14,7 @@ use MongoDB\Builder\Expression\ResolvesToNumber;
 use MongoDB\Builder\Type\AccumulatorInterface;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\WindowInterface;
 
 /**
  * Calculates the population standard deviation of the input values. Use if the values encompass the entire population of data you want to represent and do not wish to generalize about a larger population. $stdDevPop ignores non-numeric values.
@@ -22,7 +23,7 @@ use MongoDB\Builder\Type\OperatorInterface;
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/stdDevPop/
  */
-class StdDevPopAccumulator implements AccumulatorInterface, OperatorInterface
+class StdDevPopAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Accumulator/StdDevSampAccumulator.php
+++ b/src/Builder/Accumulator/StdDevSampAccumulator.php
@@ -14,6 +14,7 @@ use MongoDB\Builder\Expression\ResolvesToNumber;
 use MongoDB\Builder\Type\AccumulatorInterface;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\WindowInterface;
 
 /**
  * Calculates the sample standard deviation of the input values. Use if the values encompass a sample of a population of data from which to generalize about the population. $stdDevSamp ignores non-numeric values.
@@ -22,7 +23,7 @@ use MongoDB\Builder\Type\OperatorInterface;
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/stdDevSamp/
  */
-class StdDevSampAccumulator implements AccumulatorInterface, OperatorInterface
+class StdDevSampAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -1250,10 +1250,13 @@ trait FactoryTrait
      * It is also available as an aggregation expression.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/median/
-     * @param Decimal128|Int64|ResolvesToNumber|float|int $input $median calculates the 50th percentile value of this data. input must be a field name or an expression that evaluates to a numeric type. If the expression cannot be converted to a numeric type, the $median calculation ignores it.
+     * @param BSONArray|Decimal128|Int64|PackedArray|ResolvesToNumber|array|float|int $input $median calculates the 50th percentile value of this data. input must be a field name or an expression that evaluates to a numeric type. If the expression cannot be converted to a numeric type, the $median calculation ignores it.
      * @param non-empty-string $method The method that mongod uses to calculate the 50th percentile value. The method must be 'approximate'.
      */
-    public static function median(Decimal128|Int64|ResolvesToNumber|float|int $input, string $method): MedianOperator
+    public static function median(
+        Decimal128|Int64|PackedArray|ResolvesToNumber|BSONArray|array|float|int $input,
+        string $method,
+    ): MedianOperator
     {
         return new MedianOperator($input, $method);
     }
@@ -1453,13 +1456,13 @@ trait FactoryTrait
      * It is also available as an aggregation expression.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/percentile/
-     * @param Decimal128|Int64|ResolvesToNumber|float|int $input $percentile calculates the percentile values of this data. input must be a field name or an expression that evaluates to a numeric type. If the expression cannot be converted to a numeric type, the $percentile calculation ignores it.
+     * @param BSONArray|Decimal128|Int64|PackedArray|ResolvesToNumber|array|float|int $input $percentile calculates the percentile values of this data. input must be a field name or an expression that evaluates to a numeric type. If the expression cannot be converted to a numeric type, the $percentile calculation ignores it.
      * @param BSONArray|PackedArray|ResolvesToArray|array $p $percentile calculates a percentile value for each element in p. The elements represent percentages and must evaluate to numeric values in the range 0.0 to 1.0, inclusive.
      * $percentile returns results in the same order as the elements in p.
      * @param non-empty-string $method The method that mongod uses to calculate the percentile value. The method must be 'approximate'.
      */
     public static function percentile(
-        Decimal128|Int64|ResolvesToNumber|float|int $input,
+        Decimal128|Int64|PackedArray|ResolvesToNumber|BSONArray|array|float|int $input,
         PackedArray|ResolvesToArray|BSONArray|array $p,
         string $method,
     ): PercentileOperator

--- a/src/Builder/Expression/MedianOperator.php
+++ b/src/Builder/Expression/MedianOperator.php
@@ -10,8 +10,14 @@ namespace MongoDB\Builder\Expression;
 
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Int64;
+use MongoDB\BSON\PackedArray;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Model\BSONArray;
+
+use function array_is_list;
+use function is_array;
 
 /**
  * Returns an approximation of the median, the 50th percentile, as a scalar value.
@@ -27,18 +33,24 @@ class MedianOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
-    /** @var Decimal128|Int64|ResolvesToNumber|float|int $input $median calculates the 50th percentile value of this data. input must be a field name or an expression that evaluates to a numeric type. If the expression cannot be converted to a numeric type, the $median calculation ignores it. */
-    public readonly Decimal128|Int64|ResolvesToNumber|float|int $input;
+    /** @var BSONArray|Decimal128|Int64|PackedArray|ResolvesToNumber|array|float|int $input $median calculates the 50th percentile value of this data. input must be a field name or an expression that evaluates to a numeric type. If the expression cannot be converted to a numeric type, the $median calculation ignores it. */
+    public readonly Decimal128|Int64|PackedArray|ResolvesToNumber|BSONArray|array|float|int $input;
 
     /** @var non-empty-string $method The method that mongod uses to calculate the 50th percentile value. The method must be 'approximate'. */
     public readonly string $method;
 
     /**
-     * @param Decimal128|Int64|ResolvesToNumber|float|int $input $median calculates the 50th percentile value of this data. input must be a field name or an expression that evaluates to a numeric type. If the expression cannot be converted to a numeric type, the $median calculation ignores it.
+     * @param BSONArray|Decimal128|Int64|PackedArray|ResolvesToNumber|array|float|int $input $median calculates the 50th percentile value of this data. input must be a field name or an expression that evaluates to a numeric type. If the expression cannot be converted to a numeric type, the $median calculation ignores it.
      * @param non-empty-string $method The method that mongod uses to calculate the 50th percentile value. The method must be 'approximate'.
      */
-    public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $input, string $method)
-    {
+    public function __construct(
+        Decimal128|Int64|PackedArray|ResolvesToNumber|BSONArray|array|float|int $input,
+        string $method,
+    ) {
+        if (is_array($input) && ! array_is_list($input)) {
+            throw new InvalidArgumentException('Expected $input argument to be a list, got an associative array.');
+        }
+
         $this->input = $input;
         $this->method = $method;
     }

--- a/src/Builder/Expression/PercentileOperator.php
+++ b/src/Builder/Expression/PercentileOperator.php
@@ -36,8 +36,8 @@ class PercentileOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
-    /** @var Decimal128|Int64|ResolvesToNumber|float|int $input $percentile calculates the percentile values of this data. input must be a field name or an expression that evaluates to a numeric type. If the expression cannot be converted to a numeric type, the $percentile calculation ignores it. */
-    public readonly Decimal128|Int64|ResolvesToNumber|float|int $input;
+    /** @var BSONArray|Decimal128|Int64|PackedArray|ResolvesToNumber|array|float|int $input $percentile calculates the percentile values of this data. input must be a field name or an expression that evaluates to a numeric type. If the expression cannot be converted to a numeric type, the $percentile calculation ignores it. */
+    public readonly Decimal128|Int64|PackedArray|ResolvesToNumber|BSONArray|array|float|int $input;
 
     /**
      * @var BSONArray|PackedArray|ResolvesToArray|array $p $percentile calculates a percentile value for each element in p. The elements represent percentages and must evaluate to numeric values in the range 0.0 to 1.0, inclusive.
@@ -49,16 +49,20 @@ class PercentileOperator implements ResolvesToArray, OperatorInterface
     public readonly string $method;
 
     /**
-     * @param Decimal128|Int64|ResolvesToNumber|float|int $input $percentile calculates the percentile values of this data. input must be a field name or an expression that evaluates to a numeric type. If the expression cannot be converted to a numeric type, the $percentile calculation ignores it.
+     * @param BSONArray|Decimal128|Int64|PackedArray|ResolvesToNumber|array|float|int $input $percentile calculates the percentile values of this data. input must be a field name or an expression that evaluates to a numeric type. If the expression cannot be converted to a numeric type, the $percentile calculation ignores it.
      * @param BSONArray|PackedArray|ResolvesToArray|array $p $percentile calculates a percentile value for each element in p. The elements represent percentages and must evaluate to numeric values in the range 0.0 to 1.0, inclusive.
      * $percentile returns results in the same order as the elements in p.
      * @param non-empty-string $method The method that mongod uses to calculate the percentile value. The method must be 'approximate'.
      */
     public function __construct(
-        Decimal128|Int64|ResolvesToNumber|float|int $input,
+        Decimal128|Int64|PackedArray|ResolvesToNumber|BSONArray|array|float|int $input,
         PackedArray|ResolvesToArray|BSONArray|array $p,
         string $method,
     ) {
+        if (is_array($input) && ! array_is_list($input)) {
+            throw new InvalidArgumentException('Expected $input argument to be a list, got an associative array.');
+        }
+
         $this->input = $input;
         if (is_array($p) && ! array_is_list($p)) {
             throw new InvalidArgumentException('Expected $p argument to be a list, got an associative array.');

--- a/src/Builder/Stage/FactoryTrait.php
+++ b/src/Builder/Stage/FactoryTrait.php
@@ -581,18 +581,18 @@ trait FactoryTrait
      * New in MongoDB 5.0.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setWindowFields/
-     * @param ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass $partitionBy Specifies an expression to group the documents. In the $setWindowFields stage, the group of documents is known as a partition. Default is one partition for the entire collection.
      * @param Document|Serializable|array|stdClass $sortBy Specifies the field(s) to sort the documents by in the partition. Uses the same syntax as the $sort stage. Default is no sorting.
      * @param Document|Serializable|array|stdClass $output Specifies the field(s) to append to the documents in the output returned by the $setWindowFields stage. Each field is set to the result returned by the window operator.
      * A field can contain dots to specify embedded document fields and array fields. The semantics for the embedded document dotted notation in the $setWindowFields stage are the same as the $addFields and $set stages.
+     * @param Optional|ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass $partitionBy Specifies an expression to group the documents. In the $setWindowFields stage, the group of documents is known as a partition. Default is one partition for the entire collection.
      */
     public static function setWindowFields(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $partitionBy,
         Document|Serializable|stdClass|array $sortBy,
         Document|Serializable|stdClass|array $output,
+        Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $partitionBy = Optional::Undefined,
     ): SetWindowFieldsStage
     {
-        return new SetWindowFieldsStage($partitionBy, $sortBy, $output);
+        return new SetWindowFieldsStage($sortBy, $output, $partitionBy);
     }
 
     /**

--- a/src/Builder/Stage/SetWindowFieldsStage.php
+++ b/src/Builder/Stage/SetWindowFieldsStage.php
@@ -14,6 +14,7 @@ use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
 use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\Optional;
 use MongoDB\Builder\Type\StageInterface;
 use stdClass;
 
@@ -27,9 +28,6 @@ class SetWindowFieldsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass $partitionBy Specifies an expression to group the documents. In the $setWindowFields stage, the group of documents is known as a partition. Default is one partition for the entire collection. */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $partitionBy;
-
     /** @var Document|Serializable|array|stdClass $sortBy Specifies the field(s) to sort the documents by in the partition. Uses the same syntax as the $sort stage. Default is no sorting. */
     public readonly Document|Serializable|stdClass|array $sortBy;
 
@@ -39,20 +37,23 @@ class SetWindowFieldsStage implements StageInterface, OperatorInterface
      */
     public readonly Document|Serializable|stdClass|array $output;
 
+    /** @var Optional|ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass $partitionBy Specifies an expression to group the documents. In the $setWindowFields stage, the group of documents is known as a partition. Default is one partition for the entire collection. */
+    public readonly Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $partitionBy;
+
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass $partitionBy Specifies an expression to group the documents. In the $setWindowFields stage, the group of documents is known as a partition. Default is one partition for the entire collection.
      * @param Document|Serializable|array|stdClass $sortBy Specifies the field(s) to sort the documents by in the partition. Uses the same syntax as the $sort stage. Default is no sorting.
      * @param Document|Serializable|array|stdClass $output Specifies the field(s) to append to the documents in the output returned by the $setWindowFields stage. Each field is set to the result returned by the window operator.
      * A field can contain dots to specify embedded document fields and array fields. The semantics for the embedded document dotted notation in the $setWindowFields stage are the same as the $addFields and $set stages.
+     * @param Optional|ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass $partitionBy Specifies an expression to group the documents. In the $setWindowFields stage, the group of documents is known as a partition. Default is one partition for the entire collection.
      */
     public function __construct(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $partitionBy,
         Document|Serializable|stdClass|array $sortBy,
         Document|Serializable|stdClass|array $output,
+        Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $partitionBy = Optional::Undefined,
     ) {
-        $this->partitionBy = $partitionBy;
         $this->sortBy = $sortBy;
         $this->output = $output;
+        $this->partitionBy = $partitionBy;
     }
 
     public function getOperator(): string

--- a/tests/Builder/Accumulator/AvgAccumulatorTest.php
+++ b/tests/Builder/Accumulator/AvgAccumulatorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Accumulator;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $avg accumulator
+ */
+class AvgAccumulatorTest extends PipelineTestCase
+{
+    public function testUseInGroupStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: Expression::fieldPath('item'),
+                avgAmount: Accumulator::avg(
+                    Expression::multiply(
+                        Expression::numberFieldPath('price'),
+                        Expression::intFieldPath('quantity'),
+                    ),
+                ),
+                avgQuantity: Accumulator::avg(
+                    Expression::intFieldPath('quantity'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::AvgUseInGroupStage, $pipeline);
+    }
+
+    public function testUseInSetWindowFieldsStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::setWindowFields(
+                partitionBy: Expression::fieldPath('state'),
+                sortBy: object(
+                    orderDate: 1,
+                ),
+                output: object(
+                    averageQuantityForState: Accumulator::outputWindow(
+                        Accumulator::avg(
+                            Expression::intFieldPath('quantity'),
+                        ),
+                        documents: ['unbounded', 'current'],
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::AvgUseInSetWindowFieldsStage, $pipeline);
+    }
+}

--- a/tests/Builder/Accumulator/BottomAccumulatorTest.php
+++ b/tests/Builder/Accumulator/BottomAccumulatorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Accumulator;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $bottom accumulator
+ */
+class BottomAccumulatorTest extends PipelineTestCase
+{
+    public function testFindTheBottomScore(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                gameId: 'G1',
+            ),
+            Stage::group(
+                _id: Expression::fieldPath('gameId'),
+                playerId: Accumulator::bottom(
+                    output: [
+                        Expression::fieldPath('playerId'),
+                        Expression::fieldPath('score'),
+                    ],
+                    sortBy: object(
+                        score: -1,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::BottomFindTheBottomScore, $pipeline);
+    }
+
+    public function testFindingTheBottomScoreAcrossMultipleGames(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: Expression::fieldPath('gameId'),
+                playerId: Accumulator::bottom(
+                    output: [
+                        Expression::fieldPath('playerId'),
+                        Expression::fieldPath('score'),
+                    ],
+                    sortBy: object(
+                        score: -1,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::BottomFindingTheBottomScoreAcrossMultipleGames, $pipeline);
+    }
+}

--- a/tests/Builder/Accumulator/BottomNAccumulatorTest.php
+++ b/tests/Builder/Accumulator/BottomNAccumulatorTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Accumulator;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $bottomN accumulator
+ */
+class BottomNAccumulatorTest extends PipelineTestCase
+{
+    public function testComputingNBasedOnTheGroupKeyForGroup(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: object(
+                    gameId: Expression::fieldPath('gameId'),
+                ),
+                gamescores: Accumulator::bottomN(
+                    output: Expression::fieldPath('score'),
+                    n: Expression::cond(
+                        if: Expression::eq(
+                            Expression::fieldPath('gameId'),
+                            'G2',
+                        ),
+                        then: 1,
+                        else: 3,
+                    ),
+                    sortBy: object(
+                        score: -1,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::BottomNComputingNBasedOnTheGroupKeyForGroup, $pipeline);
+    }
+
+    public function testFindTheThreeLowestScores(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                gameId: 'G1',
+            ),
+            Stage::group(
+                _id: Expression::fieldPath('gameId'),
+                playerId: Accumulator::bottomN(
+                    output: [
+                        Expression::fieldPath('playerId'),
+                        Expression::fieldPath('score'),
+                    ],
+                    sortBy: object(
+                        score: -1,
+                    ),
+                    n: 3,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::BottomNFindTheThreeLowestScores, $pipeline);
+    }
+
+    public function testFindingTheThreeLowestScoreDocumentsAcrossMultipleGames(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: Expression::fieldPath('gameId'),
+                playerId: Accumulator::bottomN(
+                    output: [
+                        Expression::fieldPath('playerId'),
+                        Expression::fieldPath('score'),
+                    ],
+                    sortBy: object(
+                        score: -1,
+                    ),
+                    n: 3,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::BottomNFindingTheThreeLowestScoreDocumentsAcrossMultipleGames, $pipeline);
+    }
+}

--- a/tests/Builder/Accumulator/CountAccumulatorTest.php
+++ b/tests/Builder/Accumulator/CountAccumulatorTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Accumulator;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $count accumulator
+ */
+class CountAccumulatorTest extends PipelineTestCase
+{
+    public function testUseInGroupStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: Expression::fieldPath('state'),
+                countNumberOfDocumentsForState: Accumulator::count(),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::CountUseInGroupStage, $pipeline);
+    }
+
+    public function testUseInSetWindowFieldsStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::setWindowFields(
+                partitionBy: Expression::fieldPath('state'),
+                sortBy: object(
+                    orderDate: 1,
+                ),
+                output: object(
+                    countNumberOfDocumentsForState: Accumulator::outputWindow(
+                        Accumulator::count(),
+                        documents: ['unbounded', 'current'],
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::CountUseInSetWindowFieldsStage, $pipeline);
+    }
+}

--- a/tests/Builder/Accumulator/MaxAccumulatorTest.php
+++ b/tests/Builder/Accumulator/MaxAccumulatorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Accumulator;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $max accumulator
+ */
+class MaxAccumulatorTest extends PipelineTestCase
+{
+    public function testUseInGroupStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: Expression::fieldPath('item'),
+                maxTotalAmount: Accumulator::max(
+                    Expression::multiply(
+                        Expression::numberFieldPath('price'),
+                        Expression::intFieldPath('quantity'),
+                    ),
+                ),
+                maxQuantity: Accumulator::max(
+                    Expression::intFieldPath('quantity'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MaxUseInGroupStage, $pipeline);
+    }
+
+    public function testUseInSetWindowFieldsStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::setWindowFields(
+                partitionBy: Expression::fieldPath('state'),
+                sortBy: object(
+                    orderDate: 1,
+                ),
+                output: object(
+                    maximumQuantityForState: Accumulator::outputWindow(
+                        Accumulator::max(
+                            Expression::intFieldPath('quantity'),
+                        ),
+                        documents: ['unbounded', 'current'],
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MaxUseInSetWindowFieldsStage, $pipeline);
+    }
+}

--- a/tests/Builder/Accumulator/MaxNAccumulatorTest.php
+++ b/tests/Builder/Accumulator/MaxNAccumulatorTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Accumulator;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $maxN accumulator
+ */
+class MaxNAccumulatorTest extends PipelineTestCase
+{
+    public function testComputingNBasedOnTheGroupKeyForGroup(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: object(
+                    gameId: Expression::fieldPath('gameId'),
+                ),
+                gamescores: Accumulator::maxN(
+                    input: [
+                        Expression::fieldPath('score'),
+                        Expression::fieldPath('playerId'),
+                    ],
+                    n: Expression::cond(
+                        if: Expression::eq(
+                            Expression::fieldPath('gameId'),
+                            'G2',
+                        ),
+                        then: 1,
+                        else: 3,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MaxNComputingNBasedOnTheGroupKeyForGroup, $pipeline);
+    }
+
+    public function testFindTheMaximumThreeScoresForASingleGame(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                gameId: 'G1',
+            ),
+            Stage::group(
+                _id: Expression::fieldPath('gameId'),
+                maxThreeScores: Accumulator::maxN(
+                    input: [
+                        Expression::fieldPath('score'),
+                        Expression::fieldPath('playerId'),
+                    ],
+                    n: 3,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MaxNFindTheMaximumThreeScoresForASingleGame, $pipeline);
+    }
+
+    public function testFindingTheMaximumThreeScoresAcrossMultipleGames(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: Expression::fieldPath('gameId'),
+                maxScores: Accumulator::maxN(
+                    input: [
+                        Expression::fieldPath('score'),
+                        Expression::fieldPath('playerId'),
+                    ],
+                    n: 3,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MaxNFindingTheMaximumThreeScoresAcrossMultipleGames, $pipeline);
+    }
+}

--- a/tests/Builder/Accumulator/MedianAccumulatorTest.php
+++ b/tests/Builder/Accumulator/MedianAccumulatorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Accumulator;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $median accumulator
+ */
+class MedianAccumulatorTest extends PipelineTestCase
+{
+    public function testUseMedianAsAnAccumulator(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: null,
+                test01_median: Accumulator::median(
+                    input: Expression::intFieldPath('test01'),
+                    method: 'approximate',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MedianUseMedianAsAnAccumulator, $pipeline);
+    }
+
+    public function testUseMedianInASetWindowFieldStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::setWindowFields(
+                sortBy: object(
+                    test01: 1,
+                ),
+                output: object(
+                    test01_median: Accumulator::outputWindow(
+                        Accumulator::median(
+                            input: Expression::intFieldPath('test01'),
+                            method: 'approximate',
+                        ),
+                        range: [-3, 3],
+                    ),
+                ),
+            ),
+            Stage::project(
+                _id: 0,
+                studentId: 1,
+                test01_median: 1,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MedianUseMedianInASetWindowFieldStage, $pipeline);
+    }
+}

--- a/tests/Builder/Accumulator/MergeObjectsAccumulatorTest.php
+++ b/tests/Builder/Accumulator/MergeObjectsAccumulatorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Accumulator;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $mergeObjects accumulator
+ */
+class MergeObjectsAccumulatorTest extends PipelineTestCase
+{
+    public function testMergeObjectsAsAnAccumulator(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: Expression::fieldPath('item'),
+                mergedSales: Accumulator::mergeObjects(
+                    Expression::fieldPath('quantity'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MergeObjectsMergeObjectsAsAnAccumulator, $pipeline);
+    }
+}

--- a/tests/Builder/Accumulator/MinAccumulatorTest.php
+++ b/tests/Builder/Accumulator/MinAccumulatorTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Accumulator;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $min accumulator
+ */
+class MinAccumulatorTest extends PipelineTestCase
+{
+    public function testUseInGroupStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: Expression::fieldPath('item'),
+                minQuantity: Accumulator::min(
+                    Expression::intFieldPath('quantity'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MinUseInGroupStage, $pipeline);
+    }
+
+    public function testUseInSetWindowFieldsStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::setWindowFields(
+                partitionBy: Expression::fieldPath('state'),
+                sortBy: object(
+                    orderDate: 1,
+                ),
+                output: object(
+                    minimumQuantityForState: Accumulator::outputWindow(
+                        Accumulator::min(
+                            Expression::intFieldPath('quantity'),
+                        ),
+                        documents: ['unbounded', 'current'],
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MinUseInSetWindowFieldsStage, $pipeline);
+    }
+}

--- a/tests/Builder/Accumulator/PercentileAccumulatorTest.php
+++ b/tests/Builder/Accumulator/PercentileAccumulatorTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Accumulator;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $percentile accumulator
+ */
+class PercentileAccumulatorTest extends PipelineTestCase
+{
+    public function testCalculateASingleValueAsAnAccumulator(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: null,
+                test01_percentiles: Accumulator::percentile(
+                    input: Expression::numberFieldPath('test01'),
+                    p: [0.95],
+                    method: 'approximate',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::PercentileCalculateASingleValueAsAnAccumulator, $pipeline);
+    }
+
+    public function testCalculateMultipleValuesAsAnAccumulator(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: null,
+                test01_percentiles: Accumulator::percentile(
+                    input: Expression::numberFieldPath('test01'),
+                    p: [0.5, 0.75, 0.9, 0.95],
+                    method: 'approximate',
+                ),
+                test02_percentiles: Accumulator::percentile(
+                    input: Expression::numberFieldPath('test02'),
+                    p: [0.5, 0.75, 0.9, 0.95],
+                    method: 'approximate',
+                ),
+                test03_percentiles: Accumulator::percentile(
+                    input: Expression::numberFieldPath('test03'),
+                    p: [0.5, 0.75, 0.9, 0.95],
+                    method: 'approximate',
+                ),
+                test03_percent_alt: Accumulator::percentile(
+                    input: Expression::numberFieldPath('test03'),
+                    p: [0.9, 0.5, 0.75, 0.95],
+                    method: 'approximate',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::PercentileCalculateMultipleValuesAsAnAccumulator, $pipeline);
+    }
+
+    public function testUsePercentileInASetWindowFieldStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::setWindowFields(
+                sortBy: object(
+                    test01: 1,
+                ),
+                output: object(
+                    test01_95percentile: Accumulator::outputWindow(
+                        Accumulator::percentile(
+                            input: Expression::numberFieldPath('test01'),
+                            p: [0.95],
+                            method: 'approximate',
+                        ),
+                        range: [-3, 3],
+                    ),
+                ),
+            ),
+            Stage::project(
+                _id: 0,
+                studentId: 1,
+                test01_95percentile: 1,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::PercentileUsePercentileInASetWindowFieldStage, $pipeline);
+    }
+}

--- a/tests/Builder/Accumulator/Pipelines.php
+++ b/tests/Builder/Accumulator/Pipelines.php
@@ -149,6 +149,283 @@ enum Pipelines: string
     /**
      * Use in $group Stage
      *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/avg/#use-in--group-stage
+     */
+    case AvgUseInGroupStage = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": "$item",
+                "avgAmount": {
+                    "$avg": {
+                        "$multiply": [
+                            "$price",
+                            "$quantity"
+                        ]
+                    }
+                },
+                "avgQuantity": {
+                    "$avg": "$quantity"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use in $setWindowFields Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/avg/#use-in--setwindowfields-stage
+     */
+    case AvgUseInSetWindowFieldsStage = <<<'JSON'
+    [
+        {
+            "$setWindowFields": {
+                "partitionBy": "$state",
+                "sortBy": {
+                    "orderDate": {
+                        "$numberInt": "1"
+                    }
+                },
+                "output": {
+                    "averageQuantityForState": {
+                        "$avg": "$quantity",
+                        "window": {
+                            "documents": [
+                                "unbounded",
+                                "current"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Find the Bottom Score
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottom/#find-the-bottom-score
+     */
+    case BottomFindTheBottomScore = <<<'JSON'
+    [
+        {
+            "$match": {
+                "gameId": "G1"
+            }
+        },
+        {
+            "$group": {
+                "_id": "$gameId",
+                "playerId": {
+                    "$bottom": {
+                        "output": [
+                            "$playerId",
+                            "$score"
+                        ],
+                        "sortBy": {
+                            "score": {
+                                "$numberInt": "-1"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Finding the Bottom Score Across Multiple Games
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottom/#finding-the-bottom-score-across-multiple-games
+     */
+    case BottomFindingTheBottomScoreAcrossMultipleGames = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": "$gameId",
+                "playerId": {
+                    "$bottom": {
+                        "output": [
+                            "$playerId",
+                            "$score"
+                        ],
+                        "sortBy": {
+                            "score": {
+                                "$numberInt": "-1"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Find the Three Lowest Scores
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottomN/#find-the-three-lowest-scores
+     */
+    case BottomNFindTheThreeLowestScores = <<<'JSON'
+    [
+        {
+            "$match": {
+                "gameId": "G1"
+            }
+        },
+        {
+            "$group": {
+                "_id": "$gameId",
+                "playerId": {
+                    "$bottomN": {
+                        "output": [
+                            "$playerId",
+                            "$score"
+                        ],
+                        "sortBy": {
+                            "score": {
+                                "$numberInt": "-1"
+                            }
+                        },
+                        "n": {
+                            "$numberInt": "3"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Finding the Three Lowest Score Documents Across Multiple Games
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottomN/#finding-the-three-lowest-score-documents-across-multiple-games
+     */
+    case BottomNFindingTheThreeLowestScoreDocumentsAcrossMultipleGames = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": "$gameId",
+                "playerId": {
+                    "$bottomN": {
+                        "output": [
+                            "$playerId",
+                            "$score"
+                        ],
+                        "sortBy": {
+                            "score": {
+                                "$numberInt": "-1"
+                            }
+                        },
+                        "n": {
+                            "$numberInt": "3"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Computing n Based on the Group Key for $group
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottomN/#computing-n-based-on-the-group-key-for--group
+     */
+    case BottomNComputingNBasedOnTheGroupKeyForGroup = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": {
+                    "gameId": "$gameId"
+                },
+                "gamescores": {
+                    "$bottomN": {
+                        "output": "$score",
+                        "n": {
+                            "$cond": {
+                                "if": {
+                                    "$eq": [
+                                        "$gameId",
+                                        "G2"
+                                    ]
+                                },
+                                "then": {
+                                    "$numberInt": "1"
+                                },
+                                "else": {
+                                    "$numberInt": "3"
+                                }
+                            }
+                        },
+                        "sortBy": {
+                            "score": {
+                                "$numberInt": "-1"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use in $group Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/count-accumulator/#use-in--group-stage
+     */
+    case CountUseInGroupStage = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": "$state",
+                "countNumberOfDocumentsForState": {
+                    "$count": {}
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use in $setWindowFields Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/count-accumulator/#use-in--setwindowfields-stage
+     */
+    case CountUseInSetWindowFieldsStage = <<<'JSON'
+    [
+        {
+            "$setWindowFields": {
+                "partitionBy": "$state",
+                "sortBy": {
+                    "orderDate": {
+                        "$numberInt": "1"
+                    }
+                },
+                "output": {
+                    "countNumberOfDocumentsForState": {
+                        "$count": {},
+                        "window": {
+                            "documents": [
+                                "unbounded",
+                                "current"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use in $group Stage
+     *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/first/#use-in--group-stage
      */
     case FirstUseInGroupStage = <<<'JSON'
@@ -254,6 +531,134 @@ enum Pipelines: string
                         "input": "$score",
                         "n": {
                             "$numberInt": "5"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Find the First Three Player Scores for a Single Game
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/firstN/#find-the-first-three-player-scores-for-a-single-game
+     */
+    case FirstNFindTheFirstThreePlayerScoresForASingleGame = <<<'JSON'
+    [
+        {
+            "$match": {
+                "gameId": "G1"
+            }
+        },
+        {
+            "$group": {
+                "_id": "$gameId",
+                "firstThreeScores": {
+                    "$firstN": {
+                        "input": [
+                            "$playerId",
+                            "$score"
+                        ],
+                        "n": {
+                            "$numberInt": "3"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Finding the First Three Player Scores Across Multiple Games
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/firstN/#finding-the-first-three-player-scores-across-multiple-games
+     */
+    case FirstNFindingTheFirstThreePlayerScoresAcrossMultipleGames = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": "$gameId",
+                "playerId": {
+                    "$firstN": {
+                        "input": [
+                            "$playerId",
+                            "$score"
+                        ],
+                        "n": {
+                            "$numberInt": "3"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Using $sort With $firstN
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/firstN/#using--sort-with--firstn
+     */
+    case FirstNUsingSortWithFirstN = <<<'JSON'
+    [
+        {
+            "$sort": {
+                "score": {
+                    "$numberInt": "-1"
+                }
+            }
+        },
+        {
+            "$group": {
+                "_id": "$gameId",
+                "playerId": {
+                    "$firstN": {
+                        "input": [
+                            "$playerId",
+                            "$score"
+                        ],
+                        "n": {
+                            "$numberInt": "3"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Computing n Based on the Group Key for $group
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/firstN/#computing-n-based-on-the-group-key-for--group
+     */
+    case FirstNComputingNBasedOnTheGroupKeyForGroup = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": {
+                    "gameId": "$gameId"
+                },
+                "gamescores": {
+                    "$firstN": {
+                        "input": "$score",
+                        "n": {
+                            "$cond": {
+                                "if": {
+                                    "$eq": [
+                                        "$gameId",
+                                        "G2"
+                                    ]
+                                },
+                                "then": {
+                                    "$numberInt": "1"
+                                },
+                                "else": {
+                                    "$numberInt": "3"
+                                }
+                            }
                         }
                     }
                 }
@@ -440,6 +845,894 @@ enum Pipelines: string
                                 "else": {
                                     "$numberInt": "3"
                                 }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use in $group Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/max/#use-in--group-stage
+     */
+    case MaxUseInGroupStage = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": "$item",
+                "maxTotalAmount": {
+                    "$max": {
+                        "$multiply": [
+                            "$price",
+                            "$quantity"
+                        ]
+                    }
+                },
+                "maxQuantity": {
+                    "$max": "$quantity"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use in $setWindowFields Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/max/#use-in--setwindowfields-stage
+     */
+    case MaxUseInSetWindowFieldsStage = <<<'JSON'
+    [
+        {
+            "$setWindowFields": {
+                "partitionBy": "$state",
+                "sortBy": {
+                    "orderDate": {
+                        "$numberInt": "1"
+                    }
+                },
+                "output": {
+                    "maximumQuantityForState": {
+                        "$max": "$quantity",
+                        "window": {
+                            "documents": [
+                                "unbounded",
+                                "current"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Find the Maximum Three Scores for a Single Game
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/maxN/#find-the-maximum-three-scores-for-a-single-game
+     */
+    case MaxNFindTheMaximumThreeScoresForASingleGame = <<<'JSON'
+    [
+        {
+            "$match": {
+                "gameId": "G1"
+            }
+        },
+        {
+            "$group": {
+                "_id": "$gameId",
+                "maxThreeScores": {
+                    "$maxN": {
+                        "input": [
+                            "$score",
+                            "$playerId"
+                        ],
+                        "n": {
+                            "$numberInt": "3"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Finding the Maximum Three Scores Across Multiple Games
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/maxN/#finding-the-maximum-three-scores-across-multiple-games
+     */
+    case MaxNFindingTheMaximumThreeScoresAcrossMultipleGames = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": "$gameId",
+                "maxScores": {
+                    "$maxN": {
+                        "input": [
+                            "$score",
+                            "$playerId"
+                        ],
+                        "n": {
+                            "$numberInt": "3"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Computing n Based on the Group Key for $group
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/maxN/#computing-n-based-on-the-group-key-for--group
+     */
+    case MaxNComputingNBasedOnTheGroupKeyForGroup = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": {
+                    "gameId": "$gameId"
+                },
+                "gamescores": {
+                    "$maxN": {
+                        "input": [
+                            "$score",
+                            "$playerId"
+                        ],
+                        "n": {
+                            "$cond": {
+                                "if": {
+                                    "$eq": [
+                                        "$gameId",
+                                        "G2"
+                                    ]
+                                },
+                                "then": {
+                                    "$numberInt": "1"
+                                },
+                                "else": {
+                                    "$numberInt": "3"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use $median as an Accumulator
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/median/#use-operatorname-as-an-accumulator
+     */
+    case MedianUseMedianAsAnAccumulator = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": null,
+                "test01_median": {
+                    "$median": {
+                        "input": "$test01",
+                        "method": "approximate"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use $median in a $setWindowField Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/median/#use-operatorname-in-a--setwindowfield-stage
+     */
+    case MedianUseMedianInASetWindowFieldStage = <<<'JSON'
+    [
+        {
+            "$setWindowFields": {
+                "sortBy": {
+                    "test01": {
+                        "$numberInt": "1"
+                    }
+                },
+                "output": {
+                    "test01_median": {
+                        "$median": {
+                            "input": "$test01",
+                            "method": "approximate"
+                        },
+                        "window": {
+                            "range": [
+                                {
+                                    "$numberInt": "-3"
+                                },
+                                {
+                                    "$numberInt": "3"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "studentId": {
+                    "$numberInt": "1"
+                },
+                "test01_median": {
+                    "$numberInt": "1"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * $mergeObjects as an Accumulator
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/mergeObjects/#-mergeobjects-as-an-accumulator
+     */
+    case MergeObjectsMergeObjectsAsAnAccumulator = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": "$item",
+                "mergedSales": {
+                    "$mergeObjects": "$quantity"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use in $group Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/min/#use-in--group-stage
+     */
+    case MinUseInGroupStage = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": "$item",
+                "minQuantity": {
+                    "$min": "$quantity"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use in $setWindowFields Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/min/#use-in--setwindowfields-stage
+     */
+    case MinUseInSetWindowFieldsStage = <<<'JSON'
+    [
+        {
+            "$setWindowFields": {
+                "partitionBy": "$state",
+                "sortBy": {
+                    "orderDate": {
+                        "$numberInt": "1"
+                    }
+                },
+                "output": {
+                    "minimumQuantityForState": {
+                        "$min": "$quantity",
+                        "window": {
+                            "documents": [
+                                "unbounded",
+                                "current"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Calculate a Single Value as an Accumulator
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/percentile/#calculate-a-single-value-as-an-accumulator
+     */
+    case PercentileCalculateASingleValueAsAnAccumulator = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": null,
+                "test01_percentiles": {
+                    "$percentile": {
+                        "input": "$test01",
+                        "p": [
+                            {
+                                "$numberDouble": "0.94999999999999995559"
+                            }
+                        ],
+                        "method": "approximate"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Calculate Multiple Values as an Accumulator
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/percentile/#calculate-multiple-values-as-an-accumulator
+     */
+    case PercentileCalculateMultipleValuesAsAnAccumulator = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": null,
+                "test01_percentiles": {
+                    "$percentile": {
+                        "input": "$test01",
+                        "p": [
+                            {
+                                "$numberDouble": "0.5"
+                            },
+                            {
+                                "$numberDouble": "0.75"
+                            },
+                            {
+                                "$numberDouble": "0.9000000000000000222"
+                            },
+                            {
+                                "$numberDouble": "0.94999999999999995559"
+                            }
+                        ],
+                        "method": "approximate"
+                    }
+                },
+                "test02_percentiles": {
+                    "$percentile": {
+                        "input": "$test02",
+                        "p": [
+                            {
+                                "$numberDouble": "0.5"
+                            },
+                            {
+                                "$numberDouble": "0.75"
+                            },
+                            {
+                                "$numberDouble": "0.9000000000000000222"
+                            },
+                            {
+                                "$numberDouble": "0.94999999999999995559"
+                            }
+                        ],
+                        "method": "approximate"
+                    }
+                },
+                "test03_percentiles": {
+                    "$percentile": {
+                        "input": "$test03",
+                        "p": [
+                            {
+                                "$numberDouble": "0.5"
+                            },
+                            {
+                                "$numberDouble": "0.75"
+                            },
+                            {
+                                "$numberDouble": "0.9000000000000000222"
+                            },
+                            {
+                                "$numberDouble": "0.94999999999999995559"
+                            }
+                        ],
+                        "method": "approximate"
+                    }
+                },
+                "test03_percent_alt": {
+                    "$percentile": {
+                        "input": "$test03",
+                        "p": [
+                            {
+                                "$numberDouble": "0.9000000000000000222"
+                            },
+                            {
+                                "$numberDouble": "0.5"
+                            },
+                            {
+                                "$numberDouble": "0.75"
+                            },
+                            {
+                                "$numberDouble": "0.94999999999999995559"
+                            }
+                        ],
+                        "method": "approximate"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use $percentile in a $setWindowField Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/percentile/#use-operatorname-in-a--setwindowfield-stage
+     */
+    case PercentileUsePercentileInASetWindowFieldStage = <<<'JSON'
+    [
+        {
+            "$setWindowFields": {
+                "sortBy": {
+                    "test01": {
+                        "$numberInt": "1"
+                    }
+                },
+                "output": {
+                    "test01_95percentile": {
+                        "$percentile": {
+                            "input": "$test01",
+                            "p": [
+                                {
+                                    "$numberDouble": "0.94999999999999995559"
+                                }
+                            ],
+                            "method": "approximate"
+                        },
+                        "window": {
+                            "range": [
+                                {
+                                    "$numberInt": "-3"
+                                },
+                                {
+                                    "$numberInt": "3"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "studentId": {
+                    "$numberInt": "1"
+                },
+                "test01_95percentile": {
+                    "$numberInt": "1"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use in $group Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/push/#use-in--group-stage
+     */
+    case PushUseInGroupStage = <<<'JSON'
+    [
+        {
+            "$sort": {
+                "date": {
+                    "$numberInt": "1"
+                },
+                "item": {
+                    "$numberInt": "1"
+                }
+            }
+        },
+        {
+            "$group": {
+                "_id": {
+                    "day": {
+                        "$dayOfYear": {
+                            "date": "$date"
+                        }
+                    },
+                    "year": {
+                        "$year": {
+                            "date": "$date"
+                        }
+                    }
+                },
+                "itemsSold": {
+                    "$push": {
+                        "item": "$item",
+                        "quantity": "$quantity"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use in $setWindowFields Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/push/#use-in--setwindowfields-stage
+     */
+    case PushUseInSetWindowFieldsStage = <<<'JSON'
+    [
+        {
+            "$setWindowFields": {
+                "partitionBy": "$state",
+                "sortBy": {
+                    "orderDate": {
+                        "$numberInt": "1"
+                    }
+                },
+                "output": {
+                    "quantitiesForState": {
+                        "$push": "$quantity",
+                        "window": {
+                            "documents": [
+                                "unbounded",
+                                "current"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use in $group Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/stdDevPop/#use-in--group-stage
+     */
+    case StdDevPopUseInGroupStage = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": "$quiz",
+                "stdDev": {
+                    "$stdDevPop": "$score"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use in $setWindowFields Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/stdDevPop/#use-in--setwindowfields-stage
+     */
+    case StdDevPopUseInSetWindowFieldsStage = <<<'JSON'
+    [
+        {
+            "$setWindowFields": {
+                "partitionBy": "$state",
+                "sortBy": {
+                    "orderDate": {
+                        "$numberInt": "1"
+                    }
+                },
+                "output": {
+                    "stdDevPopQuantityForState": {
+                        "$stdDevPop": "$quantity",
+                        "window": {
+                            "documents": [
+                                "unbounded",
+                                "current"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use in $group Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/stdDevSamp/#use-in--group-stage
+     */
+    case StdDevSampUseInGroupStage = <<<'JSON'
+    [
+        {
+            "$sample": {
+                "size": {
+                    "$numberInt": "100"
+                }
+            }
+        },
+        {
+            "$group": {
+                "_id": null,
+                "ageStdDev": {
+                    "$stdDevSamp": "$age"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use in $setWindowFields Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/stdDevSamp/#use-in--setwindowfields-stage
+     */
+    case StdDevSampUseInSetWindowFieldsStage = <<<'JSON'
+    [
+        {
+            "$setWindowFields": {
+                "partitionBy": "$state",
+                "sortBy": {
+                    "orderDate": {
+                        "$numberInt": "1"
+                    }
+                },
+                "output": {
+                    "stdDevSampQuantityForState": {
+                        "$stdDevSamp": "$quantity",
+                        "window": {
+                            "documents": [
+                                "unbounded",
+                                "current"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use in $group Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sum/#use-in--group-stage
+     */
+    case SumUseInGroupStage = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": {
+                    "day": {
+                        "$dayOfYear": {
+                            "date": "$date"
+                        }
+                    },
+                    "year": {
+                        "$year": {
+                            "date": "$date"
+                        }
+                    }
+                },
+                "totalAmount": {
+                    "$sum": {
+                        "$multiply": [
+                            "$price",
+                            "$quantity"
+                        ]
+                    }
+                },
+                "count": {
+                    "$sum": {
+                        "$numberInt": "1"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use in $setWindowFields Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sum/#use-in--setwindowfields-stage
+     */
+    case SumUseInSetWindowFieldsStage = <<<'JSON'
+    [
+        {
+            "$setWindowFields": {
+                "partitionBy": "$state",
+                "sortBy": {
+                    "orderDate": {
+                        "$numberInt": "1"
+                    }
+                },
+                "output": {
+                    "sumQuantityForState": {
+                        "$sum": "$quantity",
+                        "window": {
+                            "documents": [
+                                "unbounded",
+                                "current"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Find the Top Score
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/top/#find-the-top-score
+     */
+    case TopFindTheTopScore = <<<'JSON'
+    [
+        {
+            "$match": {
+                "gameId": "G1"
+            }
+        },
+        {
+            "$group": {
+                "_id": "$gameId",
+                "playerId": {
+                    "$top": {
+                        "output": [
+                            "$playerId",
+                            "$score"
+                        ],
+                        "sortBy": {
+                            "score": {
+                                "$numberInt": "-1"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Find the Top Score Across Multiple Games
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/top/#find-the-top-score-across-multiple-games
+     */
+    case TopFindTheTopScoreAcrossMultipleGames = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": "$gameId",
+                "playerId": {
+                    "$top": {
+                        "output": [
+                            "$playerId",
+                            "$score"
+                        ],
+                        "sortBy": {
+                            "score": {
+                                "$numberInt": "-1"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Find the Three Highest Scores
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/topN/#find-the-three-highest-scores
+     */
+    case TopNFindTheThreeHighestScores = <<<'JSON'
+    [
+        {
+            "$match": {
+                "gameId": "G1"
+            }
+        },
+        {
+            "$group": {
+                "_id": "$gameId",
+                "playerId": {
+                    "$topN": {
+                        "output": [
+                            "$playerId",
+                            "$score"
+                        ],
+                        "sortBy": {
+                            "score": {
+                                "$numberInt": "-1"
+                            }
+                        },
+                        "n": {
+                            "$numberInt": "3"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Finding the Three Highest Score Documents Across Multiple Games
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/topN/#finding-the-three-highest-score-documents-across-multiple-games
+     */
+    case TopNFindingTheThreeHighestScoreDocumentsAcrossMultipleGames = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": "$gameId",
+                "playerId": {
+                    "$topN": {
+                        "output": [
+                            "$playerId",
+                            "$score"
+                        ],
+                        "sortBy": {
+                            "score": {
+                                "$numberInt": "-1"
+                            }
+                        },
+                        "n": {
+                            "$numberInt": "3"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Computing n Based on the Group Key for $group
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/topN/#computing-n-based-on-the-group-key-for--group
+     */
+    case TopNComputingNBasedOnTheGroupKeyForGroup = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": {
+                    "gameId": "$gameId"
+                },
+                "gamescores": {
+                    "$topN": {
+                        "output": "$score",
+                        "n": {
+                            "$cond": {
+                                "if": {
+                                    "$eq": [
+                                        "$gameId",
+                                        "G2"
+                                    ]
+                                },
+                                "then": {
+                                    "$numberInt": "1"
+                                },
+                                "else": {
+                                    "$numberInt": "3"
+                                }
+                            }
+                        },
+                        "sortBy": {
+                            "score": {
+                                "$numberInt": "-1"
                             }
                         }
                     }

--- a/tests/Builder/Accumulator/PushAccumulatorTest.php
+++ b/tests/Builder/Accumulator/PushAccumulatorTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Accumulator;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $push accumulator
+ */
+class PushAccumulatorTest extends PipelineTestCase
+{
+    public function testUseInGroupStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::sort(
+                object(
+                    date: 1,
+                    item: 1,
+                ),
+            ),
+            Stage::group(
+                _id: object(
+                    day: Expression::dayOfYear(
+                        Expression::dateFieldPath('date'),
+                    ),
+                    year: Expression::year(
+                        Expression::dateFieldPath('date'),
+                    ),
+                ),
+                itemsSold: Accumulator::push(
+                    object(
+                        item: Expression::fieldPath('item'),
+                        quantity: Expression::intFieldPath('quantity'),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::PushUseInGroupStage, $pipeline);
+    }
+
+    public function testUseInSetWindowFieldsStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::setWindowFields(
+                partitionBy: Expression::fieldPath('state'),
+                sortBy: object(
+                    orderDate: 1,
+                ),
+                output: object(
+                    quantitiesForState: Accumulator::outputWindow(
+                        Accumulator::push(
+                            Expression::numberFieldPath('quantity'),
+                        ),
+                        documents: ['unbounded', 'current'],
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::PushUseInSetWindowFieldsStage, $pipeline);
+    }
+}

--- a/tests/Builder/Accumulator/StdDevPopAccumulatorTest.php
+++ b/tests/Builder/Accumulator/StdDevPopAccumulatorTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Accumulator;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $stdDevPop accumulator
+ */
+class StdDevPopAccumulatorTest extends PipelineTestCase
+{
+    public function testUseInGroupStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: Expression::fieldPath('quiz'),
+                stdDev: Accumulator::stdDevPop(
+                    Expression::numberFieldPath('score'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::StdDevPopUseInGroupStage, $pipeline);
+    }
+
+    public function testUseInSetWindowFieldsStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::setWindowFields(
+                partitionBy: Expression::fieldPath('state'),
+                sortBy: object(
+                    orderDate: 1,
+                ),
+                output: object(
+                    stdDevPopQuantityForState: Accumulator::outputWindow(
+                        Accumulator::stdDevPop(
+                            Expression::numberFieldPath('quantity'),
+                        ),
+                        documents: ['unbounded', 'current'],
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::StdDevPopUseInSetWindowFieldsStage, $pipeline);
+    }
+}

--- a/tests/Builder/Accumulator/StdDevSampAccumulatorTest.php
+++ b/tests/Builder/Accumulator/StdDevSampAccumulatorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Accumulator;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $stdDevSamp accumulator
+ */
+class StdDevSampAccumulatorTest extends PipelineTestCase
+{
+    public function testUseInGroupStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::sample(100),
+            Stage::group(
+                _id: null,
+                ageStdDev: Accumulator::stdDevSamp(
+                    Expression::numberFieldPath('age'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::StdDevSampUseInGroupStage, $pipeline);
+    }
+
+    public function testUseInSetWindowFieldsStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::setWindowFields(
+                partitionBy: Expression::fieldPath('state'),
+                sortBy: object(
+                    orderDate: 1,
+                ),
+                output: object(
+                    stdDevSampQuantityForState: Accumulator::outputWindow(
+                        Accumulator::stdDevSamp(
+                            Expression::numberFieldPath('quantity'),
+                        ),
+                        documents: ['unbounded', 'current'],
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::StdDevSampUseInSetWindowFieldsStage, $pipeline);
+    }
+}

--- a/tests/Builder/Accumulator/SumAccumulatorTest.php
+++ b/tests/Builder/Accumulator/SumAccumulatorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Accumulator;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $sum accumulator
+ */
+class SumAccumulatorTest extends PipelineTestCase
+{
+    public function testUseInGroupStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: object(
+                    day: Expression::dayOfYear(
+                        Expression::dateFieldPath('date'),
+                    ),
+                    year: Expression::year(
+                        Expression::dateFieldPath('date'),
+                    ),
+                ),
+                totalAmount: Accumulator::sum(
+                    Expression::multiply(
+                        Expression::numberFieldPath('price'),
+                        Expression::intFieldPath('quantity'),
+                    ),
+                ),
+                count: Accumulator::sum(1),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SumUseInGroupStage, $pipeline);
+    }
+
+    public function testUseInSetWindowFieldsStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::setWindowFields(
+                partitionBy: Expression::fieldPath('state'),
+                sortBy: object(
+                    orderDate: 1,
+                ),
+                output: object(
+                    sumQuantityForState: Accumulator::outputWindow(
+                        Accumulator::sum(
+                            Expression::intFieldPath('quantity'),
+                        ),
+                        documents: ['unbounded', 'current'],
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SumUseInSetWindowFieldsStage, $pipeline);
+    }
+}

--- a/tests/Builder/Accumulator/TopAccumulatorTest.php
+++ b/tests/Builder/Accumulator/TopAccumulatorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Accumulator;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $top accumulator
+ */
+class TopAccumulatorTest extends PipelineTestCase
+{
+    public function testFindTheTopScore(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                gameId: 'G1',
+            ),
+            Stage::group(
+                _id: Expression::fieldPath('gameId'),
+                playerId: Accumulator::top(
+                    output: [
+                        Expression::fieldPath('playerId'),
+                        Expression::fieldPath('score'),
+                    ],
+                    sortBy: object(
+                        score: -1,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TopFindTheTopScore, $pipeline);
+    }
+
+    public function testFindTheTopScoreAcrossMultipleGames(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: Expression::fieldPath('gameId'),
+                playerId: Accumulator::top(
+                    output: [
+                        Expression::fieldPath('playerId'),
+                        Expression::fieldPath('score'),
+                    ],
+                    sortBy: object(
+                        score: -1,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TopFindTheTopScoreAcrossMultipleGames, $pipeline);
+    }
+}

--- a/tests/Builder/Accumulator/TopNAccumulatorTest.php
+++ b/tests/Builder/Accumulator/TopNAccumulatorTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Accumulator;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $topN accumulator
+ */
+class TopNAccumulatorTest extends PipelineTestCase
+{
+    public function testComputingNBasedOnTheGroupKeyForGroup(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: object(
+                    gameId: Expression::fieldPath('gameId'),
+                ),
+                gamescores: Accumulator::topN(
+                    output: Expression::fieldPath('score'),
+                    n: Expression::cond(
+                        if: Expression::eq(
+                            Expression::fieldPath('gameId'),
+                            'G2',
+                        ),
+                        then: 1,
+                        else: 3,
+                    ),
+                    sortBy: object(
+                        score: -1,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TopNComputingNBasedOnTheGroupKeyForGroup, $pipeline);
+    }
+
+    public function testFindTheThreeHighestScores(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                gameId: 'G1',
+            ),
+            Stage::group(
+                _id: Expression::fieldPath('gameId'),
+                playerId: Accumulator::topN(
+                    output: [
+                        Expression::fieldPath('playerId'),
+                        Expression::fieldPath('score'),
+                    ],
+                    sortBy: object(
+                        score: -1,
+                    ),
+                    n: 3,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TopNFindTheThreeHighestScores, $pipeline);
+    }
+
+    public function testFindingTheThreeHighestScoreDocumentsAcrossMultipleGames(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: Expression::fieldPath('gameId'),
+                playerId: Accumulator::topN(
+                    output: [
+                        Expression::fieldPath('playerId'),
+                        Expression::fieldPath('score'),
+                    ],
+                    sortBy: object(
+                        score: -1,
+                    ),
+                    n: 3,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TopNFindingTheThreeHighestScoreDocumentsAcrossMultipleGames, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/AvgOperatorTest.php
+++ b/tests/Builder/Expression/AvgOperatorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $avg expression
+ */
+class AvgOperatorTest extends PipelineTestCase
+{
+    public function testUseInProjectStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                quizAvg: Expression::avg(
+                    Expression::numberFieldPath('quizzes'),
+                ),
+                labAvg: Expression::avg(
+                    Expression::numberFieldPath('labs'),
+                ),
+                examAvg: Expression::avg(
+                    Expression::numberFieldPath('final'),
+                    Expression::numberFieldPath('midterm'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::AvgUseInProjectStage, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/FirstNOperatorTest.php
+++ b/tests/Builder/Expression/FirstNOperatorTest.php
@@ -9,6 +9,8 @@ use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
+use function MongoDB\object;
+
 /**
  * Test $firstN expression
  */
@@ -23,5 +25,24 @@ class FirstNOperatorTest extends PipelineTestCase
         );
 
         $this->assertSamePipeline(Pipelines::FirstNExample, $pipeline);
+    }
+
+    public function testUsingFirstNAsAnAggregationExpression(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::documents([
+                object(
+                    array: [10, 20, 30, 40],
+                ),
+            ]),
+            Stage::project(
+                firstThreeElements: Expression::firstN(
+                    input: Expression::arrayFieldPath('array'),
+                    n: 3,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::FirstNUsingFirstNAsAnAggregationExpression, $pipeline);
     }
 }

--- a/tests/Builder/Expression/MaxOperatorTest.php
+++ b/tests/Builder/Expression/MaxOperatorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $max expression
+ */
+class MaxOperatorTest extends PipelineTestCase
+{
+    public function testUseInProjectStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                quizMax: Expression::max(
+                    Expression::numberFieldPath('quizzes'),
+                ),
+                labMax: Expression::max(
+                    Expression::numberFieldPath('labs'),
+                ),
+                examMax: Expression::max(
+                    Expression::numberFieldPath('final'),
+                    Expression::numberFieldPath('midterm'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MaxUseInProjectStage, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/MedianOperatorTest.php
+++ b/tests/Builder/Expression/MedianOperatorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $median expression
+ */
+class MedianOperatorTest extends PipelineTestCase
+{
+    public function testUseMedianInAProjectStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                _id: 0,
+                studentId: 1,
+                testMedians: Expression::median(
+                    input: [
+                        Expression::numberFieldPath('test01'),
+                        Expression::numberFieldPath('test02'),
+                        Expression::numberFieldPath('test03'),
+                    ],
+                    method: 'approximate',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MedianUseMedianInAProjectStage, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/MinOperatorTest.php
+++ b/tests/Builder/Expression/MinOperatorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $min expression
+ */
+class MinOperatorTest extends PipelineTestCase
+{
+    public function testUseInProjectStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                quizMin: Expression::min(
+                    Expression::numberFieldPath('quizzes'),
+                ),
+                labMin: Expression::min(
+                    Expression::numberFieldPath('labs'),
+                ),
+                examMin: Expression::min(
+                    Expression::numberFieldPath('final'),
+                    Expression::numberFieldPath('midterm'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MinUseInProjectStage, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/PercentileOperatorTest.php
+++ b/tests/Builder/Expression/PercentileOperatorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $percentile expression
+ */
+class PercentileOperatorTest extends PipelineTestCase
+{
+    public function testUsePercentileInAProjectStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                _id: 0,
+                studentId: 1,
+                testPercentiles: Expression::percentile(
+                    input: [
+                        Expression::intFieldPath('test01'),
+                        Expression::longFieldPath('test02'),
+                        Expression::numberFieldPath('test03'),
+                    ],
+                    p: [0.5, 0.95],
+                    method: 'approximate',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::PercentileUsePercentileInAProjectStage, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -199,6 +199,36 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Use in $project Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/avg/#use-in--project-stage
+     */
+    case AvgUseInProjectStage = <<<'JSON'
+    [
+        {
+            "$project": {
+                "quizAvg": {
+                    "$avg": [
+                        "$quizzes"
+                    ]
+                },
+                "labAvg": {
+                    "$avg": [
+                        "$labs"
+                    ]
+                },
+                "examAvg": {
+                    "$avg": [
+                        "$final",
+                        "$midterm"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Example
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/binarySize/#example
@@ -681,6 +711,48 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Using $firstN as an Aggregation Expression
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/firstN/#using--firstn-as-an-aggregation-expression
+     */
+    case FirstNUsingFirstNAsAnAggregationExpression = <<<'JSON'
+    [
+        {
+            "$documents": [
+                {
+                    "array": [
+                        {
+                            "$numberInt": "10"
+                        },
+                        {
+                            "$numberInt": "20"
+                        },
+                        {
+                            "$numberInt": "30"
+                        },
+                        {
+                            "$numberInt": "40"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "$project": {
+                "firstThreeElements": {
+                    "$firstN": {
+                        "input": "$array",
+                        "n": {
+                            "$numberInt": "3"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Example
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/gt/#example
@@ -1100,6 +1172,36 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Use in $project Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/max/#use-in--project-stage
+     */
+    case MaxUseInProjectStage = <<<'JSON'
+    [
+        {
+            "$project": {
+                "quizMax": {
+                    "$max": [
+                        "$quizzes"
+                    ]
+                },
+                "labMax": {
+                    "$max": [
+                        "$labs"
+                    ]
+                },
+                "examMax": {
+                    "$max": [
+                        "$final",
+                        "$midterm"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Example
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/maxN-array-element/#example
@@ -1114,6 +1216,36 @@ enum Pipelines: string
                             "$numberInt": "2"
                         },
                         "input": "$score"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use $median in a $project Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/median/#use-operatorname-in-a--project-stage
+     */
+    case MedianUseMedianInAProjectStage = <<<'JSON'
+    [
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "studentId": {
+                    "$numberInt": "1"
+                },
+                "testMedians": {
+                    "$median": {
+                        "input": [
+                            "$test01",
+                            "$test02",
+                            "$test03"
+                        ],
+                        "method": "approximate"
                     }
                 }
             }
@@ -1157,6 +1289,36 @@ enum Pipelines: string
             "$project": {
                 "fromItems": {
                     "$numberInt": "0"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use in $project Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/min/#use-in--project-stage
+     */
+    case MinUseInProjectStage = <<<'JSON'
+    [
+        {
+            "$project": {
+                "quizMin": {
+                    "$min": [
+                        "$quizzes"
+                    ]
+                },
+                "labMin": {
+                    "$min": [
+                        "$labs"
+                    ]
+                },
+                "examMin": {
+                    "$min": [
+                        "$final",
+                        "$midterm"
+                    ]
                 }
             }
         }
@@ -1326,6 +1488,44 @@ enum Pipelines: string
                             ]
                         }
                     ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use $percentile in a $project Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/percentile/#use-operatorname-in-a--project-stage
+     */
+    case PercentileUsePercentileInAProjectStage = <<<'JSON'
+    [
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "studentId": {
+                    "$numberInt": "1"
+                },
+                "testPercentiles": {
+                    "$percentile": {
+                        "input": [
+                            "$test01",
+                            "$test02",
+                            "$test03"
+                        ],
+                        "p": [
+                            {
+                                "$numberDouble": "0.5"
+                            },
+                            {
+                                "$numberDouble": "0.94999999999999995559"
+                            }
+                        ],
+                        "method": "approximate"
+                    }
                 }
             }
         }
@@ -1816,6 +2016,25 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Use in $project Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/stdDevPop/#use-in--project-stage
+     */
+    case StdDevPopUseInProjectStage = <<<'JSON'
+    [
+        {
+            "$project": {
+                "stdDev": {
+                    "$stdDevPop": [
+                        "$scores.score"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Subtract Numbers
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/subtract/#subtract-numbers
@@ -1884,6 +2103,36 @@ enum Pipelines: string
                         {
                             "$numberInt": "300000"
                         }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use in $project Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sum/#use-in--project-stage
+     */
+    case SumUseInProjectStage = <<<'JSON'
+    [
+        {
+            "$project": {
+                "quizTotal": {
+                    "$sum": [
+                        "$quizzes"
+                    ]
+                },
+                "labTotal": {
+                    "$sum": [
+                        "$labs"
+                    ]
+                },
+                "examTotal": {
+                    "$sum": [
+                        "$final",
+                        "$midterm"
                     ]
                 }
             }

--- a/tests/Builder/Expression/StdDevPopOperatorTest.php
+++ b/tests/Builder/Expression/StdDevPopOperatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $stdDevPop expression
+ */
+class StdDevPopOperatorTest extends PipelineTestCase
+{
+    public function testUseInProjectStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                stdDev: Expression::stdDevPop(
+                    Expression::numberFieldPath('scores.score'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::StdDevPopUseInProjectStage, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/SumOperatorTest.php
+++ b/tests/Builder/Expression/SumOperatorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $sum expression
+ */
+class SumOperatorTest extends PipelineTestCase
+{
+    public function testUseInProjectStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                quizTotal: Expression::sum(
+                    Expression::intFieldPath('quizzes'),
+                ),
+                labTotal: Expression::sum(
+                    Expression::longFieldPath('labs'),
+                ),
+                examTotal: Expression::sum(
+                    Expression::doubleFieldPath('final'),
+                    Expression::decimalFieldPath('midterm'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SumUseInProjectStage, $pipeline);
+    }
+}


### PR DESCRIPTION
Fix [PHPLIB-1359](https://jira.mongodb.org/browse/PHPLIB-1359)

https://www.mongodb.com/docs/manual/reference/operator/aggregation/#accumulators---group---bucket---bucketauto---setwindowfields-

For the operators that have accumulator and expression examples on the same page, I added the examples on both.

- ~`$accumulator`~ already done
- ~`$addToSet`~ already done
- `$avg` accumulator + expression
- `$bottom`
- `$bottomN`
- `$count` the empty object required modifications in Yaml parsing
- ~`$first`~ already done
- `$firstN` accumulator + expression
- ~`$last`~ already done
- `$lastN`
- `$max` accumulator + expression
- `$maxN`
- `$median` accumulator + expression
- `$mergeObjects`
- `$min` accumulator + expression
- `$percentile` accumulator + expression
- `$push`
- `$stdDevPop` accumulator + expression
- `$stdDevSamp` accumulator + expression
- `$sum` accumulator + expression
- `$top`
- `$topN`
