### PR TITLE
PHPLIB-1363 PHPLIB-1355 Add enum for `$type` query and `$meta` expression

### DIFF
--- a/generator/config/expression/meta.yaml
+++ b/generator/config/expression/meta.yaml
@@ -11,3 +11,29 @@ arguments:
         name: keyword
         type:
             - string
+tests:
+    -
+        name: 'textScore'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/meta/#-meta---textscore-'
+        pipeline:
+            -
+                $match:
+                    $text:
+                        $search: 'cake'
+            -
+                $group:
+                    _id:
+                        $meta: 'textScore'
+                    count:
+                        $sum: 1
+    -
+        name: 'indexKey'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/meta/#-meta---indexkey-'
+        pipeline:
+            -
+                $match:
+                    type: 'apparel'
+            -
+                $addFields:
+                    idxKey:
+                        $meta: 'indexKey'

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.20.0@3f284e96c9d9be6fe6b15c79416e1d1903dcfef4">
+<files psalm-version="5.21.0@04ba9358e3f7d14a9dc3edd4e814a9d51d8c637f">
   <file src="src/Builder/Encoder/AbstractExpressionEncoder.php">
     <MixedAssignment>
       <code>$val</code>
@@ -52,6 +52,9 @@
     <ArgumentTypeCoercion>
       <code>$query</code>
     </ArgumentTypeCoercion>
+    <PossiblyInvalidArgument>
+      <code>$type</code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="src/Builder/Query/ElemMatchOperator.php">
     <MixedArgumentTypeCoercion>

--- a/src/Builder/Encoder/OperatorEncoder.php
+++ b/src/Builder/Encoder/OperatorEncoder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Encoder;
 
+use BackedEnum;
 use LogicException;
 use MongoDB\Builder\Stage\GroupStage;
 use MongoDB\Builder\Type\Encode;
@@ -65,6 +66,10 @@ class OperatorEncoder extends AbstractExpressionEncoder
      */
     private function encodeAsArray(OperatorInterface $value): stdClass
     {
+        if ($value instanceof BackedEnum) {
+            return $this->wrap($value, [$value->value]);
+        }
+
         $result = [];
         /** @var mixed $val */
         foreach (get_object_vars($value) as $val) {
@@ -142,6 +147,10 @@ class OperatorEncoder extends AbstractExpressionEncoder
      */
     private function encodeAsSingle(OperatorInterface $value): stdClass
     {
+        if ($value instanceof BackedEnum) {
+            return $this->wrap($value, $value->value);
+        }
+
         foreach (get_object_vars($value) as $val) {
             $result = $this->recursiveEncode($val);
 

--- a/src/Builder/Meta.php
+++ b/src/Builder/Meta.php
@@ -31,6 +31,11 @@ enum Meta: string implements OperatorInterface, ExpressionInterface
      */
     case IndexKey = 'indexKey';
 
+    /**
+     * Display search terms in their original context.
+     */
+    case SearchHighlights = 'searchHighlights';
+
     public function getOperator(): string
     {
         return '$meta';

--- a/src/Builder/Meta.php
+++ b/src/Builder/Meta.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder;
+
+use MongoDB\Builder\Type\Encode;
+use MongoDB\Builder\Type\ExpressionInterface;
+use MongoDB\Builder\Type\OperatorInterface;
+
+/**
+ * Returns the metadata associated with a document, e.g. "textScore" when performing text search.
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/meta/
+ */
+enum Meta: string implements OperatorInterface, ExpressionInterface
+{
+    public const ENCODE = Encode::Single;
+
+    /**
+     * Returns the score associated with the corresponding $text query for each
+     * matching document. The text score signifies how well the document matched
+     * the search term or terms.
+     */
+    case TextScore = 'textScore';
+
+    /**
+     * Returns an index key for the document if a non-text index is used. The
+     * { $meta: "indexKey" } expression is for debugging purposes only, and
+     * not for application logic, and is preferred over cursor.returnKey().
+     */
+    case IndexKey = 'indexKey';
+
+    public function getOperator(): string
+    {
+        return '$meta';
+    }
+}

--- a/src/Builder/Query.php
+++ b/src/Builder/Query.php
@@ -7,6 +7,7 @@ namespace MongoDB\Builder;
 use MongoDB\BSON\Regex;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Query\RegexOperator;
+use MongoDB\Builder\Query\TypeOperator;
 use MongoDB\Builder\Type\CombinedFieldQuery;
 use MongoDB\Builder\Type\FieldQueryInterface;
 use MongoDB\Builder\Type\QueryInterface;
@@ -25,6 +26,27 @@ final class Query
 {
     use Query\FactoryTrait {
         regex as private generatedRegex;
+        type as private generatedType;
+    }
+
+    /**
+     * Selects documents if a field is of the specified type.
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/type/
+     *
+     * @param int|non-empty-string|QueryType ...$type
+     *
+     * @no-named-arguments
+     */
+    public static function type(string|int|QueryType ...$type): TypeOperator
+    {
+        foreach ($type as &$value) {
+            if ($value instanceof QueryType) {
+                $value = $value->value;
+            }
+        }
+
+        return self::generatedType(...$type);
     }
 
     /**

--- a/src/Builder/QueryType.php
+++ b/src/Builder/QueryType.php
@@ -19,27 +19,25 @@ enum QueryType: string implements OperatorInterface, FieldQueryInterface
 {
     public const ENCODE = Encode::Array;
 
-    case Double = 'double';
-    case String = 'string';
-    case Object = 'object';
     case Array = 'array';
-    case BinaryData = 'binData';
-    case ObjectId = 'objectId';
-    case Boolean = 'bool';
-    case Date = 'date';
-    case Null = 'null';
-    case Regex = 'regex';
-    case JavaScript = 'javascript';
-    case Int = 'int';
-    case Timestamp = 'timestamp';
-    case Long = 'long';
+    case Binary = 'binData';
+    case Bool = 'bool';
+    case Decimal64 = 'double';
     case Decimal128 = 'decimal';
-    case MinKey = 'minKey';
+    case Int32 = 'int';
+    case Int64 = 'long';
+    case Javascript = 'javascript';
+    case Object = 'object';
+    case ObjectId = 'objectId';
     case MaxKey = 'maxKey';
-    /**
-     * Alias for Double, Int, Long, Decimal
-     */
+    case MinKey = 'minKey';
+    case Null = 'null';
+    /** Alias for Int32, Int64, Decimal64, Decimal128 */
     case Number = 'number';
+    case Regex = 'regex';
+    case String = 'string';
+    case Timestamp = 'timestamp';
+    case UTCDateTime = 'date';
 
     public function getOperator(): string
     {

--- a/src/Builder/QueryType.php
+++ b/src/Builder/QueryType.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder;
+
+use MongoDB\Builder\Query\TypeOperator;
+use MongoDB\Builder\Type\Encode;
+use MongoDB\Builder\Type\FieldQueryInterface;
+use MongoDB\Builder\Type\OperatorInterface;
+
+/**
+ * Shortcut for $type field query operator
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/query/type/#available-types
+ * @see TypeOperator
+ */
+enum QueryType: string implements OperatorInterface, FieldQueryInterface
+{
+    public const ENCODE = Encode::Array;
+
+    case Double = 'double';
+    case String = 'string';
+    case Object = 'object';
+    case Array = 'array';
+    case BinaryData = 'binData';
+    case ObjectId = 'objectId';
+    case Boolean = 'bool';
+    case Date = 'date';
+    case Null = 'null';
+    case Regex = 'regex';
+    case JavaScript = 'javascript';
+    case Int = 'int';
+    case Timestamp = 'timestamp';
+    case Long = 'long';
+    case Decimal128 = 'decimal';
+    case MinKey = 'minKey';
+    case MaxKey = 'maxKey';
+    /**
+     * Alias for Double, Int, Long, Decimal
+     */
+    case Number = 'number';
+
+    public function getOperator(): string
+    {
+        return '$type';
+    }
+}

--- a/tests/Builder/Expression/MetaOperatorTest.php
+++ b/tests/Builder/Expression/MetaOperatorTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Meta;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $meta expression
+ */
+class MetaOperatorTest extends PipelineTestCase
+{
+    public function testIndexKey(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                type: 'apparel',
+            ),
+            Stage::addFields(
+                idxKey: Expression::meta('indexKey'),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MetaIndexKey, $pipeline);
+    }
+
+    public function testIndexKeyWithEnum(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                type: 'apparel',
+            ),
+            Stage::addFields(
+                idxKey: Meta::IndexKey,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MetaIndexKey, $pipeline);
+    }
+
+    public function testTextScore(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::text('cake'),
+            ),
+            Stage::group(
+                _id: Expression::meta('textScore'),
+                count: Accumulator::sum(1),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MetaTextScore, $pipeline);
+    }
+
+    public function testTextScoreWithEnum(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::text('cake'),
+            ),
+            Stage::group(
+                _id: Meta::TextScore,
+                count: Accumulator::sum(1),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MetaTextScore, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -3112,6 +3112,57 @@ enum Pipelines: string
     JSON;
 
     /**
+     * textScore
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/meta/#-meta---textscore-
+     */
+    case MetaTextScore = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$text": {
+                    "$search": "cake"
+                }
+            }
+        },
+        {
+            "$group": {
+                "_id": {
+                    "$meta": "textScore"
+                },
+                "count": {
+                    "$sum": {
+                        "$numberInt": "1"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * indexKey
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/meta/#-meta---indexkey-
+     */
+    case MetaIndexKey = <<<'JSON'
+    [
+        {
+            "$match": {
+                "type": "apparel"
+            }
+        },
+        {
+            "$addFields": {
+                "idxKey": {
+                    "$meta": "indexKey"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Example
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/millisecond/#example

--- a/tests/Builder/Query/TypeOperatorTest.php
+++ b/tests/Builder/Query/TypeOperatorTest.php
@@ -6,6 +6,7 @@ namespace MongoDB\Tests\Builder\Query;
 
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Query;
+use MongoDB\Builder\QueryType;
 use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
@@ -32,16 +33,16 @@ class TypeOperatorTest extends PipelineTestCase
                 zipCode: Query::type(2),
             ),
             Stage::match(
-                zipCode: Query::type('string'),
+                zipCode: QueryType::String,
             ),
             Stage::match(
                 zipCode: Query::type(1),
             ),
             Stage::match(
-                zipCode: Query::type('double'),
+                zipCode: Query::type(QueryType::Double),
             ),
             Stage::match(
-                zipCode: Query::type('number'),
+                zipCode: QueryType::Number,
             ),
         );
 
@@ -69,7 +70,7 @@ class TypeOperatorTest extends PipelineTestCase
                 zipCode: Query::type(2, 1),
             ),
             Stage::match(
-                zipCode: Query::type('string', 'double'),
+                zipCode: Query::type(QueryType::String, 'double'),
             ),
         );
 

--- a/tests/Builder/Query/TypeOperatorTest.php
+++ b/tests/Builder/Query/TypeOperatorTest.php
@@ -39,7 +39,7 @@ class TypeOperatorTest extends PipelineTestCase
                 zipCode: Query::type(1),
             ),
             Stage::match(
-                zipCode: Query::type(QueryType::Double),
+                zipCode: Query::type(QueryType::Decimal64),
             ),
             Stage::match(
                 zipCode: QueryType::Number,


### PR DESCRIPTION
Fix [PHPLIB-1363](https://jira.mongodb.org/browse/PHPLIB-1363)
Fix [PHPLIB-1355](https://jira.mongodb.org/browse/PHPLIB-1355)

The enum implements `FieldQueryInterface` so it can be used anywhere a field query is expected. Deprecated types have been skipped.

List imported from [the doc](https://www.mongodb.com/docs/manual/reference/operator/query/type/#available-types), including the alias `number`.

Usage:
```php
        $pipeline = new Pipeline(
            Stage::match(
                zipCode: QueryType::Int,
            ),
        );
```

Limitation, it's not possible to use the enum in a list.
```php
        $pipeline = new Pipeline(
            Stage::match(
                zipCode: [QueryType::Int, QueryType::Long],
            ),
        );
```