### PR TITLE
Fix generator: builder dependency and nowdoc incompatibility

### DIFF
--- a/generator/composer.json
+++ b/generator/composer.json
@@ -17,8 +17,8 @@
         "ext-mongodb": "^1.17.0",
         "mongodb/builder": "@dev",
         "mongodb/mongodb": "^1.17.0",
-        "nette/php-generator": "^4",
-        "nikic/php-parser": "^4.17",
+        "nette/php-generator": "dev-master#933bb0368df508c759c8c9a047873741fcd9fe17",
+        "nikic/php-parser": "^5",
         "symfony/console": "^6.3|^7.0",
         "symfony/finder": "^6.3|^7.0",
         "symfony/yaml": "^6.3|^7.0"

--- a/generator/composer.json
+++ b/generator/composer.json
@@ -15,6 +15,7 @@
     "require": {
         "php": ">=8.1",
         "ext-mongodb": "^1.17.0",
+        "mongodb/builder": "@dev",
         "mongodb/mongodb": "^1.17.0",
         "nette/php-generator": "^4",
         "nikic/php-parser": "^4.17",


### PR DESCRIPTION
- The dependency to `mongodb/builder` was removed by mistake in https://github.com/mongodb/mongo-php-builder/commit/29807eda8f955302681172acab1894d5c3c4c6e6
- ~Prevent using a nowdoc in tests, not supported by nette/php-generator https://github.com/nette/php-generator/issues/151~ Fixed by the maintainer. Upgrade nette/php-generator to support nowdoc used in `WhereOperatorTest`
