### PR TITLE
PHPLIB-1349 Add tests on Data Size Operators

### DIFF
--- a/generator/config/expression/binarySize.yaml
+++ b/generator/config/expression/binarySize.yaml
@@ -13,3 +13,13 @@ arguments:
             - resolvesToString
             - resolvesToBinData
             - resolvesToNull
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/binarySize/#example'
+        pipeline:
+            -
+                $project:
+                    name: '$name'
+                    imageSize:
+                        $binarySize: '$binary'

--- a/generator/config/expression/bsonSize.yaml
+++ b/generator/config/expression/bsonSize.yaml
@@ -12,3 +12,37 @@ arguments:
         type:
             - resolvesToObject
             - resolvesToNull
+tests:
+    -
+        name: 'Return Sizes of Documents'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/bsonSize/#return-sizes-of-documents'
+        pipeline:
+            -
+                $project:
+                    name: 1
+                    object_size:
+                        $bsonSize: '$$ROOT'
+    -
+        name: 'Return Combined Size of All Documents in a Collection'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/bsonSize/#return-combined-size-of-all-documents-in-a-collection'
+        pipeline:
+            -
+                $group:
+                    _id: ~
+                    combined_object_size:
+                        $sum:
+                            $bsonSize: '$$ROOT'
+    -
+        name: 'Return Document with Largest Specified Field'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/bsonSize/#return-document-with-largest-specified-field'
+        pipeline:
+            -
+                $project:
+                    name: '$name'
+                    task_object_size:
+                        $bsonSize: '$current_task'
+            -
+                $sort:
+                    task_object_size: -1
+            -
+                $limit: 1

--- a/tests/Builder/Expression/BinarySizeOperatorTest.php
+++ b/tests/Builder/Expression/BinarySizeOperatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $binarySize expression
+ */
+class BinarySizeOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                name: Expression::stringFieldPath('name'),
+                imageSize: Expression::binarySize(
+                    Expression::binDataFieldPath('binary'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::BinarySizeExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/BsonSizeOperatorTest.php
+++ b/tests/Builder/Expression/BsonSizeOperatorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $bsonSize expression
+ */
+class BsonSizeOperatorTest extends PipelineTestCase
+{
+    public function testReturnCombinedSizeOfAllDocumentsInACollection(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: null,
+                combined_object_size: Accumulator::sum(
+                    Expression::bsonSize(
+                        Expression::variable('ROOT'),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::BsonSizeReturnCombinedSizeOfAllDocumentsInACollection, $pipeline);
+    }
+
+    public function testReturnDocumentWithLargestSpecifiedField(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                name: Expression::stringFieldPath('name'),
+                task_object_size: Expression::bsonSize(
+                    Expression::objectFieldPath('current_task'),
+                ),
+            ),
+            Stage::sort(
+                object(task_object_size: -1),
+            ),
+            Stage::limit(1),
+        );
+
+        $this->assertSamePipeline(Pipelines::BsonSizeReturnDocumentWithLargestSpecifiedField, $pipeline);
+    }
+
+    public function testReturnSizesOfDocuments(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                name: 1,
+                object_size: Expression::bsonSize(
+                    Expression::variable('ROOT'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::BsonSizeReturnSizesOfDocuments, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -199,6 +199,24 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/binarySize/#example
+     */
+    case BinarySizeExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "name": "$name",
+                "imageSize": {
+                    "$binarySize": "$binary"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Bitwise AND with Two Integers
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bitAnd/#bitwise-and-with-two-integers
@@ -314,6 +332,76 @@ enum Pipelines: string
                         "$b"
                     ]
                 }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Return Sizes of Documents
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bsonSize/#return-sizes-of-documents
+     */
+    case BsonSizeReturnSizesOfDocuments = <<<'JSON'
+    [
+        {
+            "$project": {
+                "name": {
+                    "$numberInt": "1"
+                },
+                "object_size": {
+                    "$bsonSize": "$$ROOT"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Return Combined Size of All Documents in a Collection
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bsonSize/#return-combined-size-of-all-documents-in-a-collection
+     */
+    case BsonSizeReturnCombinedSizeOfAllDocumentsInACollection = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": null,
+                "combined_object_size": {
+                    "$sum": {
+                        "$bsonSize": "$$ROOT"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Return Document with Largest Specified Field
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bsonSize/#return-document-with-largest-specified-field
+     */
+    case BsonSizeReturnDocumentWithLargestSpecifiedField = <<<'JSON'
+    [
+        {
+            "$project": {
+                "name": "$name",
+                "task_object_size": {
+                    "$bsonSize": "$current_task"
+                }
+            }
+        },
+        {
+            "$sort": {
+                "task_object_size": {
+                    "$numberInt": "-1"
+                }
+            }
+        },
+        {
+            "$limit": {
+                "$numberInt": "1"
             }
         }
     ]


### PR DESCRIPTION
Fix [PHPLIB-1349](https://jira.mongodb.org/browse/PHPLIB-1349)

https://www.mongodb.com/docs/manual/reference/operator/aggregation/#data-size-operators

- `$binarySize`
- `$bsonSize`