### PR TITLE
PHPLIB-1354 Add tests on String Expression Operators

### DIFF
--- a/generator/config/expression/concat.yaml
+++ b/generator/config/expression/concat.yaml
@@ -12,3 +12,15 @@ arguments:
         type:
             - resolvesToString
         variadic: array
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/concat/#examples'
+        pipeline:
+            -
+                $project:
+                    itemDescription:
+                        $concat:
+                            - '$item'
+                            - ' - '
+                            - '$description'

--- a/generator/config/expression/indexOfBytes.yaml
+++ b/generator/config/expression/indexOfBytes.yaml
@@ -37,3 +37,14 @@ arguments:
         description: |
             An integer, or a number that can be represented as integers (such as 2.0), that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number. If you specify a <end> index value, you should also specify a <start> index value; otherwise, $indexOfArray uses the <end> value as the <start> index value instead of the <end> value.
             If unspecified, the ending index position for the search is the end of the string.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/indexOfBytes/#examples'
+        pipeline:
+            -
+                $project:
+                    byteLocation:
+                        $indexOfBytes:
+                            - '$item'
+                            - 'foo'

--- a/generator/config/expression/indexOfCP.yaml
+++ b/generator/config/expression/indexOfCP.yaml
@@ -37,3 +37,14 @@ arguments:
         description: |
             An integer, or a number that can be represented as integers (such as 2.0), that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number. If you specify a <end> index value, you should also specify a <start> index value; otherwise, $indexOfArray uses the <end> value as the <start> index value instead of the <end> value.
             If unspecified, the ending index position for the search is the end of the string.
+tests:
+    -
+        name: 'Examples'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/indexOfCP/#examples'
+        pipeline:
+            -
+                $project:
+                    cpLocation:
+                        $indexOfCP:
+                            - '$item'
+                            - 'foo'

--- a/generator/config/expression/ltrim.yaml
+++ b/generator/config/expression/ltrim.yaml
@@ -23,3 +23,14 @@ arguments:
             The character(s) to trim from the beginning of the input.
             The argument can be any valid expression that resolves to a string. The $ltrim operator breaks down the string into individual UTF code point to trim from input.
             If unspecified, $ltrim removes whitespace characters, including the null character.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/ltrim/#example'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    description:
+                        $ltrim:
+                            input: '$description'

--- a/generator/config/expression/regexFind.yaml
+++ b/generator/config/expression/regexFind.yaml
@@ -26,3 +26,14 @@ arguments:
         type:
             - string
         optional: true
+tests:
+    -
+        name: '$regexFind and Its Options'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/regexFind/#-regexfind-and-its-options'
+        pipeline:
+            -
+                $addFields:
+                    returnObject:
+                        $regexFind:
+                            input: '$description'
+                            regex: !regex 'line'

--- a/generator/config/expression/regexFind.yaml
+++ b/generator/config/expression/regexFind.yaml
@@ -37,3 +37,30 @@ tests:
                         $regexFind:
                             input: '$description'
                             regex: !regex 'line'
+    -
+        name: 'i Option'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/regexFind/#i-option'
+        pipeline:
+            -
+                $addFields:
+                    returnObject:
+                        # Specify i as part of the Regex type
+                        $regexFind:
+                            input: '$description'
+                            regex: !regex ['line', 'i']
+            -
+                $addFields:
+                    returnObject:
+                        # Specify i in the options field
+                        $regexFind:
+                            input: '$description'
+                            regex: 'line'
+                            options: 'i'
+            -
+                $addFields:
+                    returnObject:
+                        # Mix Regex type with options field
+                        $regexFind:
+                            input: '$description'
+                            regex: !regex 'line'
+                            options: 'i'

--- a/generator/config/expression/regexFindAll.yaml
+++ b/generator/config/expression/regexFindAll.yaml
@@ -44,7 +44,7 @@ tests:
             -
                 $addFields:
                     returnObject:
-                        # Specify i as part of the regex field
+                        # Specify i as part of the regex type
                         $regexFindAll:
                             input: '$description'
                             regex: !regex ['line', 'i']
@@ -59,7 +59,7 @@ tests:
             -
                 $addFields:
                     returnObject:
-                        # Specify i in the options field
+                        # Mix Regex type with options field
                         $regexFindAll:
                             input: '$description'
                             regex: !regex 'line'

--- a/generator/config/expression/regexFindAll.yaml
+++ b/generator/config/expression/regexFindAll.yaml
@@ -26,3 +26,74 @@ arguments:
         type:
             - string
         optional: true
+tests:
+    -
+        name: '$regexFindAll and Its Options'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/regexFindAll/#-regexfindall-and-its-options'
+        pipeline:
+            -
+                $addFields:
+                    returnObject:
+                        $regexFindAll:
+                            input: '$description'
+                            regex: !regex 'line'
+    -
+        name: 'i Option'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/regexFindAll/#i-option'
+        pipeline:
+            -
+                $addFields:
+                    returnObject:
+                        # Specify i as part of the regex field
+                        $regexFindAll:
+                            input: '$description'
+                            regex: !regex ['line', 'i']
+            -
+                $addFields:
+                    returnObject:
+                        # Specify i in the options field
+                        $regexFindAll:
+                            input: '$description'
+                            regex: 'line'
+                            options: 'i'
+            -
+                $addFields:
+                    returnObject:
+                        # Specify i in the options field
+                        $regexFindAll:
+                            input: '$description'
+                            regex: !regex 'line'
+                            options: 'i'
+    -
+        name: 'Use $regexFindAll to Parse Email from String'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/regexFindAll/#use--regexfindall-to-parse-email-from-string'
+        pipeline:
+            -
+                $addFields:
+                    email:
+                        $regexFindAll:
+                            input: '$comment'
+                            regex: !regex ['[a-z0-9_.+-]+@[a-z0-9_.+-]+\.[a-z0-9_.+-]+', 'i']
+            -
+                $set:
+                    email: '$email.match'
+    -
+        name: 'Use Captured Groupings to Parse User Name'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/regexFindAll/#use-captured-groupings-to-parse-user-name'
+        pipeline:
+            -
+                $addFields:
+                    names:
+                        $regexFindAll:
+                            input: '$comment'
+                            regex: !regex ['([a-z0-9_.+-]+)@[a-z0-9_.+-]+\.[a-z0-9_.+-]+', 'i']
+            -
+                $set:
+                    names:
+                        $reduce:
+                            input: '$names.captures'
+                            initialValue: []
+                            in:
+                                $concatArrays:
+                                    - '$$value'
+                                    - '$$this'

--- a/generator/config/expression/regexMatch.yaml
+++ b/generator/config/expression/regexMatch.yaml
@@ -44,7 +44,7 @@ tests:
             -
                 $addFields:
                     result:
-                        # Specify i as part of the regex field
+                        # Specify i as part of the Regex type
                         $regexMatch:
                             input: '$description'
                             regex: !regex ['line', 'i']
@@ -59,7 +59,7 @@ tests:
             -
                 $addFields:
                     result:
-                        # Specify i in the options field
+                        # Mix Regex type with options field
                         $regexMatch:
                             input: '$description'
                             regex: !regex 'line'

--- a/generator/config/expression/regexMatch.yaml
+++ b/generator/config/expression/regexMatch.yaml
@@ -26,3 +26,55 @@ arguments:
         type:
             - string
         optional: true
+tests:
+    -
+        name: '$regexMatch and Its Options'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/regexMatch/#-regexmatch-and-its-options'
+        pipeline:
+            -
+                $addFields:
+                    result:
+                        $regexMatch:
+                            input: '$description'
+                            regex: !regex 'line'
+    -
+        name: 'i Option'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/regexMatch/#i-option'
+        pipeline:
+            -
+                $addFields:
+                    result:
+                        # Specify i as part of the regex field
+                        $regexMatch:
+                            input: '$description'
+                            regex: !regex ['line', 'i']
+            -
+                $addFields:
+                    result:
+                        # Specify i in the options field
+                        $regexMatch:
+                            input: '$description'
+                            regex: 'line'
+                            options: 'i'
+            -
+                $addFields:
+                    result:
+                        # Specify i in the options field
+                        $regexMatch:
+                            input: '$description'
+                            regex: !regex 'line'
+                            options: 'i'
+    -
+        name: 'Use $regexMatch to Check Email Address'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/regexMatch/#use--regexmatch-to-check-email-address'
+        pipeline:
+            -
+                $addFields:
+                    category:
+                        $cond:
+                            if:
+                                $regexMatch:
+                                    input: '$comment'
+                                    regex: !regex ['[a-z0-9_.+-]+@mongodb.com', 'i']
+                            then: 'Employee'
+                            else: 'External'

--- a/generator/config/expression/replaceAll.yaml
+++ b/generator/config/expression/replaceAll.yaml
@@ -30,3 +30,15 @@ arguments:
             - resolvesToNull
         description: |
             The string to use to replace all matched instances of find in input. Can be any valid expression that resolves to a string or a null.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceAll/#example'
+        pipeline:
+            -
+                $project:
+                    item:
+                        $replaceAll:
+                            input: '$item'
+                            find: 'blue paint'
+                            replacement: 'red paint'

--- a/generator/config/expression/replaceOne.yaml
+++ b/generator/config/expression/replaceOne.yaml
@@ -29,3 +29,15 @@ arguments:
             - resolvesToNull
         description: |
             The string to use to replace all matched instances of find in input. Can be any valid expression that resolves to a string or a null.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceOne/#example'
+        pipeline:
+            -
+                $project:
+                    item:
+                        $replaceOne:
+                            input: '$item'
+                            find: 'blue paint'
+                            replacement: 'red paint'

--- a/generator/config/expression/rtrim.yaml
+++ b/generator/config/expression/rtrim.yaml
@@ -22,3 +22,14 @@ arguments:
             The character(s) to trim from the beginning of the input.
             The argument can be any valid expression that resolves to a string. The $ltrim operator breaks down the string into individual UTF code point to trim from input.
             If unspecified, $ltrim removes whitespace characters, including the null character.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/rtrim/#example'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    description:
+                        $rtrim:
+                            input: '$description'

--- a/generator/config/expression/split.yaml
+++ b/generator/config/expression/split.yaml
@@ -19,3 +19,30 @@ arguments:
             - resolvesToString
         description: |
             The delimiter to use when splitting the string expression. delimiter can be any valid expression as long as it resolves to a string.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/split/#example'
+        pipeline:
+            -
+                $project:
+                    city_state:
+                        $split:
+                            - '$city'
+                            - ', '
+                    qty: 1
+            -
+                $unwind:
+                    path: '$city_state'
+            -
+                $match:
+                    city_state: !regex '[A-Z]{2}'
+            -
+                $group:
+                    _id:
+                        state: '$city_state'
+                    total_qty:
+                        $sum: '$qty'
+            -
+                $sort:
+                    total_qty: -1

--- a/generator/config/expression/strLenBytes.yaml
+++ b/generator/config/expression/strLenBytes.yaml
@@ -11,3 +11,13 @@ arguments:
         name: expression
         type:
             - resolvesToString
+tests:
+    -
+        name: 'Single-Byte and Multibyte Character Set'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/strLenBytes/#single-byte-and-multibyte-character-set'
+        pipeline:
+            -
+                $project:
+                    name: 1
+                    length:
+                        $strLenBytes: '$name'

--- a/generator/config/expression/strLenCP.yaml
+++ b/generator/config/expression/strLenCP.yaml
@@ -11,3 +11,13 @@ arguments:
         name: expression
         type:
             - resolvesToString
+tests:
+    -
+        name: 'Single-Byte and Multibyte Character Set'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/strLenBytes/#single-byte-and-multibyte-character-set'
+        pipeline:
+            -
+                $project:
+                    name: 1
+                    length:
+                        $strLenCP: '$name'

--- a/generator/config/expression/strcasecmp.yaml
+++ b/generator/config/expression/strcasecmp.yaml
@@ -15,3 +15,15 @@ arguments:
         name: expression2
         type:
             - resolvesToString
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/strcasecmp/#example'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    comparisonResult:
+                        $strcasecmp:
+                            - '$quarter'
+                            - '13q4'

--- a/generator/config/expression/substr.yaml
+++ b/generator/config/expression/substr.yaml
@@ -23,3 +23,21 @@ arguments:
             - resolvesToInt
         description: |
             If length is a negative number, $substr returns a substring that starts at the specified index and includes the rest of the string.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/substr/#example'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    yearSubstring:
+                        $substr:
+                            - '$quarter'
+                            - 0
+                            - 2
+                    quarterSubtring:
+                        $substr:
+                            - '$quarter'
+                            - 2
+                            - -1

--- a/generator/config/expression/substrBytes.yaml
+++ b/generator/config/expression/substrBytes.yaml
@@ -23,3 +23,25 @@ arguments:
             - resolvesToInt
         description: |
             If length is a negative number, $substr returns a substring that starts at the specified index and includes the rest of the string.
+tests:
+    -
+        name: 'Single-Byte Character Set'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/substrBytes/#single-byte-character-set'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    yearSubstring:
+                        $substrBytes:
+                            - '$quarter'
+                            - 0
+                            - 2
+                    quarterSubtring:
+                        $substrBytes:
+                            - '$quarter'
+                            - 2
+                            -
+                                $subtract:
+                                    -
+                                        $strLenBytes: '$quarter'
+                                    - 2

--- a/generator/config/expression/substrBytes.yaml
+++ b/generator/config/expression/substrBytes.yaml
@@ -45,3 +45,15 @@ tests:
                                     -
                                         $strLenBytes: '$quarter'
                                     - 2
+    -
+        name: 'Single-Byte and Multibyte Character Set'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/substrBytes/#single-byte-and-multibyte-character-set'
+        pipeline:
+            -
+                $project:
+                    name: 1
+                    menuCode:
+                        $substrBytes:
+                            - '$name'
+                            - 0
+                            - 3

--- a/generator/config/expression/substrCP.yaml
+++ b/generator/config/expression/substrCP.yaml
@@ -23,3 +23,37 @@ arguments:
             - resolvesToInt
         description: |
             If length is a negative number, $substr returns a substring that starts at the specified index and includes the rest of the string.
+tests:
+    -
+        name: 'Single-Byte Character Set'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/substrCP/#single-byte-character-set'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    yearSubstring:
+                        $substrCP:
+                            - '$quarter'
+                            - 0
+                            - 2
+                    quarterSubtring:
+                        $substrCP:
+                            - '$quarter'
+                            - 2
+                            -
+                                $subtract:
+                                    -
+                                        $strLenCP: '$quarter'
+                                    - 2
+    -
+        name: 'Single-Byte and Multibyte Character Set'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/substrCP/#single-byte-and-multibyte-character-set'
+        pipeline:
+            -
+                $project:
+                    name: 1
+                    menuCode:
+                        $substrCP:
+                            - '$name'
+                            - 0
+                            - 3

--- a/generator/config/expression/toLower.yaml
+++ b/generator/config/expression/toLower.yaml
@@ -11,3 +11,14 @@ arguments:
         name: expression
         type:
             - resolvesToString
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/toLower/#example'
+        pipeline:
+            -
+                $project:
+                    item:
+                        $toLower: '$item'
+                    description:
+                        $toLower: '$description'

--- a/generator/config/expression/toString.yaml
+++ b/generator/config/expression/toString.yaml
@@ -12,3 +12,15 @@ arguments:
         name: expression
         type:
             - expression
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/toString/#example'
+        pipeline:
+            -
+                $addFields:
+                    convertedZipCode:
+                        $toString: '$zipcode'
+            -
+                $sort:
+                    convertedZipCode: 1

--- a/generator/config/expression/toUpper.yaml
+++ b/generator/config/expression/toUpper.yaml
@@ -11,3 +11,14 @@ arguments:
         name: expression
         type:
             - resolvesToString
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/toUpper/#example'
+        pipeline:
+            -
+                $project:
+                    item:
+                        $toUpper: '$item'
+                    description:
+                        $toUpper: '$description'

--- a/generator/config/expression/trim.yaml
+++ b/generator/config/expression/trim.yaml
@@ -23,3 +23,14 @@ arguments:
             The character(s) to trim from the beginning of the input.
             The argument can be any valid expression that resolves to a string. The $ltrim operator breaks down the string into individual UTF code point to trim from input.
             If unspecified, $ltrim removes whitespace characters, including the null character.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/trim/#example'
+        pipeline:
+            -
+                $project:
+                    item: 1
+                    description:
+                        $trim:
+                            input: '$description'

--- a/generator/js2yaml.html
+++ b/generator/js2yaml.html
@@ -26,6 +26,8 @@
 	  regex: /^123/,
 	  regex_with_flags: /^123/i,
 	  binary: BinData(0, "ID=="),
+	  empty_object: {},
+	  empty_array: [],
     }
   },
   // First Stage
@@ -87,6 +89,10 @@
         }
 
         if (Array.isArray(object)) {
+            if (object.length === 0) {
+                return ' []';
+			}
+
             return newline + '-' + object.map((item) => toYaml(item, indent + 1)).join(newline + '-');
         }
 
@@ -114,6 +120,10 @@
                 for (var key in object) {
                     dump.push(key + ':' + toYaml(object[key], indent + 1));
                 }
+                if (dump.length === 0) {
+                    return ' {}';
+				}
+
                 return newline + dump.join(newline);
             case 'function':
                 return toYaml({

--- a/generator/js2yaml.html
+++ b/generator/js2yaml.html
@@ -16,18 +16,18 @@
 <h1>Convert JS examples into Yaml</h1>
 
 <div>
-	<label for="input">Input JS code:</label>
-	<textarea id="input">
+    <label for="input">Input JS code:</label>
+    <textarea id="input">
 [
   // Tests
   {
     $project: {
       date: new Date(36),
-	  regex: /^123/,
-	  regex_with_flags: /^123/i,
-	  binary: BinData(0, "ID=="),
-	  empty_object: {},
-	  empty_array: [],
+      regex: /^123/,
+      regex_with_flags: /^123/i,
+      binary: BinData(0, "ID=="),
+      empty_object: {},
+      empty_array: [],
     }
   },
   // First Stage
@@ -53,12 +53,12 @@
     $match: { count: {$gt: 3} }
   }
 ]
-	</textarea>
+    </textarea>
 </div>
 
 <div>
-	<label for="output">Output YAML code:</label>
-	<textarea id="output"></textarea>
+    <label for="output">Output YAML code:</label>
+    <textarea id="output"></textarea>
 </div>
 
 
@@ -75,11 +75,11 @@
     }
 
     function convert(jsString) {
-      try {
-        return toYaml(eval(jsString), 1);
-      } catch (e) {
-        return e.toString();
-      }
+        try {
+            return toYaml(eval(jsString), 1);
+        } catch (e) {
+            return e.toString();
+        }
     }
 
     function toYaml(object, indent = 0) {
@@ -91,7 +91,7 @@
         if (Array.isArray(object)) {
             if (object.length === 0) {
                 return ' []';
-			}
+            }
 
             return newline + '-' + object.map((item) => toYaml(item, indent + 1)).join(newline + '-');
         }
@@ -105,7 +105,7 @@
         }
 
         if (object instanceof TaggedValue) {
-			return " !" + object.tag + toYaml(object.value);
+            return " !" + object.tag + toYaml(object.value);
         }
 
         switch (typeof object) {
@@ -122,7 +122,7 @@
                 }
                 if (dump.length === 0) {
                     return ' {}';
-				}
+                }
 
                 return newline + dump.join(newline);
             case 'function':

--- a/generator/js2yaml.html
+++ b/generator/js2yaml.html
@@ -25,7 +25,7 @@
       date: new Date(36),
       regex: /^123/,
       regex_with_flags: /^123/i,
-      binary: BinData(0, "ID=="),
+      binary: BinData(0, "IA=="),
       empty_object: {},
       empty_array: [],
     }

--- a/tests/Builder/Expression/ConcatOperatorTest.php
+++ b/tests/Builder/Expression/ConcatOperatorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $concat expression
+ */
+class ConcatOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                itemDescription: Expression::concat(
+                    Expression::stringFieldPath('item'),
+                    ' - ',
+                    Expression::stringFieldPath('description'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ConcatExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/IndexOfBytesOperatorTest.php
+++ b/tests/Builder/Expression/IndexOfBytesOperatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $indexOfBytes expression
+ */
+class IndexOfBytesOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                byteLocation: Expression::indexOfBytes(
+                    Expression::stringFieldPath('item'),
+                    'foo',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::IndexOfBytesExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/IndexOfCPOperatorTest.php
+++ b/tests/Builder/Expression/IndexOfCPOperatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $indexOfCP expression
+ */
+class IndexOfCPOperatorTest extends PipelineTestCase
+{
+    public function testExamples(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                cpLocation: Expression::indexOfCP(
+                    Expression::stringFieldPath('item'),
+                    'foo',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::IndexOfCPExamples, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/LtrimOperatorTest.php
+++ b/tests/Builder/Expression/LtrimOperatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $ltrim expression
+ */
+class LtrimOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                description: Expression::ltrim(
+                    Expression::stringFieldPath('description'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::LtrimExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -521,6 +521,27 @@ enum Pipelines: string
     /**
      * Example
      *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/concat/#examples
+     */
+    case ConcatExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "itemDescription": {
+                    "$concat": [
+                        "$item",
+                        " - ",
+                        "$description"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/concatArrays/#example
      */
     case ConcatArraysExample = <<<'JSON'
@@ -1940,6 +1961,46 @@ enum Pipelines: string
     /**
      * Example
      *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/indexOfBytes/#examples
+     */
+    case IndexOfBytesExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "byteLocation": {
+                    "$indexOfBytes": [
+                        "$item",
+                        "foo"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Examples
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/indexOfCP/#examples
+     */
+    case IndexOfCPExamples = <<<'JSON'
+    [
+        {
+            "$project": {
+                "cpLocation": {
+                    "$indexOfCP": [
+                        "$item",
+                        "foo"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/isArray/#example
      */
     case IsArrayExample = <<<'JSON'
@@ -2174,6 +2235,28 @@ enum Pipelines: string
                 },
                 "_id": {
                     "$numberInt": "0"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/ltrim/#example
+     */
+    case LtrimExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "description": {
+                    "$ltrim": {
+                        "input": "$description"
+                    }
                 }
             }
         }
@@ -2986,6 +3069,329 @@ enum Pipelines: string
     JSON;
 
     /**
+     * $regexFind and Its Options
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/regexFind/#-regexfind-and-its-options
+     */
+    case RegexFindRegexFindAndItsOptions = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "returnObject": {
+                    "$regexFind": {
+                        "input": "$description",
+                        "regex": {
+                            "$regularExpression": {
+                                "pattern": "line",
+                                "options": ""
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * $regexFindAll and Its Options
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/regexFindAll/#-regexfindall-and-its-options
+     */
+    case RegexFindAllRegexFindAllAndItsOptions = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "returnObject": {
+                    "$regexFindAll": {
+                        "input": "$description",
+                        "regex": {
+                            "$regularExpression": {
+                                "pattern": "line",
+                                "options": ""
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * i Option
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/regexFindAll/#i-option
+     */
+    case RegexFindAllIOption = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "returnObject": {
+                    "$regexFindAll": {
+                        "input": "$description",
+                        "regex": {
+                            "$regularExpression": {
+                                "pattern": "line",
+                                "options": "i"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "$addFields": {
+                "returnObject": {
+                    "$regexFindAll": {
+                        "input": "$description",
+                        "regex": "line",
+                        "options": "i"
+                    }
+                }
+            }
+        },
+        {
+            "$addFields": {
+                "returnObject": {
+                    "$regexFindAll": {
+                        "input": "$description",
+                        "regex": {
+                            "$regularExpression": {
+                                "pattern": "line",
+                                "options": ""
+                            }
+                        },
+                        "options": "i"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use $regexFindAll to Parse Email from String
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/regexFindAll/#use--regexfindall-to-parse-email-from-string
+     */
+    case RegexFindAllUseRegexFindAllToParseEmailFromString = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "email": {
+                    "$regexFindAll": {
+                        "input": "$comment",
+                        "regex": {
+                            "$regularExpression": {
+                                "pattern": "[a-z0-9_.+-]+@[a-z0-9_.+-]+\\.[a-z0-9_.+-]+",
+                                "options": "i"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "$set": {
+                "email": "$email.match"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use Captured Groupings to Parse User Name
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/regexFindAll/#use-captured-groupings-to-parse-user-name
+     */
+    case RegexFindAllUseCapturedGroupingsToParseUserName = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "names": {
+                    "$regexFindAll": {
+                        "input": "$comment",
+                        "regex": {
+                            "$regularExpression": {
+                                "pattern": "([a-z0-9_.+-]+)@[a-z0-9_.+-]+\\.[a-z0-9_.+-]+",
+                                "options": "i"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "$set": {
+                "names": {
+                    "$reduce": {
+                        "input": "$names.captures",
+                        "initialValue": [],
+                        "in": {
+                            "$concatArrays": [
+                                "$$value",
+                                "$$this"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * $regexMatch and Its Options
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/regexMatch/#-regexmatch-and-its-options
+     */
+    case RegexMatchRegexMatchAndItsOptions = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "result": {
+                    "$regexMatch": {
+                        "input": "$description",
+                        "regex": {
+                            "$regularExpression": {
+                                "pattern": "line",
+                                "options": ""
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * i Option
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/regexMatch/#i-option
+     */
+    case RegexMatchIOption = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "result": {
+                    "$regexMatch": {
+                        "input": "$description",
+                        "regex": {
+                            "$regularExpression": {
+                                "pattern": "line",
+                                "options": "i"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "$addFields": {
+                "result": {
+                    "$regexMatch": {
+                        "input": "$description",
+                        "regex": "line",
+                        "options": "i"
+                    }
+                }
+            }
+        },
+        {
+            "$addFields": {
+                "result": {
+                    "$regexMatch": {
+                        "input": "$description",
+                        "regex": {
+                            "$regularExpression": {
+                                "pattern": "line",
+                                "options": ""
+                            }
+                        },
+                        "options": "i"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use $regexMatch to Check Email Address
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/regexMatch/#use--regexmatch-to-check-email-address
+     */
+    case RegexMatchUseRegexMatchToCheckEmailAddress = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "category": {
+                    "$cond": {
+                        "if": {
+                            "$regexMatch": {
+                                "input": "$comment",
+                                "regex": {
+                                    "$regularExpression": {
+                                        "pattern": "[a-z0-9_.+-]+@mongodb.com",
+                                        "options": "i"
+                                    }
+                                }
+                            }
+                        },
+                        "then": "Employee",
+                        "else": "External"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceAll/#example
+     */
+    case ReplaceAllExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$replaceAll": {
+                        "input": "$item",
+                        "find": "blue paint",
+                        "replacement": "red paint"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceOne/#example
+     */
+    case ReplaceOneExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$replaceOne": {
+                        "input": "$item",
+                        "find": "blue paint",
+                        "replacement": "red paint"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Example
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/reverseArray/#example
@@ -2999,6 +3405,28 @@ enum Pipelines: string
                 },
                 "reverseFavorites": {
                     "$reverseArray": "$favorites"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/rtrim/#example
+     */
+    case RtrimExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "description": {
+                    "$rtrim": {
+                        "input": "$description"
+                    }
                 }
             }
         }
@@ -3592,6 +4020,61 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/split/#example
+     */
+    case SplitExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "city_state": {
+                    "$split": [
+                        "$city",
+                        ", "
+                    ]
+                },
+                "qty": {
+                    "$numberInt": "1"
+                }
+            }
+        },
+        {
+            "$unwind": {
+                "path": "$city_state"
+            }
+        },
+        {
+            "$match": {
+                "city_state": {
+                    "$regularExpression": {
+                        "pattern": "[A-Z]{2}",
+                        "options": ""
+                    }
+                }
+            }
+        },
+        {
+            "$group": {
+                "_id": {
+                    "state": "$city_state"
+                },
+                "total_qty": {
+                    "$sum": "$qty"
+                }
+            }
+        },
+        {
+            "$sort": {
+                "total_qty": {
+                    "$numberInt": "-1"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Use in $project Stage
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/stdDevPop/#use-in--project-stage
@@ -3603,6 +4086,228 @@ enum Pipelines: string
                 "stdDev": {
                     "$stdDevPop": [
                         "$scores.score"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Single-Byte and Multibyte Character Set
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/strLenBytes/#single-byte-and-multibyte-character-set
+     */
+    case StrLenBytesSingleByteAndMultibyteCharacterSet = <<<'JSON'
+    [
+        {
+            "$project": {
+                "name": {
+                    "$numberInt": "1"
+                },
+                "length": {
+                    "$strLenBytes": "$name"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Single-Byte and Multibyte Character Set
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/strLenBytes/#single-byte-and-multibyte-character-set
+     */
+    case StrLenCPSingleByteAndMultibyteCharacterSet = <<<'JSON'
+    [
+        {
+            "$project": {
+                "name": {
+                    "$numberInt": "1"
+                },
+                "length": {
+                    "$strLenCP": "$name"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/strcasecmp/#example
+     */
+    case StrcasecmpExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "comparisonResult": {
+                    "$strcasecmp": [
+                        "$quarter",
+                        "13q4"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/substr/#example
+     */
+    case SubstrExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "yearSubstring": {
+                    "$substr": [
+                        "$quarter",
+                        {
+                            "$numberInt": "0"
+                        },
+                        {
+                            "$numberInt": "2"
+                        }
+                    ]
+                },
+                "quarterSubtring": {
+                    "$substr": [
+                        "$quarter",
+                        {
+                            "$numberInt": "2"
+                        },
+                        {
+                            "$numberInt": "-1"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Single-Byte Character Set
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/substrBytes/#single-byte-character-set
+     */
+    case SubstrBytesSingleByteCharacterSet = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "yearSubstring": {
+                    "$substrBytes": [
+                        "$quarter",
+                        {
+                            "$numberInt": "0"
+                        },
+                        {
+                            "$numberInt": "2"
+                        }
+                    ]
+                },
+                "quarterSubtring": {
+                    "$substrBytes": [
+                        "$quarter",
+                        {
+                            "$numberInt": "2"
+                        },
+                        {
+                            "$subtract": [
+                                {
+                                    "$strLenBytes": "$quarter"
+                                },
+                                {
+                                    "$numberInt": "2"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Single-Byte Character Set
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/substrCP/#single-byte-character-set
+     */
+    case SubstrCPSingleByteCharacterSet = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "yearSubstring": {
+                    "$substrCP": [
+                        "$quarter",
+                        {
+                            "$numberInt": "0"
+                        },
+                        {
+                            "$numberInt": "2"
+                        }
+                    ]
+                },
+                "quarterSubtring": {
+                    "$substrCP": [
+                        "$quarter",
+                        {
+                            "$numberInt": "2"
+                        },
+                        {
+                            "$subtract": [
+                                {
+                                    "$strLenCP": "$quarter"
+                                },
+                                {
+                                    "$numberInt": "2"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Single-Byte and Multibyte Character Set
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/substrCP/#single-byte-and-multibyte-character-set
+     */
+    case SubstrCPSingleByteAndMultibyteCharacterSet = <<<'JSON'
+    [
+        {
+            "$project": {
+                "name": {
+                    "$numberInt": "1"
+                },
+                "menuCode": {
+                    "$substrCP": [
+                        "$name",
+                        {
+                            "$numberInt": "0"
+                        },
+                        {
+                            "$numberInt": "3"
+                        }
                     ]
                 }
             }
@@ -3843,6 +4548,92 @@ enum Pipelines: string
             "$addFields": {
                 "hashedVal": {
                     "$toHashedIndexKey": "$val"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toLower/#example
+     */
+    case ToLowerExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$toLower": "$item"
+                },
+                "description": {
+                    "$toLower": "$description"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toString/#example
+     */
+    case ToStringExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "convertedZipCode": {
+                    "$toString": "$zipcode"
+                }
+            }
+        },
+        {
+            "$sort": {
+                "convertedZipCode": {
+                    "$numberInt": "1"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toUpper/#example
+     */
+    case ToUpperExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$toUpper": "$item"
+                },
+                "description": {
+                    "$toUpper": "$description"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/trim/#example
+     */
+    case TrimExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$numberInt": "1"
+                },
+                "description": {
+                    "$trim": {
+                        "input": "$description"
+                    }
                 }
             }
         }

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -3094,6 +3094,58 @@ enum Pipelines: string
     JSON;
 
     /**
+     * i Option
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/regexFind/#i-option
+     */
+    case RegexFindIOption = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "returnObject": {
+                    "$regexFind": {
+                        "input": "$description",
+                        "regex": {
+                            "$regularExpression": {
+                                "pattern": "line",
+                                "options": "i"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "$addFields": {
+                "returnObject": {
+                    "$regexFind": {
+                        "input": "$description",
+                        "regex": "line",
+                        "options": "i"
+                    }
+                }
+            }
+        },
+        {
+            "$addFields": {
+                "returnObject": {
+                    "$regexFind": {
+                        "input": "$description",
+                        "regex": {
+                            "$regularExpression": {
+                                "pattern": "line",
+                                "options": ""
+                            }
+                        },
+                        "options": "i"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * $regexFindAll and Its Options
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/regexFindAll/#-regexfindall-and-its-options
@@ -4233,6 +4285,34 @@ enum Pipelines: string
                                     "$numberInt": "2"
                                 }
                             ]
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Single-Byte and Multibyte Character Set
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/substrBytes/#single-byte-and-multibyte-character-set
+     */
+    case SubstrBytesSingleByteAndMultibyteCharacterSet = <<<'JSON'
+    [
+        {
+            "$project": {
+                "name": {
+                    "$numberInt": "1"
+                },
+                "menuCode": {
+                    "$substrBytes": [
+                        "$name",
+                        {
+                            "$numberInt": "0"
+                        },
+                        {
+                            "$numberInt": "3"
                         }
                     ]
                 }

--- a/tests/Builder/Expression/RegexFindAllOperatorTest.php
+++ b/tests/Builder/Expression/RegexFindAllOperatorTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\BSON\Regex;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $regexFindAll expression
+ */
+class RegexFindAllOperatorTest extends PipelineTestCase
+{
+    public function testIOption(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                returnObject: Expression::regexFindAll(
+                    input: Expression::stringFieldPath('description'),
+                    regex: new Regex('line', 'i'),
+                ),
+            ),
+            Stage::addFields(
+                returnObject: Expression::regexFindAll(
+                    input: Expression::stringFieldPath('description'),
+                    regex: 'line',
+                    options: 'i',
+                ),
+            ),
+            Stage::addFields(
+                returnObject: Expression::regexFindAll(
+                    input: Expression::stringFieldPath('description'),
+                    regex: new Regex('line'),
+                    options: 'i',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::RegexFindAllIOption, $pipeline);
+    }
+
+    public function testRegexFindAllAndItsOptions(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                returnObject: Expression::regexFindAll(
+                    input: Expression::stringFieldPath('description'),
+                    regex: new Regex('line'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::RegexFindAllRegexFindAllAndItsOptions, $pipeline);
+    }
+
+    public function testUseCapturedGroupingsToParseUserName(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                names: Expression::regexFindAll(
+                    input: Expression::stringFieldPath('comment'),
+                    regex: new Regex('([a-z0-9_.+-]+)@[a-z0-9_.+-]+\\.[a-z0-9_.+-]+', 'i'),
+                ),
+            ),
+            Stage::set(
+                names: Expression::reduce(
+                    input: Expression::arrayFieldPath('names.captures'),
+                    initialValue: [],
+                    in: Expression::concatArrays(
+                        Expression::variable('value'),
+                        Expression::variable('this'),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::RegexFindAllUseCapturedGroupingsToParseUserName, $pipeline);
+    }
+
+    public function testUseRegexFindAllToParseEmailFromString(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                email: Expression::regexFindAll(
+                    input: Expression::stringFieldPath('comment'),
+                    regex: new Regex('[a-z0-9_.+-]+@[a-z0-9_.+-]+\\.[a-z0-9_.+-]+', 'i'),
+                ),
+            ),
+            Stage::set(
+                email: Expression::stringFieldPath('email.match'),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::RegexFindAllUseRegexFindAllToParseEmailFromString, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/RegexFindOperatorTest.php
+++ b/tests/Builder/Expression/RegexFindOperatorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\BSON\Regex;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $regexFind expression
+ */
+class RegexFindOperatorTest extends PipelineTestCase
+{
+    public function testRegexFindAndItsOptions(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                returnObject: Expression::regexFind(
+                    input: Expression::stringFieldPath('description'),
+                    regex: new Regex('line'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::RegexFindRegexFindAndItsOptions, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/RegexFindOperatorTest.php
+++ b/tests/Builder/Expression/RegexFindOperatorTest.php
@@ -15,6 +15,34 @@ use MongoDB\Tests\Builder\PipelineTestCase;
  */
 class RegexFindOperatorTest extends PipelineTestCase
 {
+    public function testIOption(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                returnObject: Expression::regexFind(
+                    input: Expression::stringFieldPath('description'),
+                    regex: new Regex('line', 'i'),
+                ),
+            ),
+            Stage::addFields(
+                returnObject: Expression::regexFind(
+                    input: Expression::stringFieldPath('description'),
+                    regex: 'line',
+                    options: 'i',
+                ),
+            ),
+            Stage::addFields(
+                returnObject: Expression::regexFind(
+                    input: Expression::stringFieldPath('description'),
+                    regex: new Regex('line'),
+                    options: 'i',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::RegexFindIOption, $pipeline);
+    }
+
     public function testRegexFindAndItsOptions(): void
     {
         $pipeline = new Pipeline(

--- a/tests/Builder/Expression/RegexMatchOperatorTest.php
+++ b/tests/Builder/Expression/RegexMatchOperatorTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\BSON\Regex;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $regexMatch expression
+ */
+class RegexMatchOperatorTest extends PipelineTestCase
+{
+    public function testIOption(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                result: Expression::regexMatch(
+                    input: Expression::stringFieldPath('description'),
+                    regex: new Regex('line', 'i'),
+                ),
+            ),
+            Stage::addFields(
+                result: Expression::regexMatch(
+                    input: Expression::stringFieldPath('description'),
+                    regex: 'line',
+                    options: 'i',
+                ),
+            ),
+            Stage::addFields(
+                result: Expression::regexMatch(
+                    input: Expression::stringFieldPath('description'),
+                    regex: new Regex('line'),
+                    options: 'i',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::RegexMatchIOption, $pipeline);
+    }
+
+    public function testRegexMatchAndItsOptions(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                result: Expression::regexMatch(
+                    input: Expression::stringFieldPath('description'),
+                    regex: new Regex('line', ''),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::RegexMatchRegexMatchAndItsOptions, $pipeline);
+    }
+
+    public function testUseRegexMatchToCheckEmailAddress(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                category: Expression::cond(
+                    if: Expression::regexMatch(
+                        input: Expression::stringFieldPath('comment'),
+                        regex: new Regex('[a-z0-9_.+-]+@mongodb.com', 'i'),
+                    ),
+                    then: 'Employee',
+                    else: 'External',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::RegexMatchUseRegexMatchToCheckEmailAddress, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/ReplaceAllOperatorTest.php
+++ b/tests/Builder/Expression/ReplaceAllOperatorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $replaceAll expression
+ */
+class ReplaceAllOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: Expression::replaceAll(
+                    input: Expression::stringFieldPath('item'),
+                    find: 'blue paint',
+                    replacement: 'red paint',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ReplaceAllExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/ReplaceOneOperatorTest.php
+++ b/tests/Builder/Expression/ReplaceOneOperatorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $replaceOne expression
+ */
+class ReplaceOneOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: Expression::replaceOne(
+                    input: Expression::stringFieldPath('item'),
+                    find: 'blue paint',
+                    replacement: 'red paint',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ReplaceOneExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/RtrimOperatorTest.php
+++ b/tests/Builder/Expression/RtrimOperatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $rtrim expression
+ */
+class RtrimOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                description: Expression::rtrim(
+                    Expression::stringFieldPath('description'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::RtrimExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/SplitOperatorTest.php
+++ b/tests/Builder/Expression/SplitOperatorTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\BSON\Regex;
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $split expression
+ */
+class SplitOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                city_state: Expression::split(
+                    Expression::stringFieldPath('city'),
+                    ', ',
+                ),
+                qty: 1,
+            ),
+            Stage::unwind(
+                Expression::arrayFieldPath('city_state'),
+            ),
+            Stage::match(
+                city_state: new Regex('[A-Z]{2}'),
+            ),
+            Stage::group(
+                _id: object(
+                    state: Expression::stringFieldPath('city_state'),
+                ),
+                total_qty: Accumulator::sum(
+                    Expression::intFieldPath('qty'),
+                ),
+            ),
+            Stage::sort(
+                object(
+                    total_qty: -1,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SplitExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/StrLenBytesOperatorTest.php
+++ b/tests/Builder/Expression/StrLenBytesOperatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $strLenBytes expression
+ */
+class StrLenBytesOperatorTest extends PipelineTestCase
+{
+    public function testSingleByteAndMultibyteCharacterSet(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                name: 1,
+                length: Expression::strLenBytes(
+                    Expression::stringFieldPath('name'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::StrLenBytesSingleByteAndMultibyteCharacterSet, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/StrLenCPOperatorTest.php
+++ b/tests/Builder/Expression/StrLenCPOperatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $strLenCP expression
+ */
+class StrLenCPOperatorTest extends PipelineTestCase
+{
+    public function testSingleByteAndMultibyteCharacterSet(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                name: 1,
+                length: Expression::strLenCP(
+                    Expression::stringFieldPath('name'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::StrLenCPSingleByteAndMultibyteCharacterSet, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/StrcasecmpOperatorTest.php
+++ b/tests/Builder/Expression/StrcasecmpOperatorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $strcasecmp expression
+ */
+class StrcasecmpOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                comparisonResult: Expression::strcasecmp(
+                    Expression::stringFieldPath('quarter'),
+                    '13q4',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::StrcasecmpExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/SubstrBytesOperatorTest.php
+++ b/tests/Builder/Expression/SubstrBytesOperatorTest.php
@@ -14,6 +14,22 @@ use MongoDB\Tests\Builder\PipelineTestCase;
  */
 class SubstrBytesOperatorTest extends PipelineTestCase
 {
+    public function testSingleByteAndMultibyteCharacterSet(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                name: 1,
+                menuCode: Expression::substrBytes(
+                    Expression::stringFieldPath('name'),
+                    0,
+                    3,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SubstrBytesSingleByteAndMultibyteCharacterSet, $pipeline);
+    }
+
     public function testSingleByteCharacterSet(): void
     {
         $pipeline = new Pipeline(

--- a/tests/Builder/Expression/SubstrBytesOperatorTest.php
+++ b/tests/Builder/Expression/SubstrBytesOperatorTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $substrBytes expression
+ */
+class SubstrBytesOperatorTest extends PipelineTestCase
+{
+    public function testSingleByteCharacterSet(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                yearSubstring: Expression::substrBytes(
+                    Expression::stringFieldPath('quarter'),
+                    0,
+                    2,
+                ),
+                quarterSubtring: Expression::substrBytes(
+                    Expression::stringFieldPath('quarter'),
+                    2,
+                    Expression::subtract(
+                        Expression::strLenBytes(
+                            Expression::stringFieldPath('quarter'),
+                        ),
+                        2,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SubstrBytesSingleByteCharacterSet, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/SubstrCPOperatorTest.php
+++ b/tests/Builder/Expression/SubstrCPOperatorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $substrCP expression
+ */
+class SubstrCPOperatorTest extends PipelineTestCase
+{
+    public function testSingleByteAndMultibyteCharacterSet(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                name: 1,
+                menuCode: Expression::substrCP(
+                    Expression::stringFieldPath('name'),
+                    0,
+                    3,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SubstrCPSingleByteAndMultibyteCharacterSet, $pipeline);
+    }
+
+    public function testSingleByteCharacterSet(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                yearSubstring: Expression::substrCP(
+                    Expression::stringFieldPath('quarter'),
+                    0,
+                    2,
+                ),
+                quarterSubtring: Expression::substrCP(
+                    Expression::stringFieldPath('quarter'),
+                    2,
+                    Expression::subtract(
+                        Expression::strLenCP(
+                            Expression::stringFieldPath('quarter'),
+                        ),
+                        2,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SubstrCPSingleByteCharacterSet, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/SubstrOperatorTest.php
+++ b/tests/Builder/Expression/SubstrOperatorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $substr expression
+ */
+class SubstrOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                yearSubstring: Expression::substr(
+                    Expression::stringFieldPath('quarter'),
+                    0,
+                    2,
+                ),
+                quarterSubtring: Expression::substr(
+                    Expression::stringFieldPath('quarter'),
+                    2,
+                    -1,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SubstrExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/ToLowerOperatorTest.php
+++ b/tests/Builder/Expression/ToLowerOperatorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $toLower expression
+ */
+class ToLowerOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: Expression::toLower(
+                    Expression::stringFieldPath('item'),
+                ),
+                description: Expression::toLower(
+                    Expression::stringFieldPath('description'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ToLowerExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/ToStringOperatorTest.php
+++ b/tests/Builder/Expression/ToStringOperatorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $toString expression
+ */
+class ToStringOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                convertedZipCode: Expression::toString(
+                    Expression::stringFieldPath('zipcode'),
+                ),
+            ),
+            Stage::sort(
+                object(
+                    convertedZipCode: 1,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ToStringExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/ToUpperOperatorTest.php
+++ b/tests/Builder/Expression/ToUpperOperatorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $toUpper expression
+ */
+class ToUpperOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: Expression::toUpper(
+                    Expression::stringFieldPath('item'),
+                ),
+                description: Expression::toUpper(
+                    Expression::stringFieldPath('description'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ToUpperExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/TrimOperatorTest.php
+++ b/tests/Builder/Expression/TrimOperatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $trim expression
+ */
+class TrimOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: 1,
+                description: Expression::trim(
+                    Expression::stringFieldPath('description'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TrimExample, $pipeline);
+    }
+}


### PR DESCRIPTION
Fix [PHPLIB-1354](https://jira.mongodb.org/browse/PHPLIB-1354)

https://www.mongodb.com/docs/manual/reference/operator/aggregation/#string-expression-operators

- `$concat`
- ~`$dateFromString`~ already done
- ~`$dateToString`~ already done
- `$indexOfBytes`
- `$indexOfCP`
- `$ltrim`
- `$regexFind` Skipped repetitive tests on regex flags, but implemented all the ways to set the regex.
- `$regexFindAll` Skipped repetitive tests on regex flags, but implemented all the ways to set the regex.
- `$regexMatch` Skipped repetitive tests on regex flags, but implemented all the ways to set the regex.
- `$replaceOne` Skipped repetitive tests on regex flags, but implemented all the ways to set the regex.
- `$replaceAll`
- `$rtrim`
- `$split`
- `$strLenBytes`
- `$strLenCP`
- `$strcasecmp`
- `$substr`
- `$substrBytes`
- `$substrCP`
- `$toLower`
- `$toString`
- `$trim`
- `$toUpper`

Skipped repetitive tests on regex flags, but implemented all the ways to set the regex.