### PR TITLE
PHPLIB-1347 Add tests on Conditional Expression Operators

### DIFF
--- a/generator/config/expression/cond.yaml
+++ b/generator/config/expression/cond.yaml
@@ -19,3 +19,19 @@ arguments:
         name: else
         type:
             - expression
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/cond/#example'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    discount:
+                        $cond:
+                            if:
+                                $gte:
+                                    - '$qty'
+                                    - 250
+                            then: 30
+                            else: 20

--- a/generator/config/expression/ifNull.yaml
+++ b/generator/config/expression/ifNull.yaml
@@ -12,3 +12,27 @@ arguments:
         type:
             - expression
         variadic: array
+tests:
+    -
+        name: 'Single Input Expression'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/ifNull/#single-input-expression'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    description:
+                        $ifNull:
+                            - '$description'
+                            - 'Unspecified'
+    -
+        name: 'Multiple Input Expressions'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/ifNull/#multiple-input-expressions'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    value:
+                        $ifNull:
+                            - '$description'
+                            - '$quantity'
+                            - 'Unspecified'

--- a/generator/config/expression/switch.yaml
+++ b/generator/config/expression/switch.yaml
@@ -24,3 +24,47 @@ arguments:
         description: |
             The path to take if no branch case expression evaluates to true.
             Although optional, if default is unspecified and no branch case evaluates to true, $switch returns an error.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/switch/#example'
+        pipeline:
+            -
+                $project:
+                    name: 1
+                    summary:
+                        $switch:
+                            branches:
+                                -
+                                    case:
+                                        $gte:
+                                            -
+                                                #$avg: '$scores'
+                                                $avg: [ '$scores' ]
+                                            - 90
+                                    then: 'Doing great!'
+                                -
+                                    case:
+                                        $and:
+                                            -
+                                                $gte:
+                                                    -
+                                                        #$avg: '$scores'
+                                                        $avg: [ '$scores' ]
+                                                    - 80
+                                            -
+                                                $lt:
+                                                    -
+                                                        #$avg: '$scores'
+                                                        $avg: [ '$scores' ]
+                                                    - 90
+                                    then: 'Doing pretty well.'
+                                -
+                                    case:
+                                        $lt:
+                                            -
+                                                #$avg: '$scores'
+                                                $avg: [ '$scores' ]
+                                            - 80
+                                    then: 'Needs improvement.'
+                            default: 'No scores found.'

--- a/tests/Builder/Expression/CondOperatorTest.php
+++ b/tests/Builder/Expression/CondOperatorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $cond expression
+ */
+class CondOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                discount: Expression::cond(
+                    if: Expression::gte(
+                        Expression::intFieldPath('qty'),
+                        250,
+                    ),
+                    then: 30,
+                    else: 20,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::CondExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/IfNullOperatorTest.php
+++ b/tests/Builder/Expression/IfNullOperatorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $ifNull expression
+ */
+class IfNullOperatorTest extends PipelineTestCase
+{
+    public function testMultipleInputExpressions(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                value: Expression::ifNull(
+                    Expression::fieldPath('description'),
+                    Expression::fieldPath('quantity'),
+                    'Unspecified',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::IfNullMultipleInputExpressions, $pipeline);
+    }
+
+    public function testSingleInputExpression(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                description: Expression::ifNull(
+                    Expression::fieldPath('description'),
+                    'Unspecified',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::IfNullSingleInputExpression, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -373,6 +373,41 @@ enum Pipelines: string
     /**
      * Example
      *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/cond/#example
+     */
+    case CondExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "discount": {
+                    "$cond": {
+                        "if": {
+                            "$gte": [
+                                "$qty",
+                                {
+                                    "$numberInt": "250"
+                                }
+                            ]
+                        },
+                        "then": {
+                            "$numberInt": "30"
+                        },
+                        "else": {
+                            "$numberInt": "20"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/eq/#example
      */
     case EqExample = <<<'JSON'
@@ -613,6 +648,53 @@ enum Pipelines: string
                 },
                 "_id": {
                     "$numberInt": "0"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Single Input Expression
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/ifNull/#single-input-expression
+     */
+    case IfNullSingleInputExpression = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "description": {
+                    "$ifNull": [
+                        "$description",
+                        "Unspecified"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Multiple Input Expressions
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/ifNull/#multiple-input-expressions
+     */
+    case IfNullMultipleInputExpressions = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "value": {
+                    "$ifNull": [
+                        "$description",
+                        "$quantity",
+                        "Unspecified"
+                    ]
                 }
             }
         }
@@ -1715,6 +1797,91 @@ enum Pipelines: string
                             "$numberInt": "300000"
                         }
                     ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/switch/#example
+     */
+    case SwitchExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "name": {
+                    "$numberInt": "1"
+                },
+                "summary": {
+                    "$switch": {
+                        "branches": [
+                            {
+                                "case": {
+                                    "$gte": [
+                                        {
+                                            "$avg": [
+                                                "$scores"
+                                            ]
+                                        },
+                                        {
+                                            "$numberInt": "90"
+                                        }
+                                    ]
+                                },
+                                "then": "Doing great!"
+                            },
+                            {
+                                "case": {
+                                    "$and": [
+                                        {
+                                            "$gte": [
+                                                {
+                                                    "$avg": [
+                                                        "$scores"
+                                                    ]
+                                                },
+                                                {
+                                                    "$numberInt": "80"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "$lt": [
+                                                {
+                                                    "$avg": [
+                                                        "$scores"
+                                                    ]
+                                                },
+                                                {
+                                                    "$numberInt": "90"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "then": "Doing pretty well."
+                            },
+                            {
+                                "case": {
+                                    "$lt": [
+                                        {
+                                            "$avg": [
+                                                "$scores"
+                                            ]
+                                        },
+                                        {
+                                            "$numberInt": "80"
+                                        }
+                                    ]
+                                },
+                                "then": "Needs improvement."
+                            }
+                        ],
+                        "default": "No scores found."
+                    }
                 }
             }
         }

--- a/tests/Builder/Expression/SwitchOperatorTest.php
+++ b/tests/Builder/Expression/SwitchOperatorTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $switch expression
+ */
+class SwitchOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                name: 1,
+                summary: Expression::switch(
+                    branches: [
+                        object(
+                            case: Expression::gte(
+                                Expression::avg(
+                                    Expression::intFieldPath('scores'),
+                                ),
+                                90,
+                            ),
+                            then: 'Doing great!',
+                        ),
+                        object(
+                            case:Expression::and(
+                                Expression::gte(
+                                    Expression::avg(
+                                        Expression::intFieldPath('scores'),
+                                    ),
+                                    80,
+                                ),
+                                Expression::lt(
+                                    Expression::avg(
+                                        Expression::intFieldPath('scores'),
+                                    ),
+                                    90,
+                                ),
+                            ),
+                            then: 'Doing pretty well.',
+                        ),
+                        object(
+                            case: Expression::lt(
+                                Expression::avg(
+                                    Expression::intFieldPath('scores'),
+                                ),
+                                80,
+                            ),
+                            then: 'Needs improvement.',
+                        ),
+                    ],
+                    default: 'No scores found.',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SwitchExample, $pipeline);
+    }
+}

--- a/tests/Builder/Query/Pipelines.php
+++ b/tests/Builder/Query/Pipelines.php
@@ -1041,33 +1041,6 @@ enum Pipelines: string
     JSON;
 
     /**
-     * Query on Legacy Coordinates
-     *
-     * @see https://www.mongodb.com/docs/manual/reference/operator/query/near/#query-on-legacy-coordinates
-     */
-    case NearQueryOnLegacyCoordinates = <<<'JSON'
-    [
-        {
-            "$match": {
-                "location": {
-                    "$near": [
-                        {
-                            "$numberDouble": "-73.966700000000003001"
-                        },
-                        {
-                            "$numberDouble": "40.780000000000001137"
-                        }
-                    ],
-                    "$maxDistance": {
-                        "$numberDouble": "0.10000000000000000555"
-                    }
-                }
-            }
-        }
-    ]
-    JSON;
-
-    /**
      * Specify Center Point Using GeoJSON
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/nearSphere/#specify-center-point-using-geojson
@@ -1095,33 +1068,6 @@ enum Pipelines: string
                         "$maxDistance": {
                             "$numberInt": "5000"
                         }
-                    }
-                }
-            }
-        }
-    ]
-    JSON;
-
-    /**
-     * Specify Center Point Using Legacy Coordinates
-     *
-     * @see https://www.mongodb.com/docs/manual/reference/operator/query/nearSphere/#specify-center-point-using-legacy-coordinates
-     */
-    case NearSphereSpecifyCenterPointUsingLegacyCoordinates = <<<'JSON'
-    [
-        {
-            "$match": {
-                "location": {
-                    "$nearSphere": [
-                        {
-                            "$numberDouble": "-73.966700000000003001"
-                        },
-                        {
-                            "$numberDouble": "40.780000000000001137"
-                        }
-                    ],
-                    "$maxDistance": {
-                        "$numberDouble": "0.10000000000000000555"
                     }
                 }
             }


### PR DESCRIPTION
Fix [PHPLIB-1347](https://jira.mongodb.org/browse/PHPLIB-1347)

https://www.mongodb.com/docs/manual/reference/operator/aggregation/#conditional-expression-operators

- `$cond`
- `$ifNull`
- `$switch` more work needed to improve the DX of this operator [PHPLIB-1273](https://jira.mongodb.org/browse/PHPLIB-1273)