### PR TITLE
PHPLIB-1338 Add tests on $size Array Query Operators

### DIFF
--- a/generator/config/query/size.yaml
+++ b/generator/config/query/size.yaml
@@ -11,3 +11,12 @@ arguments:
         name: value
         type:
             - int
+tests:
+    -
+        name: 'Query an Array by Array Length'
+        link: 'https://www.mongodb.com/docs/manual/tutorial/query-arrays/#query-an-array-by-array-length'
+        pipeline:
+            -
+                $match:
+                    tags:
+                        $size: 3

--- a/tests/Builder/Query/Pipelines.php
+++ b/tests/Builder/Query/Pipelines.php
@@ -1363,6 +1363,25 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Query an Array by Array Length
+     *
+     * @see https://www.mongodb.com/docs/manual/tutorial/query-arrays/#query-an-array-by-array-length
+     */
+    case SizeQueryAnArrayByArrayLength = <<<'JSON'
+    [
+        {
+            "$match": {
+                "tags": {
+                    "$size": {
+                        "$numberInt": "3"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Search for a Single Word
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/text/#search-for-a-single-word

--- a/tests/Builder/Query/SizeOperatorTest.php
+++ b/tests/Builder/Query/SizeOperatorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $size query
+ */
+class SizeOperatorTest extends PipelineTestCase
+{
+    public function testQueryAnArrayByArrayLength(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                tags: Query::size(3),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SizeQueryAnArrayByArrayLength, $pipeline);
+    }
+}


### PR DESCRIPTION
Fix [PHPLIB-1338](https://jira.mongodb.org/browse/PHPLIB-1338)

https://www.mongodb.com/docs/manual/reference/operator/query/#array

- ~`$all`~ already done
- ~`$elemMatch`~ already done
- `$size`