### PR TITLE
PHPLIB-1353 Add tests on Set Expression Operators

### DIFF
--- a/generator/config/expression/allElementsTrue.yaml
+++ b/generator/config/expression/allElementsTrue.yaml
@@ -11,4 +11,15 @@ arguments:
         name: expression
         type:
             - resolvesToArray
-        variadic: array
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/allElementsTrue/#example'
+        pipeline:
+            -
+                $project:
+                    responses: 1
+                    isAllTrue:
+                        $allElementsTrue:
+                            - '$responses'
+                    _id: 0

--- a/generator/config/expression/anyElementTrue.yaml
+++ b/generator/config/expression/anyElementTrue.yaml
@@ -11,3 +11,15 @@ arguments:
         name: expression
         type:
             - resolvesToArray
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/anyElementTrue/#example'
+        pipeline:
+            -
+                $project:
+                    responses: 1
+                    isAnyTrue:
+                        $anyElementTrue:
+                            - '$responses'
+                    _id: 0

--- a/generator/config/expression/setDifference.yaml
+++ b/generator/config/expression/setDifference.yaml
@@ -19,3 +19,17 @@ arguments:
             - resolvesToArray
         description: |
             The arguments can be any valid expression as long as they each resolve to an array.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/setDifference/#example'
+        pipeline:
+            -
+                $project:
+                    flowerFieldA: 1
+                    flowerFieldB: 1
+                    inBOnly:
+                        $setDifference:
+                            - '$flowerFieldB'
+                            - '$flowerFieldA'
+                    _id: 0

--- a/generator/config/expression/setEquals.yaml
+++ b/generator/config/expression/setEquals.yaml
@@ -12,3 +12,17 @@ arguments:
         type:
             - resolvesToArray
         variadic: array
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/setEquals/#example'
+        pipeline:
+            -
+                $project:
+                    _id: 0
+                    cakes: 1
+                    cupcakes: 1
+                    sameFlavors:
+                        $setEquals:
+                            - '$cakes'
+                            - '$cupcakes'

--- a/generator/config/expression/setIntersection.yaml
+++ b/generator/config/expression/setIntersection.yaml
@@ -12,3 +12,33 @@ arguments:
         type:
             - resolvesToArray
         variadic: array
+tests:
+    -
+        name: 'Elements Array Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/setIntersection/#elements-array-example'
+        pipeline:
+            -
+                $project:
+                    flowerFieldA: 1
+                    flowerFieldB: 1
+                    commonToBoth:
+                        $setIntersection:
+                            - '$flowerFieldA'
+                            - '$flowerFieldB'
+                    _id: 0
+    -
+        name: 'Retrieve Documents for Roles Granted to the Current User'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/setIntersection/#retrieve-documents-for-roles-granted-to-the-current-user'
+        pipeline:
+            -
+                $match:
+                    $expr:
+                        $not:
+                            # the example doesn't use an array inside $not, but the documentation say it is necessary
+                            -
+                                $eq:
+                                    -
+                                        $setIntersection:
+                                            - '$allowedRoles'
+                                            - '$$USER_ROLES.role'
+                                    - []

--- a/generator/config/expression/setIsSubset.yaml
+++ b/generator/config/expression/setIsSubset.yaml
@@ -15,3 +15,18 @@ arguments:
         name: expression2
         type:
             - resolvesToArray
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/setIsSubset/#example'
+        pipeline:
+            -
+                $project:
+                    flowerFieldA: 1
+                    flowerFieldB: 1
+                    AisSubset:
+                        $setIsSubset:
+                            - '$flowerFieldA'
+                            - '$flowerFieldB'
+                    _id: 0
+

--- a/generator/config/expression/setUnion.yaml
+++ b/generator/config/expression/setUnion.yaml
@@ -12,3 +12,17 @@ arguments:
         type:
             - resolvesToArray
         variadic: array
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/setUnion/#example'
+        pipeline:
+            -
+                $project:
+                    flowerFieldA: 1
+                    flowerFieldB: 1
+                    allValues:
+                        $setUnion:
+                            - '$flowerFieldA'
+                            - '$flowerFieldB'
+                    _id: 0

--- a/src/Builder/Expression/AllElementsTrueOperator.php
+++ b/src/Builder/Expression/AllElementsTrueOperator.php
@@ -15,6 +15,7 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\BSONArray;
 
 use function array_is_list;
+use function is_array;
 
 /**
  * Returns true if no element of a set evaluates to false, otherwise, returns false. Accepts a single argument expression.
@@ -25,21 +26,16 @@ class AllElementsTrueOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 
-    /** @var list<BSONArray|PackedArray|ResolvesToArray|array> $expression */
-    public readonly array $expression;
+    /** @var BSONArray|PackedArray|ResolvesToArray|array $expression */
+    public readonly PackedArray|ResolvesToArray|BSONArray|array $expression;
 
     /**
-     * @param BSONArray|PackedArray|ResolvesToArray|array ...$expression
-     * @no-named-arguments
+     * @param BSONArray|PackedArray|ResolvesToArray|array $expression
      */
-    public function __construct(PackedArray|ResolvesToArray|BSONArray|array ...$expression)
+    public function __construct(PackedArray|ResolvesToArray|BSONArray|array $expression)
     {
-        if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
-        }
-
-        if (! array_is_list($expression)) {
-            throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
+        if (is_array($expression) && ! array_is_list($expression)) {
+            throw new InvalidArgumentException('Expected $expression argument to be a list, got an associative array.');
         }
 
         $this->expression = $expression;

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -85,14 +85,13 @@ trait FactoryTrait
      * Returns true if no element of a set evaluates to false, otherwise, returns false. Accepts a single argument expression.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/allElementsTrue/
-     * @no-named-arguments
-     * @param BSONArray|PackedArray|ResolvesToArray|array ...$expression
+     * @param BSONArray|PackedArray|ResolvesToArray|array $expression
      */
     public static function allElementsTrue(
-        PackedArray|ResolvesToArray|BSONArray|array ...$expression,
+        PackedArray|ResolvesToArray|BSONArray|array $expression,
     ): AllElementsTrueOperator
     {
-        return new AllElementsTrueOperator(...$expression);
+        return new AllElementsTrueOperator($expression);
     }
 
     /**

--- a/tests/Builder/Expression/AllElementsTrueOperatorTest.php
+++ b/tests/Builder/Expression/AllElementsTrueOperatorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $allElementsTrue expression
+ */
+class AllElementsTrueOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                responses: 1,
+                isAllTrue: Expression::allElementsTrue(
+                    Expression::arrayFieldPath('responses'),
+                ),
+                _id: 0,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::AllElementsTrueExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/AnyElementTrueOperatorTest.php
+++ b/tests/Builder/Expression/AnyElementTrueOperatorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $anyElementTrue expression
+ */
+class AnyElementTrueOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                responses: 1,
+                isAnyTrue: Expression::anyElementTrue(
+                    Expression::arrayFieldPath('responses'),
+                ),
+                _id: 0,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::AnyElementTrueExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -61,6 +61,31 @@ enum Pipelines: string
     /**
      * Example
      *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/allElementsTrue/#example
+     */
+    case AllElementsTrueExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "responses": {
+                    "$numberInt": "1"
+                },
+                "isAllTrue": {
+                    "$allElementsTrue": [
+                        "$responses"
+                    ]
+                },
+                "_id": {
+                    "$numberInt": "0"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/and/#example
      */
     case AndExample = <<<'JSON'
@@ -92,6 +117,31 @@ enum Pipelines: string
                             ]
                         }
                     ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/anyElementTrue/#example
+     */
+    case AnyElementTrueExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "responses": {
+                    "$numberInt": "1"
+                },
+                "isAnyTrue": {
+                    "$anyElementTrue": [
+                        "$responses"
+                    ]
+                },
+                "_id": {
+                    "$numberInt": "0"
                 }
             }
         }
@@ -1826,6 +1876,180 @@ enum Pipelines: string
                 },
                 "reverseFavorites": {
                     "$reverseArray": "$favorites"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setDifference/#example
+     */
+    case SetDifferenceExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "flowerFieldA": {
+                    "$numberInt": "1"
+                },
+                "flowerFieldB": {
+                    "$numberInt": "1"
+                },
+                "inBOnly": {
+                    "$setDifference": [
+                        "$flowerFieldB",
+                        "$flowerFieldA"
+                    ]
+                },
+                "_id": {
+                    "$numberInt": "0"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setEquals/#example
+     */
+    case SetEqualsExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "cakes": {
+                    "$numberInt": "1"
+                },
+                "cupcakes": {
+                    "$numberInt": "1"
+                },
+                "sameFlavors": {
+                    "$setEquals": [
+                        "$cakes",
+                        "$cupcakes"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Elements Array Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setIntersection/#elements-array-example
+     */
+    case SetIntersectionElementsArrayExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "flowerFieldA": {
+                    "$numberInt": "1"
+                },
+                "flowerFieldB": {
+                    "$numberInt": "1"
+                },
+                "commonToBoth": {
+                    "$setIntersection": [
+                        "$flowerFieldA",
+                        "$flowerFieldB"
+                    ]
+                },
+                "_id": {
+                    "$numberInt": "0"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Retrieve Documents for Roles Granted to the Current User
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setIntersection/#retrieve-documents-for-roles-granted-to-the-current-user
+     */
+    case SetIntersectionRetrieveDocumentsForRolesGrantedToTheCurrentUser = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$expr": {
+                    "$not": [
+                        {
+                            "$eq": [
+                                {
+                                    "$setIntersection": [
+                                        "$allowedRoles",
+                                        "$$USER_ROLES.role"
+                                    ]
+                                },
+                                []
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setIsSubset/#example
+     */
+    case SetIsSubsetExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "flowerFieldA": {
+                    "$numberInt": "1"
+                },
+                "flowerFieldB": {
+                    "$numberInt": "1"
+                },
+                "AisSubset": {
+                    "$setIsSubset": [
+                        "$flowerFieldA",
+                        "$flowerFieldB"
+                    ]
+                },
+                "_id": {
+                    "$numberInt": "0"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setUnion/#example
+     */
+    case SetUnionExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "flowerFieldA": {
+                    "$numberInt": "1"
+                },
+                "flowerFieldB": {
+                    "$numberInt": "1"
+                },
+                "allValues": {
+                    "$setUnion": [
+                        "$flowerFieldA",
+                        "$flowerFieldB"
+                    ]
+                },
+                "_id": {
+                    "$numberInt": "0"
                 }
             }
         }

--- a/tests/Builder/Expression/SetDifferenceOperatorTest.php
+++ b/tests/Builder/Expression/SetDifferenceOperatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $setDifference expression
+ */
+class SetDifferenceOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                flowerFieldA: 1,
+                flowerFieldB: 1,
+                inBOnly: Expression::setDifference(
+                    Expression::arrayFieldPath('flowerFieldB'),
+                    Expression::arrayFieldPath('flowerFieldA'),
+                ),
+                _id: 0,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetDifferenceExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/SetEqualsOperatorTest.php
+++ b/tests/Builder/Expression/SetEqualsOperatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $setEquals expression
+ */
+class SetEqualsOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                _id: 0,
+                cakes: 1,
+                cupcakes: 1,
+                sameFlavors: Expression::setEquals(
+                    Expression::arrayFieldPath('cakes'),
+                    Expression::arrayFieldPath('cupcakes'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetEqualsExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/SetIntersectionOperatorTest.php
+++ b/tests/Builder/Expression/SetIntersectionOperatorTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $setIntersection expression
+ */
+class SetIntersectionOperatorTest extends PipelineTestCase
+{
+    public function testElementsArrayExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                flowerFieldA: 1,
+                flowerFieldB: 1,
+                commonToBoth: Expression::setIntersection(
+                    Expression::arrayFieldPath('flowerFieldA'),
+                    Expression::arrayFieldPath('flowerFieldB'),
+                ),
+                _id: 0,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetIntersectionElementsArrayExample, $pipeline);
+    }
+
+    public function testRetrieveDocumentsForRolesGrantedToTheCurrentUser(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::expr(
+                    Expression::not(
+                        Expression::eq(
+                            Expression::setIntersection(
+                                Expression::arrayFieldPath('allowedRoles'),
+                                Expression::variable('USER_ROLES.role'),
+                            ),
+                            [],
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetIntersectionRetrieveDocumentsForRolesGrantedToTheCurrentUser, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/SetIsSubsetOperatorTest.php
+++ b/tests/Builder/Expression/SetIsSubsetOperatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $setIsSubset expression
+ */
+class SetIsSubsetOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                flowerFieldA: 1,
+                flowerFieldB: 1,
+                AisSubset: Expression::setIsSubset(
+                    Expression::arrayFieldPath('flowerFieldA'),
+                    Expression::arrayFieldPath('flowerFieldB'),
+                ),
+                _id: 0,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetIsSubsetExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/SetUnionOperatorTest.php
+++ b/tests/Builder/Expression/SetUnionOperatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $setUnion expression
+ */
+class SetUnionOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                flowerFieldA: 1,
+                flowerFieldB: 1,
+                allValues: Expression::setUnion(
+                    Expression::arrayFieldPath('flowerFieldA'),
+                    Expression::arrayFieldPath('flowerFieldB'),
+                ),
+                _id: 0,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetUnionExample, $pipeline);
+    }
+}


### PR DESCRIPTION
Fix [PHPLIB-1353](https://jira.mongodb.org/browse/PHPLIB-1353)

https://www.mongodb.com/docs/manual/reference/operator/aggregation/#set-expression-operators

- `$allElementsTrue` fix not variadic
- `$anyElementTrue`
- `$setDifference`
- `$setEquals`
- `$setIntersection`
- `$setIsSubset`
- `$setUnion`