### PR TITLE
PHPLIB-1352 Add tests on Object Expression Operators

### DIFF
--- a/generator/config/expression/setField.yaml
+++ b/generator/config/expression/setField.yaml
@@ -27,3 +27,81 @@ arguments:
         description: |
             The value that you want to assign to field. value can be any valid expression.
             Set to $$REMOVE to remove field from the input document.
+tests:
+    -
+        name: 'Add Fields that Contain Periods'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/setField/#add-fields-that-contain-periods--.-'
+        pipeline:
+            -
+                $replaceWith:
+                    $setField:
+                        field: 'price.usd'
+                        input: '$$ROOT'
+                        value: '$price'
+            -
+                # $unset: 'price'
+                $unset:
+                    - 'price'
+    -
+        name: 'Add Fields that Start with a Dollar Sign'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/setField/#add-fields-that-start-with-a-dollar-sign----'
+        pipeline:
+            -
+                $replaceWith:
+                    $setField:
+                        field:
+                            $literal: '$price'
+                        input: '$$ROOT'
+                        value: '$price'
+            -
+                # $unset: 'price'
+                $unset:
+                    - 'price'
+    -
+        name: 'Update Fields that Contain Periods'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/setField/#update-fields-that-contain-periods--.-'
+        pipeline:
+            -
+                $match:
+                    _id: 1
+            -
+                $replaceWith:
+                    $setField:
+                        field: 'price.usd'
+                        input: '$$ROOT'
+                        value: 49.99
+    -
+        name: 'Update Fields that Start with a Dollar Sign'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/setField/#update-fields-that-start-with-a-dollar-sign----'
+        pipeline:
+            -
+                $match:
+                    _id: 1
+            -
+                $replaceWith:
+                    $setField:
+                        field:
+                            $literal: '$price'
+                        input: '$$ROOT'
+                        value: 49.99
+    -
+        name: 'Remove Fields that Contain Periods'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/setField/#remove-fields-that-contain-periods--.-'
+        pipeline:
+            -
+                $replaceWith:
+                    $setField:
+                        field: 'price.usd'
+                        input: '$$ROOT'
+                        value: '$$REMOVE'
+    -
+        name: 'Remove Fields that Start with a Dollar Sign'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/setField/#remove-fields-that-start-with-a-dollar-sign----'
+        pipeline:
+            -
+                $replaceWith:
+                    $setField:
+                        field:
+                            $literal: '$price'
+                        input: '$$ROOT'
+                        value: '$$REMOVE'

--- a/generator/config/expression/unsetField.yaml
+++ b/generator/config/expression/unsetField.yaml
@@ -20,3 +20,39 @@ arguments:
             - resolvesToObject
         description: |
             Document that contains the field that you want to add or update. input must resolve to an object, missing, null, or undefined.
+tests:
+    -
+        name: 'Remove Fields that Contain Periods'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/unsetField/#remove-fields-that-contain-periods--.-'
+        pipeline:
+            -
+                $replaceWith:
+                    $unsetField:
+                        field: 'price.usd'
+                        input: '$$ROOT'
+    -
+        name: 'Remove Fields that Start with a Dollar Sign'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/unsetField/#remove-fields-that-start-with-a-dollar-sign----'
+        pipeline:
+            -
+                $replaceWith:
+                    $unsetField:
+                        field:
+                            $literal: '$price'
+                        input: '$$ROOT'
+    -
+        name: 'Remove A Subfield'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/unsetField/#remove-a-subfield'
+        pipeline:
+            -
+                $replaceWith:
+                    $setField:
+                        field: 'price'
+                        input: '$$ROOT'
+                        value:
+                            $unsetField:
+                                field: 'euro'
+                                input:
+                                    # $getField: 'price'
+                                    $getField:
+                                        field: 'price'

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -1833,6 +1833,154 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Add Fields that Contain Periods
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setField/#add-fields-that-contain-periods--.-
+     */
+    case SetFieldAddFieldsThatContainPeriods = <<<'JSON'
+    [
+        {
+            "$replaceWith": {
+                "$setField": {
+                    "field": "price.usd",
+                    "input": "$$ROOT",
+                    "value": "$price"
+                }
+            }
+        },
+        {
+            "$unset": [
+                "price"
+            ]
+        }
+    ]
+    JSON;
+
+    /**
+     * Add Fields that Start with a Dollar Sign
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setField/#add-fields-that-start-with-a-dollar-sign----
+     */
+    case SetFieldAddFieldsThatStartWithADollarSign = <<<'JSON'
+    [
+        {
+            "$replaceWith": {
+                "$setField": {
+                    "field": {
+                        "$literal": "$price"
+                    },
+                    "input": "$$ROOT",
+                    "value": "$price"
+                }
+            }
+        },
+        {
+            "$unset": [
+                "price"
+            ]
+        }
+    ]
+    JSON;
+
+    /**
+     * Update Fields that Contain Periods
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setField/#update-fields-that-contain-periods--.-
+     */
+    case SetFieldUpdateFieldsThatContainPeriods = <<<'JSON'
+    [
+        {
+            "$match": {
+                "_id": {
+                    "$numberInt": "1"
+                }
+            }
+        },
+        {
+            "$replaceWith": {
+                "$setField": {
+                    "field": "price.usd",
+                    "input": "$$ROOT",
+                    "value": {
+                        "$numberDouble": "49.99000000000000199"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Update Fields that Start with a Dollar Sign
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setField/#update-fields-that-start-with-a-dollar-sign----
+     */
+    case SetFieldUpdateFieldsThatStartWithADollarSign = <<<'JSON'
+    [
+        {
+            "$match": {
+                "_id": {
+                    "$numberInt": "1"
+                }
+            }
+        },
+        {
+            "$replaceWith": {
+                "$setField": {
+                    "field": {
+                        "$literal": "$price"
+                    },
+                    "input": "$$ROOT",
+                    "value": {
+                        "$numberDouble": "49.99000000000000199"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Remove Fields that Contain Periods
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setField/#remove-fields-that-contain-periods--.-
+     */
+    case SetFieldRemoveFieldsThatContainPeriods = <<<'JSON'
+    [
+        {
+            "$replaceWith": {
+                "$setField": {
+                    "field": "price.usd",
+                    "input": "$$ROOT",
+                    "value": "$$REMOVE"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Remove Fields that Start with a Dollar Sign
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setField/#remove-fields-that-start-with-a-dollar-sign----
+     */
+    case SetFieldRemoveFieldsThatStartWithADollarSign = <<<'JSON'
+    [
+        {
+            "$replaceWith": {
+                "$setField": {
+                    "field": {
+                        "$literal": "$price"
+                    },
+                    "input": "$$ROOT",
+                    "value": "$$REMOVE"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Example
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/size/#example
@@ -2280,6 +2428,72 @@ enum Pipelines: string
                             }
                         ],
                         "default": "No scores found."
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Remove Fields that Contain Periods
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/unsetField/#remove-fields-that-contain-periods--.-
+     */
+    case UnsetFieldRemoveFieldsThatContainPeriods = <<<'JSON'
+    [
+        {
+            "$replaceWith": {
+                "$unsetField": {
+                    "field": "price.usd",
+                    "input": "$$ROOT"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Remove Fields that Start with a Dollar Sign
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/unsetField/#remove-fields-that-start-with-a-dollar-sign----
+     */
+    case UnsetFieldRemoveFieldsThatStartWithADollarSign = <<<'JSON'
+    [
+        {
+            "$replaceWith": {
+                "$unsetField": {
+                    "field": {
+                        "$literal": "$price"
+                    },
+                    "input": "$$ROOT"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Remove A Subfield
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/unsetField/#remove-a-subfield
+     */
+    case UnsetFieldRemoveASubfield = <<<'JSON'
+    [
+        {
+            "$replaceWith": {
+                "$setField": {
+                    "field": "price",
+                    "input": "$$ROOT",
+                    "value": {
+                        "$unsetField": {
+                            "field": "euro",
+                            "input": {
+                                "$getField": {
+                                    "field": "price"
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/tests/Builder/Expression/SetFieldOperatorTest.php
+++ b/tests/Builder/Expression/SetFieldOperatorTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $setField expression
+ */
+class SetFieldOperatorTest extends PipelineTestCase
+{
+    public function testAddFieldsThatContainPeriods(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::replaceWith(
+                Expression::setField(
+                    field: 'price.usd',
+                    input: Expression::variable('ROOT'),
+                    value: Expression::fieldPath('price'),
+                ),
+            ),
+            Stage::unset('price'),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetFieldAddFieldsThatContainPeriods, $pipeline);
+    }
+
+    public function testAddFieldsThatStartWithADollarSign(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::replaceWith(
+                Expression::setField(
+                    field: Expression::literal('$price'),
+                    input: Expression::variable('ROOT'),
+                    value: Expression::fieldPath('price'),
+                ),
+            ),
+            Stage::unset('price'),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetFieldAddFieldsThatStartWithADollarSign, $pipeline);
+    }
+
+    public function testRemoveFieldsThatContainPeriods(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::replaceWith(
+                Expression::setField(
+                    field: 'price.usd',
+                    input: Expression::variable('ROOT'),
+                    value: Expression::variable('REMOVE'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetFieldRemoveFieldsThatContainPeriods, $pipeline);
+    }
+
+    public function testRemoveFieldsThatStartWithADollarSign(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::replaceWith(
+                Expression::setField(
+                    field: Expression::literal('$price'),
+                    input: Expression::variable('ROOT'),
+                    value: Expression::variable('REMOVE'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetFieldRemoveFieldsThatStartWithADollarSign, $pipeline);
+    }
+
+    public function testUpdateFieldsThatContainPeriods(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                _id: 1,
+            ),
+            Stage::replaceWith(
+                Expression::setField(
+                    field: 'price.usd',
+                    input: Expression::variable('ROOT'),
+                    value: 49.99,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetFieldUpdateFieldsThatContainPeriods, $pipeline);
+    }
+
+    public function testUpdateFieldsThatStartWithADollarSign(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                _id: 1,
+            ),
+            Stage::replaceWith(
+                Expression::setField(
+                    field: Expression::literal('$price'),
+                    input: Expression::variable('ROOT'),
+                    value: 49.99,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetFieldUpdateFieldsThatStartWithADollarSign, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/UnsetFieldOperatorTest.php
+++ b/tests/Builder/Expression/UnsetFieldOperatorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $unsetField expression
+ */
+class UnsetFieldOperatorTest extends PipelineTestCase
+{
+    public function testRemoveASubfield(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::replaceWith(
+                Expression::setField(
+                    field: 'price',
+                    input: Expression::variable('ROOT'),
+                    value: Expression::unsetField(
+                        field: 'euro',
+                        input: Expression::getField('price'),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::UnsetFieldRemoveASubfield, $pipeline);
+    }
+
+    public function testRemoveFieldsThatContainPeriods(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::replaceWith(
+                Expression::unsetField(
+                    field: 'price.usd',
+                    input: Expression::variable('ROOT'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::UnsetFieldRemoveFieldsThatContainPeriods, $pipeline);
+    }
+
+    public function testRemoveFieldsThatStartWithADollarSign(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::replaceWith(
+                Expression::unsetField(
+                    field: Expression::literal('$price'),
+                    input: Expression::variable('ROOT'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::UnsetFieldRemoveFieldsThatStartWithADollarSign, $pipeline);
+    }
+}


### PR DESCRIPTION
Fix [PHPLIB-1352](https://jira.mongodb.org/browse/PHPLIB-1352)

https://www.mongodb.com/docs/manual/reference/operator/aggregation/#object-expression-operators

- ~`$mergeObjects`~ already done
- ~`$objectToArray`~ already done
- `$setField`
- `$unsetField` in addition, because it is close to the previous one