### PR TITLE
PHPLIB-1351 Add tests on Miscellaneous Operators

### DIFF
--- a/generator/config/expression/getField.yaml
+++ b/generator/config/expression/getField.yaml
@@ -11,7 +11,7 @@ arguments:
     -
         name: field
         type:
-            - string
+            - resolvesToString
         description: |
             Field in the input object for which you want to return a value. field can be any valid expression that resolves to a string constant.
             If field begins with a dollar sign ($), place the field name inside of a $literal expression to return its value.
@@ -23,3 +23,47 @@ arguments:
         description: |
             Default: $$CURRENT
             A valid expression that contains the field for which you want to return a value. input must resolve to an object, missing, null, or undefined. If omitted, defaults to the document currently being processed in the pipeline ($$CURRENT).
+tests:
+    -
+        name: 'Query Fields that Contain Periods'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/getField/#query-fields-that-contain-periods--.-'
+        pipeline:
+            -
+                $match:
+                    $expr:
+                        $gt:
+                            -
+                                # the builder uses the verbose form with parameter names
+                                # $getField: 'price.usd'
+                                $getField:
+                                    field: 'price.usd'
+                            - 200
+    -
+        name: 'Query Fields that Start with a Dollar Sign'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/getField/#query-fields-that-start-with-a-dollar-sign----'
+        pipeline:
+            -
+                $match:
+                    $expr:
+                        $gt:
+                            -
+                                $getField:
+                                    # the builder uses the verbose form with parameter names
+                                    # $literal: '$price'
+                                    field:
+                                        $literal: '$price'
+                            - 200
+    -
+        name: 'Query a Field in a Sub-document'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/getField/#query-a-field-in-a-sub-document'
+        pipeline:
+            -
+                $match:
+                    $expr:
+                        $lte:
+                            -
+                                $getField:
+                                    field:
+                                        $literal: '$small'
+                                    input: '$quantity'
+                            - 20

--- a/generator/config/expression/rand.yaml
+++ b/generator/config/expression/rand.yaml
@@ -6,3 +6,42 @@ type:
 encode: object
 description: |
     Returns a random float between 0 and 1
+tests:
+    -
+        name: 'Generate Random Data Points'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/rand/#generate-random-data-points'
+        pipeline:
+            -
+                $set:
+                    amount:
+                        $multiply:
+                            -
+                                $rand: {}
+                            - 100
+            -
+                $set:
+                    amount:
+                        $floor: '$amount'
+            -
+                # $merge: 'donors'
+                $merge:
+                    into: 'donors'
+    -
+        name: 'Select Random Items From a Collection'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/rand/#select-random-items-from-a-collection'
+        pipeline:
+            -
+                $match:
+                    district: 3
+            -
+                $match:
+                    $expr:
+                        $lt:
+                            - 0.5
+                            -
+                                $rand: {}
+            -
+                $project:
+                    _id: 0
+                    name: 1
+                    registered: 1

--- a/generator/config/expression/toHashedIndexKey.yaml
+++ b/generator/config/expression/toHashedIndexKey.yaml
@@ -1,0 +1,28 @@
+# $schema: ../schema.json
+name: $toHashedIndexKey
+link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/toHashedIndexKey/'
+type:
+  - resolvesToLong
+encode: single
+description: |
+  Computes and returns the hash value of the input expression using the same hash function that MongoDB uses to create a hashed index. A hash function maps a key or string to a fixed-size numeric value.
+arguments:
+  -
+    name: value
+    type:
+      - expression
+    description: |
+      key or string to hash
+tests:
+  -
+    name: 'Example'
+    link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/toHashedIndexKey/#example'
+    pipeline:
+      -
+        $documents:
+          -
+            val: 'string to hash'
+      -
+        $addFields:
+          hashedVal:
+            $toHashedIndexKey: '$val'

--- a/generator/config/query/sampleRate.yaml
+++ b/generator/config/query/sampleRate.yaml
@@ -2,7 +2,7 @@
 name: $sampleRate
 link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/sampleRate/'
 type:
-    - resolvesToAny
+    - query
 encode: single
 description: |
     Randomly select documents at a given rate. Although the exact number of documents selected varies on each run, the quantity chosen approximates the sample rate expressed as a percentage of the total number of documents.
@@ -14,3 +14,13 @@ arguments:
         description: |
             The selection process uses a uniform random distribution. The sample rate is a floating point number between 0 and 1, inclusive, which represents the probability that a given document will be selected as it passes through the pipeline.
             For example, a sample rate of 0.33 selects roughly one document in three.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/sampleRate/#examples'
+        pipeline:
+            -
+                $match:
+                    $sampleRate: 0.33
+            -
+                $count: 'numMatches'

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -778,13 +778,13 @@ trait FactoryTrait
      * New in MongoDB 5.0.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/getField/
-     * @param non-empty-string $field Field in the input object for which you want to return a value. field can be any valid expression that resolves to a string constant.
+     * @param ResolvesToString|non-empty-string $field Field in the input object for which you want to return a value. field can be any valid expression that resolves to a string constant.
      * If field begins with a dollar sign ($), place the field name inside of a $literal expression to return its value.
      * @param Optional|ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass $input Default: $$CURRENT
      * A valid expression that contains the field for which you want to return a value. input must resolve to an object, missing, null, or undefined. If omitted, defaults to the document currently being processed in the pipeline ($$CURRENT).
      */
     public static function getField(
-        string $field,
+        ResolvesToString|string $field,
         Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input = Optional::Undefined,
     ): GetFieldOperator
     {
@@ -1693,18 +1693,6 @@ trait FactoryTrait
     }
 
     /**
-     * Randomly select documents at a given rate. Although the exact number of documents selected varies on each run, the quantity chosen approximates the sample rate expressed as a percentage of the total number of documents.
-     *
-     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sampleRate/
-     * @param Int64|ResolvesToDouble|float|int $rate The selection process uses a uniform random distribution. The sample rate is a floating point number between 0 and 1, inclusive, which represents the probability that a given document will be selected as it passes through the pipeline.
-     * For example, a sample rate of 0.33 selects roughly one document in three.
-     */
-    public static function sampleRate(Int64|ResolvesToDouble|float|int $rate): SampleRateOperator
-    {
-        return new SampleRateOperator($rate);
-    }
-
-    /**
      * Returns the seconds for a date as a number between 0 and 60 (leap seconds).
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/second/
@@ -2142,6 +2130,19 @@ trait FactoryTrait
     ): ToDoubleOperator
     {
         return new ToDoubleOperator($expression);
+    }
+
+    /**
+     * Computes and returns the hash value of the input expression using the same hash function that MongoDB uses to create a hashed index. A hash function maps a key or string to a fixed-size numeric value.
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toHashedIndexKey/
+     * @param ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass $value key or string to hash
+     */
+    public static function toHashedIndexKey(
+        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $value,
+    ): ToHashedIndexKeyOperator
+    {
+        return new ToHashedIndexKeyOperator($value);
     }
 
     /**

--- a/src/Builder/Expression/GetFieldOperator.php
+++ b/src/Builder/Expression/GetFieldOperator.php
@@ -26,10 +26,10 @@ class GetFieldOperator implements ResolvesToAny, OperatorInterface
     public const ENCODE = Encode::Object;
 
     /**
-     * @var non-empty-string $field Field in the input object for which you want to return a value. field can be any valid expression that resolves to a string constant.
+     * @var ResolvesToString|non-empty-string $field Field in the input object for which you want to return a value. field can be any valid expression that resolves to a string constant.
      * If field begins with a dollar sign ($), place the field name inside of a $literal expression to return its value.
      */
-    public readonly string $field;
+    public readonly ResolvesToString|string $field;
 
     /**
      * @var Optional|ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass $input Default: $$CURRENT
@@ -38,13 +38,13 @@ class GetFieldOperator implements ResolvesToAny, OperatorInterface
     public readonly Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input;
 
     /**
-     * @param non-empty-string $field Field in the input object for which you want to return a value. field can be any valid expression that resolves to a string constant.
+     * @param ResolvesToString|non-empty-string $field Field in the input object for which you want to return a value. field can be any valid expression that resolves to a string constant.
      * If field begins with a dollar sign ($), place the field name inside of a $literal expression to return its value.
      * @param Optional|ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass $input Default: $$CURRENT
      * A valid expression that contains the field for which you want to return a value. input must resolve to an object, missing, null, or undefined. If omitted, defaults to the document currently being processed in the pipeline ($$CURRENT).
      */
     public function __construct(
-        string $field,
+        ResolvesToString|string $field,
         Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input = Optional::Undefined,
     ) {
         $this->field = $field;

--- a/src/Builder/Expression/ToHashedIndexKeyOperator.php
+++ b/src/Builder/Expression/ToHashedIndexKeyOperator.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * THIS FILE IS AUTO-GENERATED. ANY CHANGES WILL BE LOST!
+ */
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Expression;
+
+use MongoDB\BSON\Type;
+use MongoDB\Builder\Type\Encode;
+use MongoDB\Builder\Type\ExpressionInterface;
+use MongoDB\Builder\Type\OperatorInterface;
+use stdClass;
+
+/**
+ * Computes and returns the hash value of the input expression using the same hash function that MongoDB uses to create a hashed index. A hash function maps a key or string to a fixed-size numeric value.
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toHashedIndexKey/
+ */
+class ToHashedIndexKeyOperator implements ResolvesToLong, OperatorInterface
+{
+    public const ENCODE = Encode::Single;
+
+    /** @var ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass $value key or string to hash */
+    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $value;
+
+    /**
+     * @param ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass $value key or string to hash
+     */
+    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function getOperator(): string
+    {
+        return '$toHashedIndexKey';
+    }
+}

--- a/src/Builder/Query/FactoryTrait.php
+++ b/src/Builder/Query/FactoryTrait.php
@@ -17,6 +17,7 @@ use MongoDB\BSON\PackedArray;
 use MongoDB\BSON\Regex;
 use MongoDB\BSON\Serializable;
 use MongoDB\BSON\Type;
+use MongoDB\Builder\Expression\ResolvesToDouble;
 use MongoDB\Builder\Type\ExpressionInterface;
 use MongoDB\Builder\Type\FieldQueryInterface;
 use MongoDB\Builder\Type\GeometryInterface;
@@ -471,6 +472,18 @@ trait FactoryTrait
     public static function regex(Regex $regex): RegexOperator
     {
         return new RegexOperator($regex);
+    }
+
+    /**
+     * Randomly select documents at a given rate. Although the exact number of documents selected varies on each run, the quantity chosen approximates the sample rate expressed as a percentage of the total number of documents.
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sampleRate/
+     * @param Int64|ResolvesToDouble|float|int $rate The selection process uses a uniform random distribution. The sample rate is a floating point number between 0 and 1, inclusive, which represents the probability that a given document will be selected as it passes through the pipeline.
+     * For example, a sample rate of 0.33 selects roughly one document in three.
+     */
+    public static function sampleRate(Int64|ResolvesToDouble|float|int $rate): SampleRateOperator
+    {
+        return new SampleRateOperator($rate);
     }
 
     /**

--- a/src/Builder/Query/SampleRateOperator.php
+++ b/src/Builder/Query/SampleRateOperator.php
@@ -6,18 +6,20 @@
 
 declare(strict_types=1);
 
-namespace MongoDB\Builder\Expression;
+namespace MongoDB\Builder\Query;
 
 use MongoDB\BSON\Int64;
+use MongoDB\Builder\Expression\ResolvesToDouble;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\QueryInterface;
 
 /**
  * Randomly select documents at a given rate. Although the exact number of documents selected varies on each run, the quantity chosen approximates the sample rate expressed as a percentage of the total number of documents.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sampleRate/
  */
-class SampleRateOperator implements ResolvesToAny, OperatorInterface
+class SampleRateOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/tests/Builder/Expression/GetFieldOperatorTest.php
+++ b/tests/Builder/Expression/GetFieldOperatorTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $getField expression
+ */
+class GetFieldOperatorTest extends PipelineTestCase
+{
+    public function testQueryAFieldInASubdocument(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::expr(
+                    Expression::lte(
+                        Expression::getField(
+                            field: Expression::literal('$small'),
+                            input: Expression::intFieldPath('quantity'),
+                        ),
+                        20,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GetFieldQueryAFieldInASubdocument, $pipeline);
+    }
+
+    public function testQueryFieldsThatContainPeriods(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::expr(
+                    Expression::gt(
+                        Expression::getField('price.usd'),
+                        200,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GetFieldQueryFieldsThatContainPeriods, $pipeline);
+    }
+
+    public function testQueryFieldsThatStartWithADollarSign(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::expr(
+                    Expression::gt(
+                        Expression::getField(
+                            Expression::literal('$price'),
+                        ),
+                        200,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GetFieldQueryFieldsThatStartWithADollarSign, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -865,6 +865,89 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Query Fields that Contain Periods
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/getField/#query-fields-that-contain-periods--.-
+     */
+    case GetFieldQueryFieldsThatContainPeriods = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$expr": {
+                    "$gt": [
+                        {
+                            "$getField": {
+                                "field": "price.usd"
+                            }
+                        },
+                        {
+                            "$numberInt": "200"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Query Fields that Start with a Dollar Sign
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/getField/#query-fields-that-start-with-a-dollar-sign----
+     */
+    case GetFieldQueryFieldsThatStartWithADollarSign = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$expr": {
+                    "$gt": [
+                        {
+                            "$getField": {
+                                "field": {
+                                    "$literal": "$price"
+                                }
+                            }
+                        },
+                        {
+                            "$numberInt": "200"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Query a Field in a Sub-document
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/getField/#query-a-field-in-a-sub-document
+     */
+    case GetFieldQueryAFieldInASubdocument = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$expr": {
+                    "$lte": [
+                        {
+                            "$getField": {
+                                "field": {
+                                    "$literal": "$small"
+                                },
+                                "input": "$quantity"
+                            }
+                        },
+                        {
+                            "$numberInt": "20"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Example
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/gt/#example
@@ -1645,6 +1728,86 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Generate Random Data Points
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/rand/#generate-random-data-points
+     */
+    case RandGenerateRandomDataPoints = <<<'JSON'
+    [
+        {
+            "$set": {
+                "amount": {
+                    "$multiply": [
+                        {
+                            "$rand": {}
+                        },
+                        {
+                            "$numberInt": "100"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "$set": {
+                "amount": {
+                    "$floor": "$amount"
+                }
+            }
+        },
+        {
+            "$merge": {
+                "into": "donors"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Select Random Items From a Collection
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/rand/#select-random-items-from-a-collection
+     */
+    case RandSelectRandomItemsFromACollection = <<<'JSON'
+    [
+        {
+            "$match": {
+                "district": {
+                    "$numberInt": "3"
+                }
+            }
+        },
+        {
+            "$match": {
+                "$expr": {
+                    "$lt": [
+                        {
+                            "$numberDouble": "0.5"
+                        },
+                        {
+                            "$rand": {}
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "name": {
+                    "$numberInt": "1"
+                },
+                "registered": {
+                    "$numberInt": "1"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Example
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/range/#example
@@ -1883,6 +2046,64 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setDifference/#example
+     */
+    case SetDifferenceExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "flowerFieldA": {
+                    "$numberInt": "1"
+                },
+                "flowerFieldB": {
+                    "$numberInt": "1"
+                },
+                "inBOnly": {
+                    "$setDifference": [
+                        "$flowerFieldB",
+                        "$flowerFieldA"
+                    ]
+                },
+                "_id": {
+                    "$numberInt": "0"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setEquals/#example
+     */
+    case SetEqualsExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "cakes": {
+                    "$numberInt": "1"
+                },
+                "cupcakes": {
+                    "$numberInt": "1"
+                },
+                "sameFlavors": {
+                    "$setEquals": [
+                        "$cakes",
+                        "$cupcakes"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Add Fields that Contain Periods
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setField/#add-fields-that-contain-periods--.-
@@ -2024,64 +2245,6 @@ enum Pipelines: string
                     },
                     "input": "$$ROOT",
                     "value": "$$REMOVE"
-                }
-            }
-        }
-    ]
-    JSON;
-
-    /**
-     * Example
-     *
-     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setDifference/#example
-     */
-    case SetDifferenceExample = <<<'JSON'
-    [
-        {
-            "$project": {
-                "flowerFieldA": {
-                    "$numberInt": "1"
-                },
-                "flowerFieldB": {
-                    "$numberInt": "1"
-                },
-                "inBOnly": {
-                    "$setDifference": [
-                        "$flowerFieldB",
-                        "$flowerFieldA"
-                    ]
-                },
-                "_id": {
-                    "$numberInt": "0"
-                }
-            }
-        }
-    ]
-    JSON;
-
-    /**
-     * Example
-     *
-     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setEquals/#example
-     */
-    case SetEqualsExample = <<<'JSON'
-    [
-        {
-            "$project": {
-                "_id": {
-                    "$numberInt": "0"
-                },
-                "cakes": {
-                    "$numberInt": "1"
-                },
-                "cupcakes": {
-                    "$numberInt": "1"
-                },
-                "sameFlavors": {
-                    "$setEquals": [
-                        "$cakes",
-                        "$cupcakes"
-                    ]
                 }
             }
         }
@@ -2653,6 +2816,30 @@ enum Pipelines: string
                         ],
                         "default": "No scores found."
                     }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toHashedIndexKey/#example
+     */
+    case ToHashedIndexKeyExample = <<<'JSON'
+    [
+        {
+            "$documents": [
+                {
+                    "val": "string to hash"
+                }
+            ]
+        },
+        {
+            "$addFields": {
+                "hashedVal": {
+                    "$toHashedIndexKey": "$val"
                 }
             }
         }

--- a/tests/Builder/Expression/RandOperatorTest.php
+++ b/tests/Builder/Expression/RandOperatorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $rand expression
+ */
+class RandOperatorTest extends PipelineTestCase
+{
+    public function testGenerateRandomDataPoints(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::set(
+                amount: Expression::multiply(
+                    Expression::rand(),
+                    100,
+                ),
+            ),
+            Stage::set(
+                amount: Expression::floor(
+                    Expression::numberFieldPath('amount'),
+                ),
+            ),
+            Stage::merge('donors'),
+        );
+
+        $this->assertSamePipeline(Pipelines::RandGenerateRandomDataPoints, $pipeline);
+    }
+
+    public function testSelectRandomItemsFromACollection(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                district: 3,
+            ),
+            Stage::match(
+                Query::expr(
+                    Expression::lt(
+                        0.5,
+                        Expression::rand(),
+                    ),
+                ),
+            ),
+            Stage::project(
+                _id: 0,
+                name: 1,
+                registered: 1,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::RandSelectRandomItemsFromACollection, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/ToHashedIndexKeyOperatorTest.php
+++ b/tests/Builder/Expression/ToHashedIndexKeyOperatorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $toHashedIndexKey expression
+ */
+class ToHashedIndexKeyOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::documents([
+                object(val: 'string to hash'),
+            ]),
+            Stage::addFields(
+                hashedVal: Expression::toHashedIndexKey(
+                    Expression::stringFieldPath('val'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ToHashedIndexKeyExample, $pipeline);
+    }
+}

--- a/tests/Builder/Query/Pipelines.php
+++ b/tests/Builder/Query/Pipelines.php
@@ -1363,6 +1363,26 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sampleRate/#examples
+     */
+    case SampleRateExample = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$sampleRate": {
+                    "$numberDouble": "0.33000000000000001554"
+                }
+            }
+        },
+        {
+            "$count": "numMatches"
+        }
+    ]
+    JSON;
+
+    /**
      * Query an Array by Array Length
      *
      * @see https://www.mongodb.com/docs/manual/tutorial/query-arrays/#query-an-array-by-array-length

--- a/tests/Builder/Query/SampleRateOperatorTest.php
+++ b/tests/Builder/Query/SampleRateOperatorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $sampleRate query
+ */
+class SampleRateOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::sampleRate(0.33),
+            ),
+            Stage::count('numMatches'),
+        );
+
+        $this->assertSamePipeline(Pipelines::SampleRateExample, $pipeline);
+    }
+}


### PR DESCRIPTION
Fix [PHPLIB-1351](https://jira.mongodb.org/browse/PHPLIB-1351)

https://www.mongodb.com/docs/manual/reference/operator/aggregation/#miscellaneous-operators

- `$getField`
- `$rand`
- `$sampleRate` moved to `query` as it is used in a `$match` stage
- `$toHashedIndexKey` operator that was missing from my initial import.