### PR TITLE
PHPLIB-1348 Add tests on Custom Aggregation Expression Operators

### DIFF
--- a/generator/config/accumulator/accumulator.yaml
+++ b/generator/config/accumulator/accumulator.yaml
@@ -64,14 +64,29 @@ tests:
                     avgCopies:
                         $accumulator:
                             init:
-                                $code: 'function () { return { count: 0, sum: 0 } }'
+                                $code: |-
+                                    function() {
+                                        return { count: 0, sum: 0 }
+                                    }
                             accumulate:
-                                $code: 'function (state, numCopies) { return { count: state.count + 1, sum: state.sum + numCopies } }'
+                                $code: |-
+                                    function(state, numCopies) {
+                                        return { count: state.count + 1, sum: state.sum + numCopies }
+                                    }
                             accumulateArgs: [ "$copies" ],
                             merge:
-                                $code: 'function (state1, state2) { return { count: state1.count + state2.count, sum: state1.sum + state2.sum } }'
+                                $code: |-
+                                    function(state1, state2) {
+                                        return {
+                                            count: state1.count + state2.count,
+                                            sum: state1.sum + state2.sum
+                                        }
+                                    }
                             finalize:
-                                $code: 'function (state) { return (state.sum / state.count) }'
+                                $code: |-
+                                    function(state) {
+                                        return (state.sum / state.count)
+                                    }
                             lang: 'js'
 
     -
@@ -85,16 +100,34 @@ tests:
                     restaurants:
                         $accumulator:
                             init:
-                                $code: 'function (city, userProfileCity) { return { max: city === userProfileCity ? 3 : 1, restaurants: [] } }'
+                                $code: |-
+                                    function(city, userProfileCity) {
+                                        return { max: city === userProfileCity ? 3 : 1, restaurants: [] }
+                                    }
                             initArgs:
                                 - '$city'
                                 - 'Bettles'
                             accumulate:
-                                $code: 'function (state, restaurantName) { if (state.restaurants.length < state.max) { state.restaurants.push(restaurantName); } return state; }'
+                                $code: |-
+                                    function(state, restaurantName) {
+                                        if (state.restaurants.length < state.max) {
+                                            state.restaurants.push(restaurantName);
+                                        }
+                                        return state;
+                                    }
                             accumulateArgs:
                                 - '$name'
                             merge:
-                                $code: 'function (state1, state2) { return { max: state1.max, restaurants: state1.restaurants.concat(state2.restaurants).slice(0, state1.max) } }'
+                                $code: |-
+                                    function(state1, state2) {
+                                        return {
+                                            max: state1.max,
+                                            restaurants: state1.restaurants.concat(state2.restaurants).slice(0, state1.max)
+                                        }
+                                    }
                             finalize:
-                                $code: 'function (state) { return state.restaurants }'
+                                $code: |-
+                                    function(state) {
+                                        return state.restaurants
+                                    }
                             lang: 'js'

--- a/generator/config/expression/function.yaml
+++ b/generator/config/expression/function.yaml
@@ -21,8 +21,54 @@ arguments:
             - array
         description: |
             Arguments passed to the function body. If the body function does not take an argument, you can specify an empty array [ ].
+        default: []
     -
         name: lang
         type:
             - string
         default: js
+tests:
+    -
+        name: 'Usage Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/function/#example-1--usage-example'
+        pipeline:
+            -
+                $addFields:
+                    isFound:
+                        $function:
+                            body:
+                                $code: |-
+                                    function(name) {
+                                        return hex_md5(name) == "15b0a220baa16331e8d80e15367677ad"
+                                    }
+                            args:
+                                - '$name'
+                            lang: 'js'
+                    message:
+                        $function:
+                            body:
+                                $code: |-
+                                    function(name, scores) {
+                                        let total = Array.sum(scores);
+                                        return `Hello ${name}. Your total score is ${total}.`
+                                    }
+                            args:
+                                - '$name'
+                                - '$scores'
+                            lang: 'js'
+    -
+        name: 'Alternative to $where'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/function/#example-2--alternative-to--where'
+        pipeline:
+            -
+                $match:
+                    $expr:
+                        $function:
+                            body:
+                                $code: |-
+                                    function(name) {
+                                        return hex_md5(name) == "15b0a220baa16331e8d80e15367677ad";
+                                    }
+                            args:
+                                - '$name'
+                            lang: 'js'

--- a/generator/config/query/where.yaml
+++ b/generator/config/query/where.yaml
@@ -18,14 +18,19 @@ tests:
         pipeline:
             -
                 $match:
-                    $where: 'function() { return hex_md5(this.name) == "9b53e667f30cd329dca1ec9e6a83e994" }'
+                    $where:
+                        $code: |-
+                            function() {
+                                return hex_md5(this.name) == "9b53e667f30cd329dca1ec9e6a83e994"
+                            }
             -
                 $match:
                     $expr:
                         $function:
-                            body: |-
-                                function(name) {
-                                    return hex_md5(name) == "9b53e667f30cd329dca1ec9e6a83e994";
-                                }
+                            body:
+                                $code: |-
+                                    function(name) {
+                                        return hex_md5(name) == "9b53e667f30cd329dca1ec9e6a83e994";
+                                    }
                             args: ['$name']
                             lang: 'js'

--- a/generator/config/schema.json
+++ b/generator/config/schema.json
@@ -166,7 +166,7 @@
                 },
                 "default": {
                     "$comment": "The default value for the argument.",
-                    "type": ["string", "number", "boolean"]
+                    "type": ["array", "boolean", "number", "string"]
                 }
             },
             "required": [

--- a/generator/src/OperatorClassGenerator.php
+++ b/generator/src/OperatorClassGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MongoDB\CodeGenerator;
 
+use MongoDB\BSON\Javascript;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
 use MongoDB\Builder\Type\QueryObject;
@@ -147,6 +148,17 @@ class OperatorClassGenerator extends OperatorGenerator
                     $constuctor->addBody(<<<PHP
                     if (is_array(\${$argument->name})) {
                         \${$argument->name} = QueryObject::create(\${$argument->name});
+                    }
+
+                    PHP);
+                }
+
+                if ($type->javascript) {
+                    $namespace->addUseFunction('is_string');
+                    $namespace->addUse(Javascript::class);
+                    $constuctor->addBody(<<<PHP
+                    if (is_string(\${$argument->name})) {
+                        \${$argument->name} = new Javascript(\${$argument->name});
                     }
 
                     PHP);

--- a/generator/src/OperatorFactoryGenerator.php
+++ b/generator/src/OperatorFactoryGenerator.php
@@ -80,6 +80,8 @@ final class OperatorFactoryGenerator extends OperatorGenerator
             } else {
                 if ($argument->optional) {
                     $parameter->setDefaultValue(new Literal('Optional::Undefined'));
+                } elseif ($argument->default !== null) {
+                    $parameter->setDefaultValue($argument->default);
                 }
 
                 $method->addComment('@param ' . $type->doc . ' $' . $argument->name . rtrim(' ' . $argument->description));

--- a/generator/src/OperatorGenerator.php
+++ b/generator/src/OperatorGenerator.php
@@ -71,7 +71,7 @@ abstract class OperatorGenerator extends AbstractGenerator
      * Expression types can contain class names, interface, native types or "list".
      * PHPDoc types are more precise than native types, so we use them systematically even if redundant.
      *
-     * @return object{native:string,doc:string,use:list<class-string>,list:bool,query:bool}
+     * @return object{native:string,doc:string,use:list<class-string>,list:bool,query:bool,javascript:bool}
      */
     final protected function getAcceptedTypes(ArgumentDefinition $arg): stdClass
     {
@@ -117,6 +117,9 @@ abstract class OperatorGenerator extends AbstractGenerator
         // If the argument is a query, we need to convert it to a QueryObject
         $isQuery = in_array('query', $arg->type, true);
 
+        // If the argument is code, we need to convert it to a Javascript object
+        $isJavascript = in_array('javascript', $arg->type, true);
+
         // mixed can only be used as a standalone type
         if (in_array('mixed', $nativeTypes, true)) {
             $nativeTypes = ['mixed'];
@@ -132,6 +135,7 @@ abstract class OperatorGenerator extends AbstractGenerator
             'use' => array_unique($use),
             'list' => $listCheck,
             'query' => $isQuery,
+            'javascript' => $isJavascript,
         ];
     }
 

--- a/src/Builder/Accumulator/AccumulatorAccumulator.php
+++ b/src/Builder/Accumulator/AccumulatorAccumulator.php
@@ -20,6 +20,7 @@ use MongoDB\Model\BSONArray;
 
 use function array_is_list;
 use function is_array;
+use function is_string;
 
 /**
  * Defines a custom accumulator function.
@@ -70,13 +71,25 @@ class AccumulatorAccumulator implements AccumulatorInterface, OperatorInterface
         Optional|PackedArray|ResolvesToArray|BSONArray|array $initArgs = Optional::Undefined,
         Optional|Javascript|string $finalize = Optional::Undefined,
     ) {
+        if (is_string($init)) {
+            $init = new Javascript($init);
+        }
+
         $this->init = $init;
+        if (is_string($accumulate)) {
+            $accumulate = new Javascript($accumulate);
+        }
+
         $this->accumulate = $accumulate;
         if (is_array($accumulateArgs) && ! array_is_list($accumulateArgs)) {
             throw new InvalidArgumentException('Expected $accumulateArgs argument to be a list, got an associative array.');
         }
 
         $this->accumulateArgs = $accumulateArgs;
+        if (is_string($merge)) {
+            $merge = new Javascript($merge);
+        }
+
         $this->merge = $merge;
         $this->lang = $lang;
         if (is_array($initArgs) && ! array_is_list($initArgs)) {
@@ -84,6 +97,10 @@ class AccumulatorAccumulator implements AccumulatorInterface, OperatorInterface
         }
 
         $this->initArgs = $initArgs;
+        if (is_string($finalize)) {
+            $finalize = new Javascript($finalize);
+        }
+
         $this->finalize = $finalize;
     }
 

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -767,8 +767,8 @@ trait FactoryTrait
      */
     public static function function(
         Javascript|string $body,
-        PackedArray|BSONArray|array $args,
-        string $lang,
+        PackedArray|BSONArray|array $args = [],
+        string $lang = 'js',
     ): FunctionOperator
     {
         return new FunctionOperator($body, $args, $lang);

--- a/src/Builder/Expression/FunctionOperator.php
+++ b/src/Builder/Expression/FunctionOperator.php
@@ -17,6 +17,7 @@ use MongoDB\Model\BSONArray;
 
 use function array_is_list;
 use function is_array;
+use function is_string;
 
 /**
  * Defines a custom function.
@@ -46,8 +47,12 @@ class FunctionOperator implements ResolvesToAny, OperatorInterface
      * @param BSONArray|PackedArray|array $args Arguments passed to the function body. If the body function does not take an argument, you can specify an empty array [ ].
      * @param non-empty-string $lang
      */
-    public function __construct(Javascript|string $body, PackedArray|BSONArray|array $args, string $lang = 'js')
+    public function __construct(Javascript|string $body, PackedArray|BSONArray|array $args = [], string $lang = 'js')
     {
+        if (is_string($body)) {
+            $body = new Javascript($body);
+        }
+
         $this->body = $body;
         if (is_array($args) && ! array_is_list($args)) {
             throw new InvalidArgumentException('Expected $args argument to be a list, got an associative array.');

--- a/src/Builder/Query/WhereOperator.php
+++ b/src/Builder/Query/WhereOperator.php
@@ -13,6 +13,8 @@ use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
 use MongoDB\Builder\Type\QueryInterface;
 
+use function is_string;
+
 /**
  * Matches documents that satisfy a JavaScript expression.
  *
@@ -30,6 +32,10 @@ class WhereOperator implements QueryInterface, OperatorInterface
      */
     public function __construct(Javascript|string $function)
     {
+        if (is_string($function)) {
+            $function = new Javascript($function);
+        }
+
         $this->function = $function;
     }
 

--- a/tests/Builder/Accumulator/Pipelines.php
+++ b/tests/Builder/Accumulator/Pipelines.php
@@ -23,19 +23,19 @@ enum Pipelines: string
                 "avgCopies": {
                     "$accumulator": {
                         "init": {
-                            "$code": "function () { return { count: 0, sum: 0 } }"
+                            "$code": "function() {\n    return { count: 0, sum: 0 }\n}"
                         },
                         "accumulate": {
-                            "$code": "function (state, numCopies) { return { count: state.count + 1, sum: state.sum + numCopies } }"
+                            "$code": "function(state, numCopies) {\n    return { count: state.count + 1, sum: state.sum + numCopies }\n}"
                         },
                         "accumulateArgs": [
                             "$copies"
                         ],
                         "merge": {
-                            "$code": "function (state1, state2) { return { count: state1.count + state2.count, sum: state1.sum + state2.sum } }"
+                            "$code": "function(state1, state2) {\n    return {\n        count: state1.count + state2.count,\n        sum: state1.sum + state2.sum\n    }\n}"
                         },
                         "finalize": {
-                            "$code": "function (state) { return (state.sum \/ state.count) }"
+                            "$code": "function(state) {\n    return (state.sum \/ state.count)\n}"
                         },
                         "lang": "js"
                     }
@@ -60,23 +60,23 @@ enum Pipelines: string
                 "restaurants": {
                     "$accumulator": {
                         "init": {
-                            "$code": "function (city, userProfileCity) { return { max: city === userProfileCity ? 3 : 1, restaurants: [] } }"
+                            "$code": "function(city, userProfileCity) {\n    return { max: city === userProfileCity ? 3 : 1, restaurants: [] }\n}"
                         },
                         "initArgs": [
                             "$city",
                             "Bettles"
                         ],
                         "accumulate": {
-                            "$code": "function (state, restaurantName) { if (state.restaurants.length < state.max) { state.restaurants.push(restaurantName); } return state; }"
+                            "$code": "function(state, restaurantName) {\n    if (state.restaurants.length < state.max) {\n        state.restaurants.push(restaurantName);\n    }\n    return state;\n}"
                         },
                         "accumulateArgs": [
                             "$name"
                         ],
                         "merge": {
-                            "$code": "function (state1, state2) { return { max: state1.max, restaurants: state1.restaurants.concat(state2.restaurants).slice(0, state1.max) } }"
+                            "$code": "function(state1, state2) {\n    return {\n        max: state1.max,\n        restaurants: state1.restaurants.concat(state2.restaurants).slice(0, state1.max)\n    }\n}"
                         },
                         "finalize": {
-                            "$code": "function (state) { return state.restaurants }"
+                            "$code": "function(state) {\n    return state.restaurants\n}"
                         },
                         "lang": "js"
                     }

--- a/tests/Builder/Expression/FunctionOperatorTest.php
+++ b/tests/Builder/Expression/FunctionOperatorTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $function expression
+ */
+class FunctionOperatorTest extends PipelineTestCase
+{
+    public function testAlternativeToWhere(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::expr(
+                    Expression::function(
+                        body: <<<'JS'
+                            function(name) {
+                                return hex_md5(name) == "15b0a220baa16331e8d80e15367677ad";
+                            }
+                            JS,
+                        args: [
+                            Expression::stringFieldPath('name'),
+                        ],
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::FunctionAlternativeToWhere, $pipeline);
+    }
+
+    public function testUsageExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                isFound: Expression::function(
+                    body: <<<'JS'
+                        function(name) {
+                            return hex_md5(name) == "15b0a220baa16331e8d80e15367677ad"
+                        }
+                        JS,
+                    args: [
+                        Expression::stringFieldPath('name'),
+                    ],
+                ),
+                message: Expression::function(
+                    body: <<<'JS'
+                        function(name, scores) {
+                            let total = Array.sum(scores);
+                            return `Hello ${name}. Your total score is ${total}.`
+                        }
+                        JS,
+                    args: [
+                        Expression::stringFieldPath('name'),
+                        Expression::stringFieldPath('scores'),
+                    ],
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::FunctionUsageExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -753,6 +753,68 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Usage Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/function/#example-1--usage-example
+     */
+    case FunctionUsageExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "isFound": {
+                    "$function": {
+                        "body": {
+                            "$code": "function(name) {\n    return hex_md5(name) == \"15b0a220baa16331e8d80e15367677ad\"\n}"
+                        },
+                        "args": [
+                            "$name"
+                        ],
+                        "lang": "js"
+                    }
+                },
+                "message": {
+                    "$function": {
+                        "body": {
+                            "$code": "function(name, scores) {\n    let total = Array.sum(scores);\n    return `Hello ${name}. Your total score is ${total}.`\n}"
+                        },
+                        "args": [
+                            "$name",
+                            "$scores"
+                        ],
+                        "lang": "js"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Alternative to $where
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/function/#example-2--alternative-to--where
+     */
+    case FunctionAlternativeToWhere = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$expr": {
+                    "$function": {
+                        "body": {
+                            "$code": "function(name) {\n    return hex_md5(name) == \"15b0a220baa16331e8d80e15367677ad\";\n}"
+                        },
+                        "args": [
+                            "$name"
+                        ],
+                        "lang": "js"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Example
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/gt/#example

--- a/tests/Builder/Query/Pipelines.php
+++ b/tests/Builder/Query/Pipelines.php
@@ -1657,14 +1657,18 @@ enum Pipelines: string
     [
         {
             "$match": {
-                "$where": "function() { return hex_md5(this.name) == \"9b53e667f30cd329dca1ec9e6a83e994\" }"
+                "$where": {
+                    "$code": "function() {\n    return hex_md5(this.name) == \"9b53e667f30cd329dca1ec9e6a83e994\"\n}"
+                }
             }
         },
         {
             "$match": {
                 "$expr": {
                     "$function": {
-                        "body": "function(name) {\n    return hex_md5(name) == \"9b53e667f30cd329dca1ec9e6a83e994\";\n}",
+                        "body": {
+                            "$code": "function(name) {\n    return hex_md5(name) == \"9b53e667f30cd329dca1ec9e6a83e994\";\n}"
+                        },
                         "args": [
                             "$name"
                         ],

--- a/tests/Builder/Query/WhereOperatorTest.php
+++ b/tests/Builder/Query/WhereOperatorTest.php
@@ -19,7 +19,11 @@ class WhereOperatorTest extends PipelineTestCase
     {
         $pipeline = new Pipeline(
             Stage::match(
-                Query::where('function() { return hex_md5(this.name) == "9b53e667f30cd329dca1ec9e6a83e994" }'),
+                Query::where(<<<'JS'
+                    function() {
+                        return hex_md5(this.name) == "9b53e667f30cd329dca1ec9e6a83e994"
+                    }
+                    JS),
             ),
             Stage::match(
                 Query::expr(


### PR DESCRIPTION
Fix [PHPLIB-1348](https://jira.mongodb.org/browse/PHPLIB-1348)

I updated the operators accepting `javascript` type, to automatically convert strings into a `MongoDB\BSON\Javascript` object.
The `$function` operator has default values for `args: []` and `lang: 'js'`, because this parameters are required. The lang is the only one supported.

https://www.mongodb.com/docs/manual/reference/operator/aggregation/#custom-aggregation-expression-operators

- `$accumulator` example updated to use automatic creation of `Javascript` objects from string
- `$function`
- `$where` fixed examples to be `Javascript` objects
