### PR TITLE
PHPLIB-1350 PHPLIB-1350 Add tests on Date Expression Operators and add Yaml tags for BSON types

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -17,5 +17,18 @@ To run the generator, you need to have PHP 8.1+ installed and Composer.
 
 The `generator/config/*.yaml` files contains the list of operators and stages that are supported by the library.
 
+### Test pipelines
+
+Each operator can contain a `tests` section with a list if pipelines. To represent specific BSON objects,
+it is necessary to use Yaml tags:
+
+| BSON Type   | Example                                      |
+|-------------|----------------------------------------------|
+| Regex       | `!regex '^abc'` <br/> `!regex ['^abc', 'i']` |
+| Int64       | `!long '123456789'`                          |
+| Decimal128  | `!double '0.9'`                              |
+| UTCDateTime | `!date 0`                                    |
+| Binary      | `!binary 'IA=='`                             |
+
 To add new test cases to operators, you can get inspiration from the official MongoDB documentation and use
 the `generator/js2yaml.html` web page to manually convert a pipeline array from JS to Yaml.

--- a/generator/config/expression/dateAdd.yaml
+++ b/generator/config/expression/dateAdd.yaml
@@ -33,3 +33,100 @@ arguments:
         optional: true
         description: |
             The timezone to carry out the operation. $timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
+tests:
+    -
+        name: 'Add a Future Date'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateAdd/#add-a-future-date'
+        pipeline:
+            -
+                $project:
+                    expectedDeliveryDate:
+                        $dateAdd:
+                            startDate: '$purchaseDate'
+                            unit: 'day'
+                            amount: 3
+            -
+                # $merge: 'shipping'
+                $merge:
+                    into: 'shipping'
+    -
+        name: 'Filter on a Date Range'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateAdd/#filter-on-a-date-range'
+        pipeline:
+            -
+                $match:
+                    $expr:
+                        $gt:
+                            - '$deliveryDate'
+                            -
+                                $dateAdd:
+                                    startDate: '$purchaseDate'
+                                    unit: 'day'
+                                    amount: 5
+            -
+                $project:
+                    _id: 0
+                    custId: 1
+                    purchased:
+                        $dateToString:
+                            format: '%Y-%m-%d'
+                            date: '$purchaseDate'
+                    delivery:
+                        $dateToString:
+                            format: '%Y-%m-%d'
+                            date: '$deliveryDate'
+    -
+        name: 'Adjust for Daylight Savings Time'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateAdd/#adjust-for-daylight-savings-time'
+        pipeline:
+            -
+                $project:
+                    _id: 0
+                    location: 1
+                    start:
+                        $dateToString:
+                            format: '%Y-%m-%d %H:%M'
+                            date: '$login'
+                    days:
+                        $dateToString:
+                            format: '%Y-%m-%d %H:%M'
+                            date:
+                                $dateAdd:
+                                    startDate: '$login'
+                                    unit: 'day'
+                                    amount: 1
+                                    timezone: '$location'
+                    hours:
+                        $dateToString:
+                            format: '%Y-%m-%d %H:%M'
+                            date:
+                                $dateAdd:
+                                    startDate: '$login'
+                                    unit: 'hour'
+                                    amount: 24
+                                    timezone: '$location'
+                    startTZInfo:
+                        $dateToString:
+                            format: '%Y-%m-%d %H:%M'
+                            date: '$login'
+                            timezone: '$location'
+                    daysTZInfo:
+                        $dateToString:
+                            format: '%Y-%m-%d %H:%M'
+                            date:
+                                $dateAdd:
+                                    startDate: '$login'
+                                    unit: 'day'
+                                    amount: 1
+                                    timezone: '$location'
+                            timezone: '$location'
+                    hoursTZInfo:
+                        $dateToString:
+                            format: '%Y-%m-%d %H:%M'
+                            date:
+                                $dateAdd:
+                                    startDate: '$login'
+                                    unit: 'hour'
+                                    amount: 24
+                                    timezone: '$location'
+                            timezone: '$location'

--- a/generator/config/expression/dateDiff.yaml
+++ b/generator/config/expression/dateDiff.yaml
@@ -43,3 +43,72 @@ arguments:
         optional: true
         description: |
             Used when the unit is equal to week. Defaults to Sunday. The startOfWeek parameter is an expression that resolves to a case insensitive string
+tests:
+    -
+        name: 'Elapsed Time'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateDiff/#elapsed-time'
+        pipeline:
+            -
+                $group:
+                    _id: ~
+                    averageTime:
+                        $avg:
+                            $dateDiff:
+                                startDate: '$purchased'
+                                endDate: '$delivered'
+                                unit: 'day'
+            -
+                $project:
+                    _id: 0
+                    numDays:
+                        $trunc:
+                            - '$averageTime'
+                            - 1
+    -
+        name: 'Result Precision'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateDiff/#result-precision'
+        pipeline:
+            -
+                $project:
+                    Start: '$start'
+                    End: '$end'
+                    years:
+                        $dateDiff:
+                            startDate: '$start'
+                            endDate: '$end'
+                            unit: 'year'
+                    months:
+                        $dateDiff:
+                            startDate: '$start'
+                            endDate: '$end'
+                            unit: 'month'
+                    days:
+                        $dateDiff:
+                            startDate: '$start'
+                            endDate: '$end'
+                            unit: 'day'
+                    _id: 0
+    -
+        name: 'Weeks Per Month'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateDiff/#weeks-per-month'
+        pipeline:
+            -
+                $project:
+                    wks_default:
+                        $dateDiff:
+                            startDate: '$start'
+                            endDate: '$end'
+                            unit: 'week'
+                    wks_monday:
+                        $dateDiff:
+                            startDate: '$start'
+                            endDate: '$end'
+                            unit: 'week'
+                            startOfWeek: 'Monday'
+                    wks_friday:
+                        $dateDiff:
+                            startDate: '$start'
+                            endDate: '$end'
+                            unit: 'week'
+                            startOfWeek: 'fri'
+                    _id: 0

--- a/generator/config/expression/dateFromParts.yaml
+++ b/generator/config/expression/dateFromParts.yaml
@@ -11,12 +11,14 @@ arguments:
         name: year
         type:
             - resolvesToNumber
+        optional: true
         description: |
             Calendar year. Can be any expression that evaluates to a number.
     -
         name: isoWeekYear
         type:
             - resolvesToNumber
+        optional: true
         description: |
             ISO Week Date Year. Can be any expression that evaluates to a number.
     -
@@ -82,3 +84,31 @@ arguments:
         optional: true
         description: |
             The timezone to carry out the operation. $timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateFromParts/#example'
+        pipeline:
+            -
+                $project:
+                    date:
+                        $dateFromParts:
+                            year: 2017
+                            month: 2
+                            day: 8
+                            hour: 12
+                    date_iso:
+                        $dateFromParts:
+                            isoWeekYear: 2017
+                            isoWeek: 6
+                            isoDayOfWeek: 3
+                            hour: 12
+                    date_timezone:
+                        $dateFromParts:
+                            year: 2016
+                            month: 12
+                            day: 31
+                            hour: 23
+                            minute: 46
+                            second: 12
+                            timezone: 'America/New_York'

--- a/generator/config/expression/dateFromString.yaml
+++ b/generator/config/expression/dateFromString.yaml
@@ -77,5 +77,5 @@ tests:
                             dateString: '$date'
                             timezone: '$timezone'
                             # onNull: new Date(0)
-                            onNull: 1970-01-01T00:00:00+00:00
+                            onNull: !date 0
 

--- a/generator/config/expression/dateFromString.yaml
+++ b/generator/config/expression/dateFromString.yaml
@@ -44,3 +44,38 @@ arguments:
         description: |
             If the dateString provided to $dateFromString is null or missing, it outputs the result value of the provided onNull expression. This result value can be of any type.
             If you do not specify onNull and dateString is null or missing, then $dateFromString outputs null.
+tests:
+    -
+        name: 'Converting Dates'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateFromString/#converting-dates'
+        pipeline:
+            -
+                $project:
+                    date:
+                        $dateFromString:
+                            dateString: '$date'
+                            timezone: 'America/New_York'
+    -
+        name: 'onError'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateFromString/#onerror'
+        pipeline:
+            -
+                $project:
+                    date:
+                        $dateFromString:
+                            dateString: '$date'
+                            timezone: '$timezone'
+                            onError: '$date'
+    -
+        name: 'onNull'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateFromString/#onnull'
+        pipeline:
+            -
+                $project:
+                    date:
+                        $dateFromString:
+                            dateString: '$date'
+                            timezone: '$timezone'
+                            # onNull: new Date(0)
+                            onNull: 1970-01-01T00:00:00+00:00
+

--- a/generator/config/expression/dateSubtract.yaml
+++ b/generator/config/expression/dateSubtract.yaml
@@ -33,3 +33,105 @@ arguments:
         optional: true
         description: |
             The timezone to carry out the operation. $timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
+tests:
+    -
+        name: 'Subtract A Fixed Amount'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateSubtract/#subtract-a-fixed-amount'
+        pipeline:
+            -
+                $match:
+                    $expr:
+                        $eq:
+                            -
+                                # $month: '$logout'
+                                $month:
+                                    date: '$logout'
+                            - 1
+            -
+                $project:
+                    logoutTime:
+                        $dateSubtract:
+                            startDate: '$logout'
+                            unit: 'hour'
+                            amount: 3
+            -
+                # $merge: 'connectionTime'
+                $merge:
+                    into: 'connectionTime'
+    -
+        name: 'Filter by Relative Dates'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateSubtract/#filter-by-relative-dates'
+        pipeline:
+            -
+                $match:
+                    $expr:
+                        $gt:
+                            - '$logoutTime'
+                            -
+                                $dateSubtract:
+                                    startDate: '$$NOW'
+                                    unit: 'week'
+                                    amount: 1
+            -
+                $project:
+                    _id: 0
+                    custId: 1
+                    loggedOut:
+                        $dateToString:
+                            format: '%Y-%m-%d'
+                            date: '$logoutTime'
+    -
+        name: 'Adjust for Daylight Savings Time'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateSubtract/#adjust-for-daylight-savings-time'
+        pipeline:
+            -
+                $project:
+                    _id: 0
+                    location: 1
+                    start:
+                        $dateToString:
+                            format: '%Y-%m-%d %H:%M'
+                            date: '$login'
+                    days:
+                        $dateToString:
+                            format: '%Y-%m-%d %H:%M'
+                            date:
+                                $dateSubtract:
+                                    startDate: '$login'
+                                    unit: 'day'
+                                    amount: 1
+                                    timezone: '$location'
+                    hours:
+                        $dateToString:
+                            format: '%Y-%m-%d %H:%M'
+                            date:
+                                $dateSubtract:
+                                    startDate: '$login'
+                                    unit: 'hour'
+                                    amount: 24
+                                    timezone: '$location'
+                    startTZInfo:
+                        $dateToString:
+                            format: '%Y-%m-%d %H:%M'
+                            date: '$login'
+                            timezone: '$location'
+                    daysTZInfo:
+                        $dateToString:
+                            format: '%Y-%m-%d %H:%M'
+                            date:
+                                $dateSubtract:
+                                    startDate: '$login'
+                                    unit: 'day'
+                                    amount: 1
+                                    timezone: '$location'
+                            timezone: '$location'
+                    hoursTZInfo:
+                        $dateToString:
+                            format: '%Y-%m-%d %H:%M'
+                            date:
+                                $dateSubtract:
+                                    startDate: '$login'
+                                    unit: 'hour'
+                                    amount: 24
+                                    timezone: '$location'
+                            timezone: '$location'

--- a/generator/config/expression/dateToParts.yaml
+++ b/generator/config/expression/dateToParts.yaml
@@ -29,3 +29,21 @@ arguments:
         optional: true
         description: |
             If set to true, modifies the output document to use ISO week date fields. Defaults to false.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateToParts/#example'
+        pipeline:
+            -
+                $project:
+                    date:
+                        $dateToParts:
+                            date: '$date'
+                    date_iso:
+                        $dateToParts:
+                            date: '$date'
+                            iso8601: true
+                    date_timezone:
+                        $dateToParts:
+                            date: '$date'
+                            timezone: 'America/New_York'

--- a/generator/config/expression/dateToString.yaml
+++ b/generator/config/expression/dateToString.yaml
@@ -38,3 +38,44 @@ arguments:
         description: |
             The value to return if the date is null or missing.
             If unspecified, $dateToString returns null if the date is null or missing.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateToString/#example'
+        pipeline:
+            -
+                $project:
+                    yearMonthDayUTC:
+                        $dateToString:
+                            format: '%Y-%m-%d'
+                            date: '$date'
+                    timewithOffsetNY:
+                        $dateToString:
+                            format: '%H:%M:%S:%L%z'
+                            date: '$date'
+                            timezone: 'America/New_York'
+                    timewithOffset430:
+                        $dateToString:
+                            format: '%H:%M:%S:%L%z'
+                            date: '$date'
+                            timezone: '+04:30'
+                    minutesOffsetNY:
+                        $dateToString:
+                            format: '%Z'
+                            date: '$date'
+                            timezone: 'America/New_York'
+                    minutesOffset430:
+                        $dateToString:
+                            format: '%Z'
+                            date: '$date'
+                            timezone: '+04:30'
+                    abbreviated_month:
+                        $dateToString:
+                            format: '%b'
+                            date: '$date'
+                            timezone: '+04:30'
+                    full_month:
+                        $dateToString:
+                            format: '%B'
+                            date: '$date'
+                            timezone: '+04:30'

--- a/generator/config/expression/dateTrunc.yaml
+++ b/generator/config/expression/dateTrunc.yaml
@@ -45,3 +45,33 @@ arguments:
         description: |
             The start of the week. Used when 
             unit is week. Defaults to Sunday.
+tests:
+    -
+        name: 'Truncate Order Dates in a $project Pipeline Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateTrunc/#truncate-order-dates-in-a--project-pipeline-stage'
+        pipeline:
+            -
+                $project:
+                    _id: 1
+                    orderDate: 1
+                    truncatedOrderDate:
+                        $dateTrunc:
+                            date: '$orderDate'
+                            unit: 'week'
+                            binSize: 2
+                            timezone: 'America/Los_Angeles'
+                            startOfWeek: 'Monday'
+    -
+        name: 'Truncate Order Dates and Obtain Quantity Sum in a $group Pipeline Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateTrunc/#truncate-order-dates-and-obtain-quantity-sum-in-a--group-pipeline-stage'
+        pipeline:
+            -
+                $group:
+                    _id:
+                        truncatedOrderDate:
+                            $dateTrunc:
+                                date: '$orderDate'
+                                unit: 'month'
+                                binSize: 6
+                    sumQuantity:
+                        $sum: '$quantity'

--- a/generator/config/expression/dayOfMonth.yaml
+++ b/generator/config/expression/dayOfMonth.yaml
@@ -22,3 +22,14 @@ arguments:
         optional: true
         description: |
             The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/dayOfMonth/#example'
+        pipeline:
+            -
+                $project:
+                    day:
+                        # $dayOfMonth: '$date'
+                        $dayOfMonth:
+                            date: '$date'

--- a/generator/config/expression/dayOfWeek.yaml
+++ b/generator/config/expression/dayOfWeek.yaml
@@ -22,3 +22,14 @@ arguments:
         optional: true
         description: |
             The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/dayOfWeek/#example'
+        pipeline:
+            -
+                $project:
+                    dayOfWeek:
+                        # $dayOfWeek: '$date'
+                        $dayOfWeek:
+                            date: '$date'

--- a/generator/config/expression/dayOfYear.yaml
+++ b/generator/config/expression/dayOfYear.yaml
@@ -22,3 +22,14 @@ arguments:
         optional: true
         description: |
             The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/dayOfYear/#example'
+        pipeline:
+            -
+                $project:
+                    dayOfYear:
+                        # $dayOfYear: '$date'
+                        $dayOfYear:
+                            date: '$date'

--- a/generator/config/expression/hour.yaml
+++ b/generator/config/expression/hour.yaml
@@ -22,3 +22,14 @@ arguments:
         optional: true
         description: |
             The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/hour/#example'
+        pipeline:
+            -
+                $project:
+                    hour:
+                        # $hour: '$date'
+                        $hour:
+                            date: '$date'

--- a/generator/config/expression/isoDayOfWeek.yaml
+++ b/generator/config/expression/isoDayOfWeek.yaml
@@ -22,3 +22,16 @@ arguments:
         optional: true
         description: |
             The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/isoDayOfWeek/#example'
+        pipeline:
+            -
+                $project:
+                    _id: 0
+                    name: '$name'
+                    dayOfWeek:
+                        # $isoDayOfWeek: '$birthday'
+                        $isoDayOfWeek:
+                            date: '$birthday'

--- a/generator/config/expression/isoWeek.yaml
+++ b/generator/config/expression/isoWeek.yaml
@@ -22,3 +22,16 @@ arguments:
         optional: true
         description: |
             The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/isoWeek/#example'
+        pipeline:
+            -
+                $project:
+                    _id: 0
+                    city: '$city'
+                    weekNumber:
+                        # $isoWeek: '$date'
+                        $isoWeek:
+                            date: '$date'

--- a/generator/config/expression/isoWeekYear.yaml
+++ b/generator/config/expression/isoWeekYear.yaml
@@ -22,3 +22,14 @@ arguments:
         optional: true
         description: |
             The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/isoWeekYear/#example'
+        pipeline:
+            -
+                $project:
+                    yearNumber:
+                        # $isoWeekYear: '$date'
+                        $isoWeekYear:
+                            date: '$date'

--- a/generator/config/expression/millisecond.yaml
+++ b/generator/config/expression/millisecond.yaml
@@ -22,3 +22,14 @@ arguments:
         optional: true
         description: |
             The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/millisecond/#example'
+        pipeline:
+            -
+                $project:
+                    milliseconds:
+                        # $millisecond: '$date'
+                        $millisecond:
+                            date: '$date'

--- a/generator/config/expression/minute.yaml
+++ b/generator/config/expression/minute.yaml
@@ -22,3 +22,14 @@ arguments:
         optional: true
         description: |
             The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/minute/#example'
+        pipeline:
+            -
+                $project:
+                    minutes:
+                        # $minute: '$date'
+                        $minute:
+                            date: '$date'

--- a/generator/config/expression/month.yaml
+++ b/generator/config/expression/month.yaml
@@ -22,3 +22,14 @@ arguments:
         optional: true
         description: |
             The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/month/#example'
+        pipeline:
+            -
+                $project:
+                    month:
+                        # $month: '$date'
+                        $month:
+                            date: '$date'

--- a/generator/config/expression/second.yaml
+++ b/generator/config/expression/second.yaml
@@ -22,3 +22,14 @@ arguments:
         optional: true
         description: |
             The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/second/#example'
+        pipeline:
+            -
+                $project:
+                    seconds:
+                        # $second: '$date'
+                        $second:
+                            date: '$date'

--- a/generator/config/expression/toDate.yaml
+++ b/generator/config/expression/toDate.yaml
@@ -12,3 +12,15 @@ arguments:
         name: expression
         type:
             - expression
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/toDate/#example'
+        pipeline:
+            -
+                $addFields:
+                    convertedDate:
+                        $toDate: '$order_date'
+            -
+                $sort:
+                    convertedDate: 1

--- a/generator/config/expression/week.yaml
+++ b/generator/config/expression/week.yaml
@@ -22,3 +22,14 @@ arguments:
         optional: true
         description: |
             The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/week/#example'
+        pipeline:
+            -
+                $project:
+                    week:
+                        # $week: '$date'
+                        $week:
+                            date: '$date'

--- a/generator/config/expression/year.yaml
+++ b/generator/config/expression/year.yaml
@@ -22,3 +22,14 @@ arguments:
         optional: true
         description: |
             The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/year/#example'
+        pipeline:
+            -
+                $project:
+                    year:
+                        # $year: '$date'
+                        $year:
+                            date: '$date'

--- a/generator/config/query/eq.yaml
+++ b/generator/config/query/eq.yaml
@@ -53,13 +53,9 @@ tests:
             -
                 $match:
                     company:
-                        $regularExpression:
-                            options: ''
-                            pattern: '^MongoDB'
+                        !regex '^MongoDB'
             -
                 $match:
                     company:
                         $eq:
-                            $regularExpression:
-                                options: ''
-                                pattern: '^MongoDB'
+                            !regex '^MongoDB'

--- a/generator/config/query/in.yaml
+++ b/generator/config/query/in.yaml
@@ -28,11 +28,5 @@ tests:
                 $match:
                     tags:
                         $in:
-                            -
-                                $regularExpression:
-                                    options: ''
-                                    pattern: '^be'
-                            -
-                                $regularExpression:
-                                    options: ''
-                                    pattern: '^st'
+                            - !regex '^be'
+                            - !regex '^st'

--- a/generator/config/query/not.yaml
+++ b/generator/config/query/not.yaml
@@ -28,7 +28,4 @@ tests:
             -
                 $match:
                     price:
-                        $not:
-                            $regularExpression:
-                                pattern: '^p.*'
-                                options: ''
+                        $not: !regex '^p.*'

--- a/generator/config/query/regex.yaml
+++ b/generator/config/query/regex.yaml
@@ -21,9 +21,7 @@ tests:
                 $match:
                     sku:
                         $regex:
-                            $regularExpression:
-                                pattern: '789$'
-                                options: ''
+                            !regex '789$'
     -
         name: 'Perform Case-Insensitive Regular Expression Match'
         link: 'https://www.mongodb.com/docs/manual/reference/operator/query/regex/#perform-case-insensitive-regular-expression-match'
@@ -32,6 +30,4 @@ tests:
                 $match:
                     sku:
                         $regex:
-                            $regularExpression:
-                                pattern: '^ABC'
-                                options: 'i'
+                            !regex ['^ABC', 'i']

--- a/generator/config/stage/addFields.yaml
+++ b/generator/config/stage/addFields.yaml
@@ -14,7 +14,6 @@ arguments:
         variadic: object
         description: |
             Specify the name of each field to add and set its value to an aggregation expression or an empty object.
-
 tests:
     -
         name: 'Using Two $addFields Stages'
@@ -37,5 +36,6 @@ tests:
         name: 'Adding Fields to an Embedded Document'
         link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/addFields/#adding-fields-to-an-embedded-document'
         pipeline:
-            - $addFields:
-                  specs.fuel_type: 'unleaded'
+            -
+                $addFields:
+                    specs.fuel_type: 'unleaded'

--- a/generator/js2yaml.html
+++ b/generator/js2yaml.html
@@ -19,6 +19,14 @@
 	<label for="input">Input JS code:</label>
 	<textarea id="input">
 [
+  // Tests
+  {
+    $project: {
+      date: new Date(36),
+	  regex: /^123/,
+	  regex_with_flags: /^123/i,
+    }
+  },
   // First Stage
   {
     $bucket: {
@@ -78,6 +86,13 @@
             case 'number':
                 return ' ' + object.toString();
             case 'object':
+                if (object instanceof RegExp) {
+                    return ' !regex ' + (object.flags ? "['"+object.source+"', '"+object.flags+"']" : "'"+object.source+"'");
+                }
+                if (object instanceof Date) {
+                  return ' !date ' + object.getTime();
+                }
+
                 var dump = [];
                 for (var key in object) {
                     dump.push(key + ':' + toYaml(object[key], indent + 1));

--- a/generator/js2yaml.html
+++ b/generator/js2yaml.html
@@ -25,6 +25,7 @@
       date: new Date(36),
 	  regex: /^123/,
 	  regex_with_flags: /^123/i,
+	  binary: BinData(0, "ID=="),
     }
   },
   // First Stage
@@ -60,6 +61,17 @@
 
 
 <script>
+    class TaggedValue {
+        constructor(tag, value) {
+            this.tag = tag;
+            this.value = value;
+        }
+    }
+
+    function BinData(type, value) {
+        return new TaggedValue('binary', value);
+    }
+
     function convert(jsString) {
       try {
         return toYaml(eval(jsString), 1);
@@ -78,6 +90,18 @@
             return newline + '-' + object.map((item) => toYaml(item, indent + 1)).join(newline + '-');
         }
 
+        if (object instanceof RegExp) {
+            return ' !regex ' + (object.flags ? "['" + object.source + "', '" + object.flags + "']" : "'" + object.source + "'");
+        }
+
+        if (object instanceof Date) {
+            return ' !date ' + object.getTime();
+        }
+
+        if (object instanceof TaggedValue) {
+			return " !" + object.tag + toYaml(object.value);
+        }
+
         switch (typeof object) {
             case 'boolean':
                 return object ? ' true' : ' false';
@@ -86,13 +110,6 @@
             case 'number':
                 return ' ' + object.toString();
             case 'object':
-                if (object instanceof RegExp) {
-                    return ' !regex ' + (object.flags ? "['"+object.source+"', '"+object.flags+"']" : "'"+object.source+"'");
-                }
-                if (object instanceof Date) {
-                  return ' !date ' + object.getTime();
-                }
-
                 var dump = [];
                 for (var key in object) {
                     dump.push(key + ':' + toYaml(object[key], indent + 1));

--- a/generator/src/Definition/YamlReader.php
+++ b/generator/src/Definition/YamlReader.php
@@ -19,7 +19,10 @@ final class YamlReader
 
         $definitions = [];
         foreach ($finder as $file) {
-            $operator = Yaml::parseFile($file->getPathname(), Yaml::PARSE_OBJECT | Yaml::PARSE_OBJECT_FOR_MAP);
+            $operator = Yaml::parseFile(
+                $file->getPathname(),
+                Yaml::PARSE_OBJECT | Yaml::PARSE_OBJECT_FOR_MAP | Yaml::PARSE_DATETIME,
+            );
             $definitions[] = new OperatorDefinition(...get_object_vars($operator));
         }
 

--- a/generator/src/Definition/YamlReader.php
+++ b/generator/src/Definition/YamlReader.php
@@ -21,7 +21,7 @@ final class YamlReader
         foreach ($finder as $file) {
             $operator = Yaml::parseFile(
                 $file->getPathname(),
-                Yaml::PARSE_OBJECT | Yaml::PARSE_OBJECT_FOR_MAP | Yaml::PARSE_DATETIME,
+                Yaml::PARSE_OBJECT | Yaml::PARSE_OBJECT_FOR_MAP | Yaml::PARSE_CUSTOM_TAGS,
             );
             $definitions[] = new OperatorDefinition(...get_object_vars($operator));
         }

--- a/generator/src/OperatorTestGenerator.php
+++ b/generator/src/OperatorTestGenerator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MongoDB\CodeGenerator;
 
-use DateTimeInterface;
 use InvalidArgumentException;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\Decimal128;
@@ -24,6 +23,7 @@ use RuntimeException;
 use Symfony\Component\Yaml\Tag\TaggedValue;
 use Throwable;
 
+use function base64_decode;
 use function basename;
 use function get_object_vars;
 use function is_array;
@@ -142,7 +142,7 @@ class OperatorTestGenerator extends OperatorGenerator
                 'long' => new Int64($value),
                 'double' => new Decimal128($value),
                 'date' => new UTCDateTime($value),
-                'binary' => new Binary($value),
+                'binary' => new Binary(base64_decode($value)),
                 default => throw new InvalidArgumentException(sprintf('Yaml tag "%s" is not supported.', $object->getTag())),
             };
         }

--- a/src/Builder/Expression/DateFromPartsOperator.php
+++ b/src/Builder/Expression/DateFromPartsOperator.php
@@ -23,11 +23,11 @@ class DateFromPartsOperator implements ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
-    /** @var Decimal128|Int64|ResolvesToNumber|float|int $year Calendar year. Can be any expression that evaluates to a number. */
-    public readonly Decimal128|Int64|ResolvesToNumber|float|int $year;
+    /** @var Optional|Decimal128|Int64|ResolvesToNumber|float|int $year Calendar year. Can be any expression that evaluates to a number. */
+    public readonly Optional|Decimal128|Int64|ResolvesToNumber|float|int $year;
 
-    /** @var Decimal128|Int64|ResolvesToNumber|float|int $isoWeekYear ISO Week Date Year. Can be any expression that evaluates to a number. */
-    public readonly Decimal128|Int64|ResolvesToNumber|float|int $isoWeekYear;
+    /** @var Optional|Decimal128|Int64|ResolvesToNumber|float|int $isoWeekYear ISO Week Date Year. Can be any expression that evaluates to a number. */
+    public readonly Optional|Decimal128|Int64|ResolvesToNumber|float|int $isoWeekYear;
 
     /** @var Optional|Decimal128|Int64|ResolvesToNumber|float|int $month Month. Defaults to 1. */
     public readonly Optional|Decimal128|Int64|ResolvesToNumber|float|int $month;
@@ -57,8 +57,8 @@ class DateFromPartsOperator implements ResolvesToDate, OperatorInterface
     public readonly Optional|ResolvesToString|string $timezone;
 
     /**
-     * @param Decimal128|Int64|ResolvesToNumber|float|int $year Calendar year. Can be any expression that evaluates to a number.
-     * @param Decimal128|Int64|ResolvesToNumber|float|int $isoWeekYear ISO Week Date Year. Can be any expression that evaluates to a number.
+     * @param Optional|Decimal128|Int64|ResolvesToNumber|float|int $year Calendar year. Can be any expression that evaluates to a number.
+     * @param Optional|Decimal128|Int64|ResolvesToNumber|float|int $isoWeekYear ISO Week Date Year. Can be any expression that evaluates to a number.
      * @param Optional|Decimal128|Int64|ResolvesToNumber|float|int $month Month. Defaults to 1.
      * @param Optional|Decimal128|Int64|ResolvesToNumber|float|int $isoWeek Week of year. Defaults to 1.
      * @param Optional|Decimal128|Int64|ResolvesToNumber|float|int $day Day of month. Defaults to 1.
@@ -70,8 +70,8 @@ class DateFromPartsOperator implements ResolvesToDate, OperatorInterface
      * @param Optional|ResolvesToString|non-empty-string $timezone The timezone to carry out the operation. $timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public function __construct(
-        Decimal128|Int64|ResolvesToNumber|float|int $year,
-        Decimal128|Int64|ResolvesToNumber|float|int $isoWeekYear,
+        Optional|Decimal128|Int64|ResolvesToNumber|float|int $year = Optional::Undefined,
+        Optional|Decimal128|Int64|ResolvesToNumber|float|int $isoWeekYear = Optional::Undefined,
         Optional|Decimal128|Int64|ResolvesToNumber|float|int $month = Optional::Undefined,
         Optional|Decimal128|Int64|ResolvesToNumber|float|int $isoWeek = Optional::Undefined,
         Optional|Decimal128|Int64|ResolvesToNumber|float|int $day = Optional::Undefined,

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -463,8 +463,8 @@ trait FactoryTrait
      * Constructs a BSON Date object given the date's constituent parts.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateFromParts/
-     * @param Decimal128|Int64|ResolvesToNumber|float|int $year Calendar year. Can be any expression that evaluates to a number.
-     * @param Decimal128|Int64|ResolvesToNumber|float|int $isoWeekYear ISO Week Date Year. Can be any expression that evaluates to a number.
+     * @param Optional|Decimal128|Int64|ResolvesToNumber|float|int $year Calendar year. Can be any expression that evaluates to a number.
+     * @param Optional|Decimal128|Int64|ResolvesToNumber|float|int $isoWeekYear ISO Week Date Year. Can be any expression that evaluates to a number.
      * @param Optional|Decimal128|Int64|ResolvesToNumber|float|int $month Month. Defaults to 1.
      * @param Optional|Decimal128|Int64|ResolvesToNumber|float|int $isoWeek Week of year. Defaults to 1.
      * @param Optional|Decimal128|Int64|ResolvesToNumber|float|int $day Day of month. Defaults to 1.
@@ -476,8 +476,8 @@ trait FactoryTrait
      * @param Optional|ResolvesToString|non-empty-string $timezone The timezone to carry out the operation. $timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public static function dateFromParts(
-        Decimal128|Int64|ResolvesToNumber|float|int $year,
-        Decimal128|Int64|ResolvesToNumber|float|int $isoWeekYear,
+        Optional|Decimal128|Int64|ResolvesToNumber|float|int $year = Optional::Undefined,
+        Optional|Decimal128|Int64|ResolvesToNumber|float|int $isoWeekYear = Optional::Undefined,
         Optional|Decimal128|Int64|ResolvesToNumber|float|int $month = Optional::Undefined,
         Optional|Decimal128|Int64|ResolvesToNumber|float|int $isoWeek = Optional::Undefined,
         Optional|Decimal128|Int64|ResolvesToNumber|float|int $day = Optional::Undefined,

--- a/tests/Builder/Accumulator/Pipelines.php
+++ b/tests/Builder/Accumulator/Pipelines.php
@@ -35,7 +35,7 @@ enum Pipelines: string
                             "$code": "function(state1, state2) {\n    return {\n        count: state1.count + state2.count,\n        sum: state1.sum + state2.sum\n    }\n}"
                         },
                         "finalize": {
-                            "$code": "function(state) {\n    return (state.sum \/ state.count)\n}"
+                            "$code": "function(state) {\n    return (state.sum / state.count)\n}"
                         },
                         "lang": "js"
                     }

--- a/tests/Builder/Expression/DateAddOperatorTest.php
+++ b/tests/Builder/Expression/DateAddOperatorTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $dateAdd expression
+ */
+class DateAddOperatorTest extends PipelineTestCase
+{
+    public function testAddAFutureDate(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                expectedDeliveryDate: Expression::dateAdd(
+                    startDate: Expression::dateFieldPath('purchaseDate'),
+                    unit: 'day',
+                    amount: 3,
+                ),
+            ),
+            Stage::merge('shipping'),
+        );
+
+        $this->assertSamePipeline(Pipelines::DateAddAddAFutureDate, $pipeline);
+    }
+
+    public function testAdjustForDaylightSavingsTime(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                _id: 0,
+                location: 1,
+                start: Expression::dateToString(
+                    format: '%Y-%m-%d %H:%M',
+                    date: Expression::dateFieldPath('login'),
+                ),
+                days: Expression::dateToString(
+                    format: '%Y-%m-%d %H:%M',
+                    date: Expression::dateAdd(
+                        startDate: Expression::dateFieldPath('login'),
+                        unit: 'day',
+                        amount: 1,
+                        timezone: Expression::stringFieldPath('location'),
+                    ),
+                ),
+                hours: Expression::dateToString(
+                    format: '%Y-%m-%d %H:%M',
+                    date: Expression::dateAdd(
+                        startDate: Expression::dateFieldPath('login'),
+                        unit: 'hour',
+                        amount: 24,
+                        timezone: Expression::stringFieldPath('location'),
+                    ),
+                ),
+                startTZInfo: Expression::dateToString(
+                    format: '%Y-%m-%d %H:%M',
+                    date: Expression::dateFieldPath('login'),
+                    timezone: Expression::stringFieldPath('location'),
+                ),
+                daysTZInfo: Expression::dateToString(
+                    format: '%Y-%m-%d %H:%M',
+                    date: Expression::dateAdd(
+                        startDate: Expression::dateFieldPath('login'),
+                        unit: 'day',
+                        amount: 1,
+                        timezone: Expression::stringFieldPath('location'),
+                    ),
+                    timezone: Expression::stringFieldPath('location'),
+                ),
+                hoursTZInfo: Expression::dateToString(
+                    format: '%Y-%m-%d %H:%M',
+                    date: Expression::dateAdd(
+                        startDate: Expression::dateFieldPath('login'),
+                        unit: 'hour',
+                        amount: 24,
+                        timezone: Expression::stringFieldPath('location'),
+                    ),
+                    timezone: Expression::stringFieldPath('location'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DateAddAdjustForDaylightSavingsTime, $pipeline);
+    }
+
+    public function testFilterOnADateRange(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::expr(
+                    Expression::gt(
+                        Expression::dateFieldPath('deliveryDate'),
+                        Expression::dateAdd(
+                            startDate: Expression::dateFieldPath('purchaseDate'),
+                            unit: 'day',
+                            amount: 5,
+                        ),
+                    ),
+                ),
+            ),
+            Stage::project(
+                _id: 0,
+                custId: 1,
+                purchased: Expression::dateToString(
+                    format: '%Y-%m-%d',
+                    date: Expression::dateFieldPath('purchaseDate'),
+                ),
+                delivery: Expression::dateToString(
+                    format: '%Y-%m-%d',
+                    date: Expression::dateFieldPath('deliveryDate'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DateAddFilterOnADateRange, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/DateDiffOperatorTest.php
+++ b/tests/Builder/Expression/DateDiffOperatorTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $dateDiff expression
+ */
+class DateDiffOperatorTest extends PipelineTestCase
+{
+    public function testElapsedTime(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: null,
+                averageTime: Accumulator::avg(
+                    Expression::dateDiff(
+                        startDate: Expression::dateFieldPath('purchased'),
+                        endDate: Expression::dateFieldPath('delivered'),
+                        unit: 'day',
+                    ),
+                ),
+            ),
+            Stage::project(
+                _id: 0,
+                numDays: Expression::trunc(
+                    Expression::numberFieldPath('averageTime'),
+                    1,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DateDiffElapsedTime, $pipeline);
+    }
+
+    public function testResultPrecision(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                Start: Expression::dateFieldPath('start'),
+                End: Expression::dateFieldPath('end'),
+                years: Expression::dateDiff(
+                    startDate: Expression::dateFieldPath('start'),
+                    endDate: Expression::dateFieldPath('end'),
+                    unit: 'year',
+                ),
+                months: Expression::dateDiff(
+                    startDate: Expression::dateFieldPath('start'),
+                    endDate: Expression::dateFieldPath('end'),
+                    unit: 'month',
+                ),
+                days: Expression::dateDiff(
+                    startDate: Expression::dateFieldPath('start'),
+                    endDate: Expression::dateFieldPath('end'),
+                    unit: 'day',
+                ),
+                _id: 0,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DateDiffResultPrecision, $pipeline);
+    }
+
+    public function testWeeksPerMonth(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                wks_default: Expression::dateDiff(
+                    startDate: Expression::dateFieldPath('start'),
+                    endDate: Expression::dateFieldPath('end'),
+                    unit: 'week',
+                ),
+                wks_monday: Expression::dateDiff(
+                    startDate: Expression::dateFieldPath('start'),
+                    endDate: Expression::dateFieldPath('end'),
+                    unit: 'week',
+                    startOfWeek: 'Monday',
+                ),
+                wks_friday: Expression::dateDiff(
+                    startDate: Expression::dateFieldPath('start'),
+                    endDate: Expression::dateFieldPath('end'),
+                    unit: 'week',
+                    startOfWeek: 'fri',
+                ),
+                _id: 0,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DateDiffWeeksPerMonth, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/DateFromPartsOperatorTest.php
+++ b/tests/Builder/Expression/DateFromPartsOperatorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $dateFromParts expression
+ */
+class DateFromPartsOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                date: Expression::dateFromParts(
+                    year: 2017,
+                    month: 2,
+                    day: 8,
+                    hour: 12,
+                ),
+                date_iso: Expression::dateFromParts(
+                    isoWeekYear: 2017,
+                    isoWeek: 6,
+                    isoDayOfWeek: 3,
+                    hour: 12,
+                ),
+                date_timezone: Expression::dateFromParts(
+                    year: 2016,
+                    month: 12,
+                    day: 31,
+                    hour: 23,
+                    minute: 46,
+                    second: 12,
+                    timezone: 'America/New_York',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DateFromPartsExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/DateFromStringOperatorTest.php
+++ b/tests/Builder/Expression/DateFromStringOperatorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $dateFromString expression
+ */
+class DateFromStringOperatorTest extends PipelineTestCase
+{
+    public function testConvertingDates(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                date: Expression::dateFromString(
+                    dateString: Expression::stringFieldPath('date'),
+                    timezone: 'America/New_York',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DateFromStringConvertingDates, $pipeline);
+    }
+
+    public function testOnError(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                date: Expression::dateFromString(
+                    dateString: Expression::stringFieldPath('date'),
+                    timezone: Expression::stringFieldPath('timezone'),
+                    onError: Expression::stringFieldPath('date'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DateFromStringOnError, $pipeline);
+    }
+
+    public function testOnNull(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                date: Expression::dateFromString(
+                    dateString: Expression::stringFieldPath('date'),
+                    timezone: Expression::stringFieldPath('timezone'),
+                    onNull: new UTCDateTime(0),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DateFromStringOnNull, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/DateSubtractOperatorTest.php
+++ b/tests/Builder/Expression/DateSubtractOperatorTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $dateSubtract expression
+ */
+class DateSubtractOperatorTest extends PipelineTestCase
+{
+    public function testAdjustForDaylightSavingsTime(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                _id: 0,
+                location: 1,
+                start: Expression::dateToString(
+                    format: '%Y-%m-%d %H:%M',
+                    date: Expression::dateFieldPath('login'),
+                ),
+                days: Expression::dateToString(
+                    format: '%Y-%m-%d %H:%M',
+                    date: Expression::dateSubtract(
+                        startDate: Expression::dateFieldPath('login'),
+                        unit: 'day',
+                        amount: 1,
+                        timezone: Expression::stringFieldPath('location'),
+                    ),
+                ),
+                hours: Expression::dateToString(
+                    format: '%Y-%m-%d %H:%M',
+                    date: Expression::dateSubtract(
+                        startDate: Expression::dateFieldPath('login'),
+                        unit: 'hour',
+                        amount: 24,
+                        timezone: Expression::stringFieldPath('location'),
+                    ),
+                ),
+                startTZInfo: Expression::dateToString(
+                    format: '%Y-%m-%d %H:%M',
+                    date: Expression::dateFieldPath('login'),
+                    timezone: Expression::stringFieldPath('location'),
+                ),
+                daysTZInfo: Expression::dateToString(
+                    format: '%Y-%m-%d %H:%M',
+                    date: Expression::dateSubtract(
+                        startDate: Expression::dateFieldPath('login'),
+                        unit: 'day',
+                        amount: 1,
+                        timezone: Expression::stringFieldPath('location'),
+                    ),
+                    timezone: Expression::stringFieldPath('location'),
+                ),
+                hoursTZInfo: Expression::dateToString(
+                    format: '%Y-%m-%d %H:%M',
+                    date: Expression::dateSubtract(
+                        startDate: Expression::dateFieldPath('login'),
+                        unit: 'hour',
+                        amount: 24,
+                        timezone: Expression::stringFieldPath('location'),
+                    ),
+                    timezone: Expression::stringFieldPath('location'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DateSubtractAdjustForDaylightSavingsTime, $pipeline);
+    }
+
+    public function testFilterByRelativeDates(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::expr(
+                    Expression::gt(
+                        Expression::dateFieldPath('logoutTime'),
+                        Expression::dateSubtract(
+                            startDate: Expression::variable('NOW'),
+                            unit: 'week',
+                            amount: 1,
+                        ),
+                    ),
+                ),
+            ),
+            Stage::project(
+                _id: 0,
+                custId: 1,
+                loggedOut: Expression::dateToString(
+                    format: '%Y-%m-%d',
+                    date: Expression::dateFieldPath('logoutTime'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DateSubtractFilterByRelativeDates, $pipeline);
+    }
+
+    public function testSubtractAFixedAmount(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::expr(
+                    Expression::eq(
+                        Expression::month(
+                            Expression::dateFieldPath('logout'),
+                        ),
+                        1,
+                    ),
+                ),
+            ),
+            Stage::project(
+                logoutTime: Expression::dateSubtract(
+                    startDate: Expression::dateFieldPath('logout'),
+                    unit: 'hour',
+                    amount: 3,
+                ),
+            ),
+            Stage::merge('connectionTime'),
+        );
+
+        $this->assertSamePipeline(Pipelines::DateSubtractSubtractAFixedAmount, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/DateToPartsOperatorTest.php
+++ b/tests/Builder/Expression/DateToPartsOperatorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $dateToParts expression
+ */
+class DateToPartsOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                date: Expression::dateToParts(
+                    Expression::dateFieldPath('date'),
+                ),
+                date_iso: Expression::dateToParts(
+                    date: Expression::dateFieldPath('date'),
+                    iso8601: true,
+                ),
+                date_timezone: Expression::dateToParts(
+                    date: Expression::dateFieldPath('date'),
+                    timezone: 'America/New_York',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DateToPartsExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/DateToStringOperatorTest.php
+++ b/tests/Builder/Expression/DateToStringOperatorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $dateToString expression
+ */
+class DateToStringOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                yearMonthDayUTC: Expression::dateToString(
+                    format: '%Y-%m-%d',
+                    date: Expression::dateFieldPath('date'),
+                ),
+                timewithOffsetNY: Expression::dateToString(
+                    format: '%H:%M:%S:%L%z',
+                    date: Expression::dateFieldPath('date'),
+                    timezone: 'America/New_York',
+                ),
+                timewithOffset430: Expression::dateToString(
+                    format: '%H:%M:%S:%L%z',
+                    date: Expression::dateFieldPath('date'),
+                    timezone: '+04:30',
+                ),
+                minutesOffsetNY: Expression::dateToString(
+                    format: '%Z',
+                    date: Expression::dateFieldPath('date'),
+                    timezone: 'America/New_York',
+                ),
+                minutesOffset430: Expression::dateToString(
+                    format: '%Z',
+                    date: Expression::dateFieldPath('date'),
+                    timezone: '+04:30',
+                ),
+                abbreviated_month: Expression::dateToString(
+                    format: '%b',
+                    date: Expression::dateFieldPath('date'),
+                    timezone: '+04:30',
+                ),
+                full_month: Expression::dateToString(
+                    format: '%B',
+                    date: Expression::dateFieldPath('date'),
+                    timezone: '+04:30',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DateToStringExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/DateTruncOperatorTest.php
+++ b/tests/Builder/Expression/DateTruncOperatorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $dateTrunc expression
+ */
+class DateTruncOperatorTest extends PipelineTestCase
+{
+    public function testTruncateOrderDatesAndObtainQuantitySumInAGroupPipelineStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: object(
+                    truncatedOrderDate: Expression::dateTrunc(
+                        date: Expression::dateFieldPath('orderDate'),
+                        unit: 'month',
+                        binSize: 6,
+                    ),
+                ),
+                sumQuantity: Accumulator::sum(
+                    Expression::intFieldPath('quantity'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DateTruncTruncateOrderDatesAndObtainQuantitySumInAGroupPipelineStage, $pipeline);
+    }
+
+    public function testTruncateOrderDatesInAProjectPipelineStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                _id: 1,
+                orderDate: 1,
+                truncatedOrderDate: Expression::dateTrunc(
+                    date: Expression::dateFieldPath('orderDate'),
+                    unit: 'week',
+                    binSize: 2,
+                    timezone: 'America/Los_Angeles',
+                    startOfWeek: 'Monday',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DateTruncTruncateOrderDatesInAProjectPipelineStage, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/DayOfMonthOperatorTest.php
+++ b/tests/Builder/Expression/DayOfMonthOperatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $dayOfMonth expression
+ */
+class DayOfMonthOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                day: Expression::dayOfMonth(
+                    Expression::dateFieldPath('date'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DayOfMonthExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/DayOfWeekOperatorTest.php
+++ b/tests/Builder/Expression/DayOfWeekOperatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $dayOfWeek expression
+ */
+class DayOfWeekOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                dayOfWeek: Expression::dayOfWeek(
+                    Expression::dateFieldPath('date'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DayOfWeekExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/DayOfYearOperatorTest.php
+++ b/tests/Builder/Expression/DayOfYearOperatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $dayOfYear expression
+ */
+class DayOfYearOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                dayOfYear: Expression::dayOfYear(
+                    Expression::dateFieldPath('date'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DayOfYearExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/HourOperatorTest.php
+++ b/tests/Builder/Expression/HourOperatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $hour expression
+ */
+class HourOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                hour: Expression::hour(
+                    Expression::dateFieldPath('date'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::HourExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/IsoDayOfWeekOperatorTest.php
+++ b/tests/Builder/Expression/IsoDayOfWeekOperatorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $isoDayOfWeek expression
+ */
+class IsoDayOfWeekOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                _id: 0,
+                name: Expression::stringFieldPath('name'),
+                dayOfWeek: Expression::isoDayOfWeek(
+                    Expression::dateFieldPath('birthday'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::IsoDayOfWeekExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/IsoWeekOperatorTest.php
+++ b/tests/Builder/Expression/IsoWeekOperatorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $isoWeek expression
+ */
+class IsoWeekOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                _id: 0,
+                city: Expression::stringFieldPath('city'),
+                weekNumber: Expression::isoWeek(
+                    Expression::dateFieldPath('date'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::IsoWeekExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/IsoWeekYearOperatorTest.php
+++ b/tests/Builder/Expression/IsoWeekYearOperatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $isoWeekYear expression
+ */
+class IsoWeekYearOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                yearNumber: Expression::isoWeekYear(
+                    Expression::dateFieldPath('date'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::IsoWeekYearExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/MillisecondOperatorTest.php
+++ b/tests/Builder/Expression/MillisecondOperatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $millisecond expression
+ */
+class MillisecondOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                milliseconds: Expression::millisecond(
+                    Expression::dateFieldPath('date'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MillisecondExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/MinuteOperatorTest.php
+++ b/tests/Builder/Expression/MinuteOperatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $minute expression
+ */
+class MinuteOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                minutes: Expression::minute(
+                    Expression::dateFieldPath('date'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MinuteExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/MonthOperatorTest.php
+++ b/tests/Builder/Expression/MonthOperatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $month expression
+ */
+class MonthOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                month: Expression::month(
+                    Expression::dateFieldPath('date'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MonthExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -926,7 +926,7 @@ enum Pipelines: string
                         "second": {
                             "$numberInt": "12"
                         },
-                        "timezone": "America\/New_York"
+                        "timezone": "America/New_York"
                     }
                 }
             }
@@ -946,7 +946,7 @@ enum Pipelines: string
                 "date": {
                     "$dateFromString": {
                         "dateString": "$date",
-                        "timezone": "America\/New_York"
+                        "timezone": "America/New_York"
                     }
                 }
             }
@@ -1206,7 +1206,7 @@ enum Pipelines: string
                 "date_timezone": {
                     "$dateToParts": {
                         "date": "$date",
-                        "timezone": "America\/New_York"
+                        "timezone": "America/New_York"
                     }
                 }
             }
@@ -1233,7 +1233,7 @@ enum Pipelines: string
                     "$dateToString": {
                         "format": "%H:%M:%S:%L%z",
                         "date": "$date",
-                        "timezone": "America\/New_York"
+                        "timezone": "America/New_York"
                     }
                 },
                 "timewithOffset430": {
@@ -1247,7 +1247,7 @@ enum Pipelines: string
                     "$dateToString": {
                         "format": "%Z",
                         "date": "$date",
-                        "timezone": "America\/New_York"
+                        "timezone": "America/New_York"
                     }
                 },
                 "minutesOffset430": {
@@ -1298,7 +1298,7 @@ enum Pipelines: string
                         "binSize": {
                             "$numberInt": "2"
                         },
-                        "timezone": "America\/Los_Angeles",
+                        "timezone": "America/Los_Angeles",
                         "startOfWeek": "Monday"
                     }
                 }

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -574,6 +574,825 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Add a Future Date
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateAdd/#add-a-future-date
+     */
+    case DateAddAddAFutureDate = <<<'JSON'
+    [
+        {
+            "$project": {
+                "expectedDeliveryDate": {
+                    "$dateAdd": {
+                        "startDate": "$purchaseDate",
+                        "unit": "day",
+                        "amount": {
+                            "$numberInt": "3"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "$merge": {
+                "into": "shipping"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Filter on a Date Range
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateAdd/#filter-on-a-date-range
+     */
+    case DateAddFilterOnADateRange = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$expr": {
+                    "$gt": [
+                        "$deliveryDate",
+                        {
+                            "$dateAdd": {
+                                "startDate": "$purchaseDate",
+                                "unit": "day",
+                                "amount": {
+                                    "$numberInt": "5"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "custId": {
+                    "$numberInt": "1"
+                },
+                "purchased": {
+                    "$dateToString": {
+                        "format": "%Y-%m-%d",
+                        "date": "$purchaseDate"
+                    }
+                },
+                "delivery": {
+                    "$dateToString": {
+                        "format": "%Y-%m-%d",
+                        "date": "$deliveryDate"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Adjust for Daylight Savings Time
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateAdd/#adjust-for-daylight-savings-time
+     */
+    case DateAddAdjustForDaylightSavingsTime = <<<'JSON'
+    [
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "location": {
+                    "$numberInt": "1"
+                },
+                "start": {
+                    "$dateToString": {
+                        "format": "%Y-%m-%d %H:%M",
+                        "date": "$login"
+                    }
+                },
+                "days": {
+                    "$dateToString": {
+                        "format": "%Y-%m-%d %H:%M",
+                        "date": {
+                            "$dateAdd": {
+                                "startDate": "$login",
+                                "unit": "day",
+                                "amount": {
+                                    "$numberInt": "1"
+                                },
+                                "timezone": "$location"
+                            }
+                        }
+                    }
+                },
+                "hours": {
+                    "$dateToString": {
+                        "format": "%Y-%m-%d %H:%M",
+                        "date": {
+                            "$dateAdd": {
+                                "startDate": "$login",
+                                "unit": "hour",
+                                "amount": {
+                                    "$numberInt": "24"
+                                },
+                                "timezone": "$location"
+                            }
+                        }
+                    }
+                },
+                "startTZInfo": {
+                    "$dateToString": {
+                        "format": "%Y-%m-%d %H:%M",
+                        "date": "$login",
+                        "timezone": "$location"
+                    }
+                },
+                "daysTZInfo": {
+                    "$dateToString": {
+                        "format": "%Y-%m-%d %H:%M",
+                        "date": {
+                            "$dateAdd": {
+                                "startDate": "$login",
+                                "unit": "day",
+                                "amount": {
+                                    "$numberInt": "1"
+                                },
+                                "timezone": "$location"
+                            }
+                        },
+                        "timezone": "$location"
+                    }
+                },
+                "hoursTZInfo": {
+                    "$dateToString": {
+                        "format": "%Y-%m-%d %H:%M",
+                        "date": {
+                            "$dateAdd": {
+                                "startDate": "$login",
+                                "unit": "hour",
+                                "amount": {
+                                    "$numberInt": "24"
+                                },
+                                "timezone": "$location"
+                            }
+                        },
+                        "timezone": "$location"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Elapsed Time
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateDiff/#elapsed-time
+     */
+    case DateDiffElapsedTime = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": null,
+                "averageTime": {
+                    "$avg": {
+                        "$dateDiff": {
+                            "startDate": "$purchased",
+                            "endDate": "$delivered",
+                            "unit": "day"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "numDays": {
+                    "$trunc": [
+                        "$averageTime",
+                        {
+                            "$numberInt": "1"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Result Precision
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateDiff/#result-precision
+     */
+    case DateDiffResultPrecision = <<<'JSON'
+    [
+        {
+            "$project": {
+                "Start": "$start",
+                "End": "$end",
+                "years": {
+                    "$dateDiff": {
+                        "startDate": "$start",
+                        "endDate": "$end",
+                        "unit": "year"
+                    }
+                },
+                "months": {
+                    "$dateDiff": {
+                        "startDate": "$start",
+                        "endDate": "$end",
+                        "unit": "month"
+                    }
+                },
+                "days": {
+                    "$dateDiff": {
+                        "startDate": "$start",
+                        "endDate": "$end",
+                        "unit": "day"
+                    }
+                },
+                "_id": {
+                    "$numberInt": "0"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Weeks Per Month
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateDiff/#weeks-per-month
+     */
+    case DateDiffWeeksPerMonth = <<<'JSON'
+    [
+        {
+            "$project": {
+                "wks_default": {
+                    "$dateDiff": {
+                        "startDate": "$start",
+                        "endDate": "$end",
+                        "unit": "week"
+                    }
+                },
+                "wks_monday": {
+                    "$dateDiff": {
+                        "startDate": "$start",
+                        "endDate": "$end",
+                        "unit": "week",
+                        "startOfWeek": "Monday"
+                    }
+                },
+                "wks_friday": {
+                    "$dateDiff": {
+                        "startDate": "$start",
+                        "endDate": "$end",
+                        "unit": "week",
+                        "startOfWeek": "fri"
+                    }
+                },
+                "_id": {
+                    "$numberInt": "0"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateFromParts/#example
+     */
+    case DateFromPartsExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "date": {
+                    "$dateFromParts": {
+                        "year": {
+                            "$numberInt": "2017"
+                        },
+                        "month": {
+                            "$numberInt": "2"
+                        },
+                        "day": {
+                            "$numberInt": "8"
+                        },
+                        "hour": {
+                            "$numberInt": "12"
+                        }
+                    }
+                },
+                "date_iso": {
+                    "$dateFromParts": {
+                        "isoWeekYear": {
+                            "$numberInt": "2017"
+                        },
+                        "isoWeek": {
+                            "$numberInt": "6"
+                        },
+                        "isoDayOfWeek": {
+                            "$numberInt": "3"
+                        },
+                        "hour": {
+                            "$numberInt": "12"
+                        }
+                    }
+                },
+                "date_timezone": {
+                    "$dateFromParts": {
+                        "year": {
+                            "$numberInt": "2016"
+                        },
+                        "month": {
+                            "$numberInt": "12"
+                        },
+                        "day": {
+                            "$numberInt": "31"
+                        },
+                        "hour": {
+                            "$numberInt": "23"
+                        },
+                        "minute": {
+                            "$numberInt": "46"
+                        },
+                        "second": {
+                            "$numberInt": "12"
+                        },
+                        "timezone": "America\/New_York"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Converting Dates
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateFromString/#converting-dates
+     */
+    case DateFromStringConvertingDates = <<<'JSON'
+    [
+        {
+            "$project": {
+                "date": {
+                    "$dateFromString": {
+                        "dateString": "$date",
+                        "timezone": "America\/New_York"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * onError
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateFromString/#onerror
+     */
+    case DateFromStringOnError = <<<'JSON'
+    [
+        {
+            "$project": {
+                "date": {
+                    "$dateFromString": {
+                        "dateString": "$date",
+                        "timezone": "$timezone",
+                        "onError": "$date"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * onNull
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateFromString/#onnull
+     */
+    case DateFromStringOnNull = <<<'JSON'
+    [
+        {
+            "$project": {
+                "date": {
+                    "$dateFromString": {
+                        "dateString": "$date",
+                        "timezone": "$timezone",
+                        "onNull": {
+                            "$date": {
+                                "$numberLong": "0"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Subtract A Fixed Amount
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateSubtract/#subtract-a-fixed-amount
+     */
+    case DateSubtractSubtractAFixedAmount = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$expr": {
+                    "$eq": [
+                        {
+                            "$month": {
+                                "date": "$logout"
+                            }
+                        },
+                        {
+                            "$numberInt": "1"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "$project": {
+                "logoutTime": {
+                    "$dateSubtract": {
+                        "startDate": "$logout",
+                        "unit": "hour",
+                        "amount": {
+                            "$numberInt": "3"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "$merge": {
+                "into": "connectionTime"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Filter by Relative Dates
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateSubtract/#filter-by-relative-dates
+     */
+    case DateSubtractFilterByRelativeDates = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$expr": {
+                    "$gt": [
+                        "$logoutTime",
+                        {
+                            "$dateSubtract": {
+                                "startDate": "$$NOW",
+                                "unit": "week",
+                                "amount": {
+                                    "$numberInt": "1"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "custId": {
+                    "$numberInt": "1"
+                },
+                "loggedOut": {
+                    "$dateToString": {
+                        "format": "%Y-%m-%d",
+                        "date": "$logoutTime"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Adjust for Daylight Savings Time
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateSubtract/#adjust-for-daylight-savings-time
+     */
+    case DateSubtractAdjustForDaylightSavingsTime = <<<'JSON'
+    [
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "location": {
+                    "$numberInt": "1"
+                },
+                "start": {
+                    "$dateToString": {
+                        "format": "%Y-%m-%d %H:%M",
+                        "date": "$login"
+                    }
+                },
+                "days": {
+                    "$dateToString": {
+                        "format": "%Y-%m-%d %H:%M",
+                        "date": {
+                            "$dateSubtract": {
+                                "startDate": "$login",
+                                "unit": "day",
+                                "amount": {
+                                    "$numberInt": "1"
+                                },
+                                "timezone": "$location"
+                            }
+                        }
+                    }
+                },
+                "hours": {
+                    "$dateToString": {
+                        "format": "%Y-%m-%d %H:%M",
+                        "date": {
+                            "$dateSubtract": {
+                                "startDate": "$login",
+                                "unit": "hour",
+                                "amount": {
+                                    "$numberInt": "24"
+                                },
+                                "timezone": "$location"
+                            }
+                        }
+                    }
+                },
+                "startTZInfo": {
+                    "$dateToString": {
+                        "format": "%Y-%m-%d %H:%M",
+                        "date": "$login",
+                        "timezone": "$location"
+                    }
+                },
+                "daysTZInfo": {
+                    "$dateToString": {
+                        "format": "%Y-%m-%d %H:%M",
+                        "date": {
+                            "$dateSubtract": {
+                                "startDate": "$login",
+                                "unit": "day",
+                                "amount": {
+                                    "$numberInt": "1"
+                                },
+                                "timezone": "$location"
+                            }
+                        },
+                        "timezone": "$location"
+                    }
+                },
+                "hoursTZInfo": {
+                    "$dateToString": {
+                        "format": "%Y-%m-%d %H:%M",
+                        "date": {
+                            "$dateSubtract": {
+                                "startDate": "$login",
+                                "unit": "hour",
+                                "amount": {
+                                    "$numberInt": "24"
+                                },
+                                "timezone": "$location"
+                            }
+                        },
+                        "timezone": "$location"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateToParts/#example
+     */
+    case DateToPartsExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "date": {
+                    "$dateToParts": {
+                        "date": "$date"
+                    }
+                },
+                "date_iso": {
+                    "$dateToParts": {
+                        "date": "$date",
+                        "iso8601": true
+                    }
+                },
+                "date_timezone": {
+                    "$dateToParts": {
+                        "date": "$date",
+                        "timezone": "America\/New_York"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateToString/#example
+     */
+    case DateToStringExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "yearMonthDayUTC": {
+                    "$dateToString": {
+                        "format": "%Y-%m-%d",
+                        "date": "$date"
+                    }
+                },
+                "timewithOffsetNY": {
+                    "$dateToString": {
+                        "format": "%H:%M:%S:%L%z",
+                        "date": "$date",
+                        "timezone": "America\/New_York"
+                    }
+                },
+                "timewithOffset430": {
+                    "$dateToString": {
+                        "format": "%H:%M:%S:%L%z",
+                        "date": "$date",
+                        "timezone": "+04:30"
+                    }
+                },
+                "minutesOffsetNY": {
+                    "$dateToString": {
+                        "format": "%Z",
+                        "date": "$date",
+                        "timezone": "America\/New_York"
+                    }
+                },
+                "minutesOffset430": {
+                    "$dateToString": {
+                        "format": "%Z",
+                        "date": "$date",
+                        "timezone": "+04:30"
+                    }
+                },
+                "abbreviated_month": {
+                    "$dateToString": {
+                        "format": "%b",
+                        "date": "$date",
+                        "timezone": "+04:30"
+                    }
+                },
+                "full_month": {
+                    "$dateToString": {
+                        "format": "%B",
+                        "date": "$date",
+                        "timezone": "+04:30"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Truncate Order Dates in a $project Pipeline Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateTrunc/#truncate-order-dates-in-a--project-pipeline-stage
+     */
+    case DateTruncTruncateOrderDatesInAProjectPipelineStage = <<<'JSON'
+    [
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "1"
+                },
+                "orderDate": {
+                    "$numberInt": "1"
+                },
+                "truncatedOrderDate": {
+                    "$dateTrunc": {
+                        "date": "$orderDate",
+                        "unit": "week",
+                        "binSize": {
+                            "$numberInt": "2"
+                        },
+                        "timezone": "America\/Los_Angeles",
+                        "startOfWeek": "Monday"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Truncate Order Dates and Obtain Quantity Sum in a $group Pipeline Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateTrunc/#truncate-order-dates-and-obtain-quantity-sum-in-a--group-pipeline-stage
+     */
+    case DateTruncTruncateOrderDatesAndObtainQuantitySumInAGroupPipelineStage = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": {
+                    "truncatedOrderDate": {
+                        "$dateTrunc": {
+                            "date": "$orderDate",
+                            "unit": "month",
+                            "binSize": {
+                                "$numberInt": "6"
+                            }
+                        }
+                    }
+                },
+                "sumQuantity": {
+                    "$sum": "$quantity"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dayOfMonth/#example
+     */
+    case DayOfMonthExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "day": {
+                    "$dayOfMonth": {
+                        "date": "$date"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dayOfWeek/#example
+     */
+    case DayOfWeekExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "dayOfWeek": {
+                    "$dayOfWeek": {
+                        "date": "$date"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dayOfYear/#example
+     */
+    case DayOfYearExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "dayOfYear": {
+                    "$dayOfYear": {
+                        "date": "$date"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Example
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/eq/#example
@@ -1010,6 +1829,25 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/hour/#example
+     */
+    case HourExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "hour": {
+                    "$hour": {
+                        "date": "$date"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Single Input Expression
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/ifNull/#single-input-expression
@@ -1131,6 +1969,71 @@ enum Pipelines: string
                             ]
                         },
                         "else": "One or more fields is not an array."
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/isoDayOfWeek/#example
+     */
+    case IsoDayOfWeekExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "name": "$name",
+                "dayOfWeek": {
+                    "$isoDayOfWeek": {
+                        "date": "$birthday"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/isoWeek/#example
+     */
+    case IsoWeekExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "city": "$city",
+                "weekNumber": {
+                    "$isoWeek": {
+                        "date": "$date"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/isoWeekYear/#example
+     */
+    case IsoWeekYearExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "yearNumber": {
+                    "$isoWeekYear": {
+                        "date": "$date"
                     }
                 }
             }
@@ -1491,6 +2394,25 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/millisecond/#example
+     */
+    case MillisecondExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "milliseconds": {
+                    "$millisecond": {
+                        "date": "$date"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Use in $project Stage
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/min/#use-in--project-stage
@@ -1535,6 +2457,44 @@ enum Pipelines: string
                             "$numberInt": "2"
                         },
                         "input": "$score"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/minute/#example
+     */
+    case MinuteExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "minutes": {
+                    "$minute": {
+                        "date": "$date"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/month/#example
+     */
+    case MonthExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "month": {
+                    "$month": {
+                        "date": "$date"
                     }
                 }
             }
@@ -2039,6 +2999,25 @@ enum Pipelines: string
                 },
                 "reverseFavorites": {
                     "$reverseArray": "$favorites"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/second/#example
+     */
+    case SecondExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "seconds": {
+                    "$second": {
+                        "date": "$date"
+                    }
                 }
             }
         }
@@ -2825,6 +3804,30 @@ enum Pipelines: string
     /**
      * Example
      *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toDate/#example
+     */
+    case ToDateExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "convertedDate": {
+                    "$toDate": "$order_date"
+                }
+            }
+        },
+        {
+            "$sort": {
+                "convertedDate": {
+                    "$numberInt": "1"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toHashedIndexKey/#example
      */
     case ToHashedIndexKeyExample = <<<'JSON'
@@ -2905,6 +3908,44 @@ enum Pipelines: string
                                 }
                             }
                         }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/week/#example
+     */
+    case WeekExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "week": {
+                    "$week": {
+                        "date": "$date"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/year/#example
+     */
+    case YearExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "year": {
+                    "$year": {
+                        "date": "$date"
                     }
                 }
             }

--- a/tests/Builder/Expression/SecondOperatorTest.php
+++ b/tests/Builder/Expression/SecondOperatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $second expression
+ */
+class SecondOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                seconds: Expression::second(
+                    Expression::dateFieldPath('date'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SecondExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/ToDateOperatorTest.php
+++ b/tests/Builder/Expression/ToDateOperatorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $toDate expression
+ */
+class ToDateOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                convertedDate: Expression::toDate(
+                    Expression::fieldPath('order_date'),
+                ),
+            ),
+            Stage::sort(
+                object(
+                    convertedDate: 1,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ToDateExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/WeekOperatorTest.php
+++ b/tests/Builder/Expression/WeekOperatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $week expression
+ */
+class WeekOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                week: Expression::week(
+                    Expression::dateFieldPath('date'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::WeekExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/YearOperatorTest.php
+++ b/tests/Builder/Expression/YearOperatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $year expression
+ */
+class YearOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                year: Expression::year(
+                    Expression::dateFieldPath('date'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::YearExample, $pipeline);
+    }
+}

--- a/tests/Builder/Query/Pipelines.php
+++ b/tests/Builder/Query/Pipelines.php
@@ -338,8 +338,8 @@ enum Pipelines: string
             "$match": {
                 "company": {
                     "$regularExpression": {
-                        "options": "",
-                        "pattern": "^MongoDB"
+                        "pattern": "^MongoDB",
+                        "options": ""
                     }
                 }
             }
@@ -349,8 +349,8 @@ enum Pipelines: string
                 "company": {
                     "$eq": {
                         "$regularExpression": {
-                            "options": "",
-                            "pattern": "^MongoDB"
+                            "pattern": "^MongoDB",
+                            "options": ""
                         }
                     }
                 }
@@ -813,14 +813,14 @@ enum Pipelines: string
                     "$in": [
                         {
                             "$regularExpression": {
-                                "options": "",
-                                "pattern": "^be"
+                                "pattern": "^be",
+                                "options": ""
                             }
                         },
                         {
                             "$regularExpression": {
-                                "options": "",
-                                "pattern": "^st"
+                                "pattern": "^st",
+                                "options": ""
                             }
                         }
                     ]


### PR DESCRIPTION
Fix [PHPLIB-1350](https://jira.mongodb.org/browse/PHPLIB-1350)

https://www.mongodb.com/docs/manual/reference/operator/aggregation/#date-expression-operators

- `$dateAdd`
- `$dateDiff`
- `$dateFromParts`
- `$dateFromString`
- `$dateSubtract`
- `$dateToParts`
- `$dateToString`
- `$dateTrunc`
- `$dayOfMonth` using verbose `date` field
- `$dayOfWeek` using verbose `date` field
- `$dayOfYear` using verbose `date` field
- `$hour` using verbose `date` field
- `$isoDayOfWeek` using verbose `date` field
- `$isoWeek` using verbose `date` field
- `$isoWeekYear` using verbose `date` field
- `$millisecond` using verbose `date` field
- `$minute` using verbose `date` field
- `$month` using verbose `date` field
- `$second` using verbose `date` field
- `$toDate`
- `$week` using verbose `date` field
- `$year` using verbose `date` field