### PR TITLE
PHPLIB-1250 Split encoders and fix psalm issues

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -42,7 +42,6 @@
         <exclude name="SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn" />
         <exclude name="SlevomatCodingStandard.Functions.StaticClosure" />
         <exclude name="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure" />
-        <exclude name="SlevomatCodingStandard.Operators.DisallowEqualOperators" />
 
         <!-- ********************* -->
         <!-- Exclude broken sniffs -->

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -29,7 +29,15 @@
       <code>$val</code>
     </MixedAssignment>
   </file>
+  <file src="src/Builder/Encoder/OutputWindowEncoder.php">
+    <MixedArgument>
+      <code>$result</code>
+    </MixedArgument>
+  </file>
   <file src="src/Builder/Encoder/QueryEncoder.php">
+    <MixedArgument>
+      <code><![CDATA[$this->recursiveEncode($value)]]></code>
+    </MixedArgument>
     <MixedAssignment>
       <code>$subValue</code>
       <code>$value</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.20.0@3f284e96c9d9be6fe6b15c79416e1d1903dcfef4">
-  <file src="src/Builder/BuilderEncoder.php">
-    <MixedArgument>
-      <code>$value</code>
-    </MixedArgument>
+  <file src="src/Builder/Encoder/AbstractExpressionEncoder.php">
+    <MixedAssignment>
+      <code>$val</code>
+      <code>$val</code>
+      <code>$value[$key]</code>
+    </MixedAssignment>
   </file>
   <file src="src/Builder/Encoder/CombinedFieldQueryEncoder.php">
     <MixedAssignment>
       <code>$filter</code>
       <code>$filterValue</code>
-      <code>$val</code>
-      <code>$val</code>
-      <code>$value[$key]</code>
     </MixedAssignment>
+  </file>
+  <file src="src/Builder/Encoder/FieldPathEncoder.php">
+    <NoInterfaceProperties>
+      <code><![CDATA[$value->name]]></code>
+    </NoInterfaceProperties>
   </file>
   <file src="src/Builder/Encoder/OperatorEncoder.php">
     <MixedAssignment>
@@ -23,46 +27,103 @@
       <code>$val</code>
       <code>$val</code>
       <code>$val</code>
-      <code>$val</code>
-      <code>$val</code>
-      <code>$value[$key]</code>
     </MixedAssignment>
-  </file>
-  <file src="src/Builder/Encoder/OutputWindowEncoder.php">
-    <MixedAssignment>
-      <code>$val</code>
-      <code>$val</code>
-      <code>$value[$key]</code>
-    </MixedAssignment>
-  </file>
-  <file src="src/Builder/Encoder/PipelineEncoder.php">
-    <MixedAssignment>
-      <code>$encoded[]</code>
-    </MixedAssignment>
+    <UndefinedConstant>
+      <code>$value::ENCODE</code>
+    </UndefinedConstant>
   </file>
   <file src="src/Builder/Encoder/QueryEncoder.php">
-    <MixedArgument>
-      <code>$key</code>
-      <code><![CDATA[$this->recursiveEncode($value)]]></code>
-    </MixedArgument>
     <MixedAssignment>
-      <code>$key</code>
       <code>$subValue</code>
-      <code>$val</code>
-      <code>$val</code>
       <code>$value</code>
-      <code>$value[$key]</code>
     </MixedAssignment>
   </file>
-  <file src="src/Builder/Type/CombinedFieldQuery.php">
-    <MixedAssignment>
-      <code>$fieldQuery</code>
-    </MixedAssignment>
+  <file src="src/Builder/Projection/ElemMatchOperator.php">
+    <MixedArgumentTypeCoercion>
+      <code>$query</code>
+    </MixedArgumentTypeCoercion>
+  </file>
+  <file src="src/Builder/Query.php">
+    <ArgumentTypeCoercion>
+      <code>$query</code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="src/Builder/Query/ElemMatchOperator.php">
+    <MixedArgumentTypeCoercion>
+      <code>$query</code>
+    </MixedArgumentTypeCoercion>
+  </file>
+  <file src="src/Builder/Stage/AddFieldsStage.php">
+    <PropertyTypeCoercion>
+      <code>$expression</code>
+    </PropertyTypeCoercion>
+    <TooManyTemplateParams>
+      <code>stdClass</code>
+    </TooManyTemplateParams>
+  </file>
+  <file src="src/Builder/Stage/FacetStage.php">
+    <PropertyTypeCoercion>
+      <code>$facet</code>
+    </PropertyTypeCoercion>
+    <TooManyTemplateParams>
+      <code>stdClass</code>
+    </TooManyTemplateParams>
+  </file>
+  <file src="src/Builder/Stage/GeoNearStage.php">
+    <MixedArgumentTypeCoercion>
+      <code>$query</code>
+    </MixedArgumentTypeCoercion>
+  </file>
+  <file src="src/Builder/Stage/GraphLookupStage.php">
+    <MixedArgumentTypeCoercion>
+      <code>$restrictSearchWithMatch</code>
+    </MixedArgumentTypeCoercion>
+  </file>
+  <file src="src/Builder/Stage/GroupStage.php">
+    <PropertyTypeCoercion>
+      <code>$field</code>
+    </PropertyTypeCoercion>
+    <TooManyTemplateParams>
+      <code>stdClass</code>
+    </TooManyTemplateParams>
+  </file>
+  <file src="src/Builder/Stage/MatchStage.php">
+    <MixedArgumentTypeCoercion>
+      <code>$query</code>
+    </MixedArgumentTypeCoercion>
+  </file>
+  <file src="src/Builder/Stage/ProjectStage.php">
+    <PropertyTypeCoercion>
+      <code>$specification</code>
+    </PropertyTypeCoercion>
+    <TooManyTemplateParams>
+      <code>stdClass</code>
+    </TooManyTemplateParams>
+  </file>
+  <file src="src/Builder/Stage/SetStage.php">
+    <PropertyTypeCoercion>
+      <code>$field</code>
+    </PropertyTypeCoercion>
+    <TooManyTemplateParams>
+      <code>stdClass</code>
+    </TooManyTemplateParams>
+  </file>
+  <file src="src/Builder/Type/OutputWindow.php">
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_string($documents[1]) && ! is_int($documents[1])]]></code>
+      <code><![CDATA[! is_string($range[1]) && ! is_numeric($range[1])]]></code>
+    </DocblockTypeContradiction>
   </file>
   <file src="src/Builder/Type/QueryObject.php">
     <MixedAssignment>
       <code>$queries[$fieldPath]</code>
       <code>$query</code>
     </MixedAssignment>
+    <RedundantConditionGivenDocblockType>
+      <code><![CDATA[count($queriesOrArrayOfQueries) === 1 &&
+            isset($queriesOrArrayOfQueries[0]) &&
+            is_array($queriesOrArrayOfQueries[0]) &&
+            count($queriesOrArrayOfQueries[0]) > 0]]></code>
+    </RedundantConditionGivenDocblockType>
   </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -28,9 +28,6 @@
       <code>$val</code>
       <code>$val</code>
     </MixedAssignment>
-    <UndefinedConstant>
-      <code>$value::ENCODE</code>
-    </UndefinedConstant>
   </file>
   <file src="src/Builder/Encoder/QueryEncoder.php">
     <MixedAssignment>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,3 +1,68 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
+<files psalm-version="5.20.0@3f284e96c9d9be6fe6b15c79416e1d1903dcfef4">
+  <file src="src/Builder/BuilderEncoder.php">
+    <MixedArgument>
+      <code>$value</code>
+    </MixedArgument>
+  </file>
+  <file src="src/Builder/Encoder/CombinedFieldQueryEncoder.php">
+    <MixedAssignment>
+      <code>$filter</code>
+      <code>$filterValue</code>
+      <code>$val</code>
+      <code>$val</code>
+      <code>$value[$key]</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Builder/Encoder/OperatorEncoder.php">
+    <MixedAssignment>
+      <code>$result</code>
+      <code>$result[]</code>
+      <code>$val</code>
+      <code>$val</code>
+      <code>$val</code>
+      <code>$val</code>
+      <code>$val</code>
+      <code>$val</code>
+      <code>$val</code>
+      <code>$value[$key]</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Builder/Encoder/OutputWindowEncoder.php">
+    <MixedAssignment>
+      <code>$val</code>
+      <code>$val</code>
+      <code>$value[$key]</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Builder/Encoder/PipelineEncoder.php">
+    <MixedAssignment>
+      <code>$encoded[]</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Builder/Encoder/QueryEncoder.php">
+    <MixedArgument>
+      <code>$key</code>
+      <code><![CDATA[$this->recursiveEncode($value)]]></code>
+    </MixedArgument>
+    <MixedAssignment>
+      <code>$key</code>
+      <code>$subValue</code>
+      <code>$val</code>
+      <code>$val</code>
+      <code>$value</code>
+      <code>$value[$key]</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Builder/Type/CombinedFieldQuery.php">
+    <MixedAssignment>
+      <code>$fieldQuery</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Builder/Type/QueryObject.php">
+    <MixedAssignment>
+      <code>$queries[$fieldPath]</code>
+      <code>$query</code>
+    </MixedAssignment>
+  </file>
 </files>

--- a/src/Builder/BuilderEncoder.php
+++ b/src/Builder/BuilderEncoder.php
@@ -60,16 +60,14 @@ class BuilderEncoder implements Encoder
             return false;
         }
 
-        $encoder = $this->getEncoderFor($value);
-
-        return $encoder !== null && $encoder->canEncode($value);
+        return (bool) $this->getEncoderFor($value)?->canEncode($value);
     }
 
     public function encode(mixed $value): stdClass|array|string
     {
         $encoder = $this->getEncoderFor($value);
 
-        if (! $encoder || ! $encoder->canEncode($value)) {
+        if (! $encoder?->canEncode($value)) {
             throw UnsupportedValueException::invalidEncodableValue($value);
         }
 

--- a/src/Builder/BuilderEncoder.php
+++ b/src/Builder/BuilderEncoder.php
@@ -4,57 +4,66 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder;
 
-use LogicException;
+use MongoDB\Builder\Encoder\CombinedFieldQueryEncoder;
+use MongoDB\Builder\Encoder\ExpressionEncoder;
+use MongoDB\Builder\Encoder\FieldPathEncoder;
+use MongoDB\Builder\Encoder\OperatorEncoder;
+use MongoDB\Builder\Encoder\OutputWindowEncoder;
+use MongoDB\Builder\Encoder\PipelineEncoder;
+use MongoDB\Builder\Encoder\QueryEncoder;
+use MongoDB\Builder\Encoder\VariableEncoder;
 use MongoDB\Builder\Expression\Variable;
-use MongoDB\Builder\Stage\GroupStage;
-use MongoDB\Builder\Type\AccumulatorInterface;
 use MongoDB\Builder\Type\CombinedFieldQuery;
-use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
 use MongoDB\Builder\Type\FieldPathInterface;
-use MongoDB\Builder\Type\FieldQueryInterface;
 use MongoDB\Builder\Type\OperatorInterface;
-use MongoDB\Builder\Type\Optional;
 use MongoDB\Builder\Type\OutputWindow;
-use MongoDB\Builder\Type\ProjectionInterface;
 use MongoDB\Builder\Type\QueryInterface;
 use MongoDB\Builder\Type\QueryObject;
 use MongoDB\Builder\Type\StageInterface;
-use MongoDB\Builder\Type\WindowInterface;
 use MongoDB\Codec\EncodeIfSupported;
 use MongoDB\Codec\Encoder;
 use MongoDB\Exception\UnsupportedValueException;
 use stdClass;
 
-use function array_key_exists;
-use function array_key_first;
-use function assert;
-use function get_debug_type;
-use function get_object_vars;
-use function is_array;
 use function is_object;
-use function MongoDB\is_first_key_operator;
-use function property_exists;
-use function sprintf;
 
 /** @template-implements Encoder<Pipeline|StageInterface|ExpressionInterface|QueryInterface, stdClass|array|string> */
 class BuilderEncoder implements Encoder
 {
     use EncodeIfSupported;
 
+    /** @var array<class-string, class-string<ExpressionEncoder>> */
+    private array $defaultEncoders = [
+        Pipeline::class => PipelineEncoder::class,
+        Variable::class => VariableEncoder::class,
+        FieldPathInterface::class => FieldPathEncoder::class,
+        CombinedFieldQuery::class => CombinedFieldQueryEncoder::class,
+        QueryObject::class => QueryEncoder::class,
+        OutputWindow::class => OutputWindowEncoder::class,
+        OperatorInterface::class => OperatorEncoder::class,
+    ];
+
+    /** @var array<class-string, class-string<ExpressionEncoder>> */
+    private array $cachedEncoders = [];
+
+    /** @param array<class-string, class-string<ExpressionEncoder>> $customEncoders */
+    public function __construct(private readonly array $customEncoders = [])
+    {
+    }
+
     /**
      * {@inheritdoc}
      */
     public function canEncode($value): bool
     {
-        return $value instanceof Pipeline
-            || $value instanceof OperatorInterface
-            || $value instanceof ExpressionInterface
-            || $value instanceof QueryInterface
-            || $value instanceof FieldQueryInterface
-            || $value instanceof AccumulatorInterface
-            || $value instanceof ProjectionInterface
-            || $value instanceof WindowInterface;
+        if (! is_object($value)) {
+            return false;
+        }
+
+        $encoder = $this->getEncoderFor($value);
+
+        return $encoder !== null && $encoder->canEncode($value);
     }
 
     /**
@@ -62,265 +71,38 @@ class BuilderEncoder implements Encoder
      */
     public function encode($value): stdClass|array|string
     {
-        if (! $this->canEncode($value)) {
+        $encoder = $this->getEncoderFor($value);
+
+        if (! $encoder || ! $encoder->canEncode($value)) {
             throw UnsupportedValueException::invalidEncodableValue($value);
         }
 
-        // A pipeline is encoded as a list of stages
-        if ($value instanceof Pipeline) {
-            $encoded = [];
-            foreach ($value->getIterator() as $stage) {
-                $encoded[] = $this->encodeIfSupported($stage);
-            }
-
-            return $encoded;
-        }
-
-        // This specific encoding code if temporary until we have a generic way to encode stages and operators
-        if ($value instanceof FieldPathInterface) {
-            return '$' . $value->name;
-        }
-
-        if ($value instanceof Variable) {
-            return '$$' . $value->name;
-        }
-
-        if ($value instanceof QueryObject) {
-            return $this->encodeQueryObject($value);
-        }
-
-        if ($value instanceof CombinedFieldQuery) {
-            return $this->encodeCombinedFilter($value);
-        }
-
-        if ($value instanceof OutputWindow) {
-            return $this->encodeOutputWindow($value);
-        }
-
-        if (! $value instanceof OperatorInterface) {
-            throw new LogicException(sprintf('Class "%s" does not implement OperatorInterface.', $value::class));
-        }
-
-        // The generic but incomplete encoding code
-        switch ($value::ENCODE) {
-            case Encode::Single:
-                return $this->encodeAsSingle($value);
-
-            case Encode::Array:
-                return $this->encodeAsArray($value);
-
-            case Encode::Object:
-                return $this->encodeAsObject($value);
-
-            case Encode::DollarObject:
-                return $this->encodeAsDollarObject($value);
-
-            case Encode::Group:
-                assert($value instanceof GroupStage);
-
-                return $this->encodeAsGroup($value);
-        }
-
-        throw new LogicException(sprintf('Class "%s" does not have a valid ENCODE constant.', $value::class));
+        return $encoder->encode($value);
     }
 
-    /**
-     * Encode the value as an array of properties, in the order they are defined in the class.
-     */
-    private function encodeAsArray(OperatorInterface $value): stdClass
+    private function getEncoderFor(object $value): ExpressionEncoder|null
     {
-        $result = [];
-        /** @var mixed $val */
-        foreach (get_object_vars($value) as $val) {
-            // Skip optional arguments.
-            // $slice operator has the optional <position> argument in the middle of the array
-            if ($val === Optional::Undefined) {
-                continue;
-            }
-
-            $result[] = $this->recursiveEncode($val);
+        $valueClass = $value::class;
+        if (isset($this->cachedEncoders[$valueClass])) {
+            return $this->cachedEncoders[$valueClass];
         }
 
-        return $this->wrap($value, $result);
-    }
+        $encoderList = $this->customEncoders + $this->defaultEncoders;
 
-    /**
-     * $group stage have a specific encoding because the _id argument is required and others are variadic
-     */
-    private function encodeAsGroup(GroupStage $value): stdClass
-    {
-        $result = new stdClass();
-        $result->_id = $this->recursiveEncode($value->_id);
-
-        foreach (get_object_vars($value->field) as $key => $val) {
-            $result->{$key} = $this->recursiveEncode($val);
-        }
-
-        return $this->wrap($value, $result);
-    }
-
-    private function encodeAsObject(OperatorInterface $value): stdClass
-    {
-        $result = new stdClass();
-        foreach (get_object_vars($value) as $key => $val) {
-            // Skip optional arguments. If they have a default value, it is resolved by the server.
-            if ($val === Optional::Undefined) {
-                continue;
-            }
-
-            $result->{$key} = $this->recursiveEncode($val);
-        }
-
-        return $this->wrap($value, $result);
-    }
-
-    private function encodeAsDollarObject(OperatorInterface $value): stdClass
-    {
-        $result = new stdClass();
-        foreach (get_object_vars($value) as $key => $val) {
-            // Skip optional arguments. If they have a default value, it is resolved by the server.
-            if ($val === Optional::Undefined) {
-                continue;
-            }
-
-            $val = $this->recursiveEncode($val);
-
-            if ($key === 'geometry') {
-                if (is_object($val) && property_exists($val, '$geometry')) {
-                    $result->{'$geometry'} = $val->{'$geometry'};
-                } elseif (is_array($val) && array_key_exists('$geometry', $val)) {
-                    $result->{'$geometry'} = $val->{'$geometry'};
-                } else {
-                    $result->{'$geometry'} = $val;
-                }
-            } else {
-                $result->{'$' . $key} = $val;
+        // First attempt: match class name exactly
+        foreach ($encoderList as $className => $encoderClass) {
+            if ($className == $valueClass) {
+                return $this->cachedEncoders[$valueClass] = $encoderClass::createForEncoder($this);
             }
         }
 
-        return $this->wrap($value, $result);
-    }
-
-    /**
-     * Get the unique property of the operator as value
-     */
-    private function encodeAsSingle(OperatorInterface $value): stdClass
-    {
-        foreach (get_object_vars($value) as $val) {
-            $result = $this->recursiveEncode($val);
-
-            return $this->wrap($value, $result);
-        }
-
-        throw new LogicException(sprintf('Class "%s" does not have a single property.', $value::class));
-    }
-
-    private function encodeCombinedFilter(CombinedFieldQuery $filter): stdClass
-    {
-        $result = new stdClass();
-        foreach ($filter->fieldQueries as $filter) {
-            $filter = $this->recursiveEncode($filter);
-            if (is_object($filter)) {
-                $filter = get_object_vars($filter);
-            } elseif (! is_array($filter)) {
-                throw new LogicException(sprintf('Query filters must an array or an object. Got "%s"', get_debug_type($filter)));
-            }
-
-            foreach ($filter as $key => $value) {
-                $result->{$key} = $value;
+        // Second attempt: catch child classes
+        foreach ($encoderList as $className => $encoderClass) {
+            if ($value instanceof $className) {
+                return $this->cachedEncoders[$valueClass] = $encoderClass::createForEncoder($this);
             }
         }
 
-        return $result;
-    }
-
-    /**
-     * Query objects are encoded by merging query operator with field path to filter operators in the same object.
-     */
-    private function encodeQueryObject(QueryObject $query): stdClass
-    {
-        $result = new stdClass();
-        foreach ($query->queries as $key => $value) {
-            if ($value instanceof QueryInterface) {
-                // The sub-objects is merged into the main object, replacing duplicate keys
-                foreach (get_object_vars($this->recursiveEncode($value)) as $subKey => $subValue) {
-                    if (property_exists($result, (string) $subKey)) {
-                        throw new LogicException(sprintf('Duplicate key "%s" in query object', $subKey));
-                    }
-
-                    $result->{$subKey} = $subValue;
-                }
-            } else {
-                if (property_exists($result, (string) $key)) {
-                    throw new LogicException(sprintf('Duplicate key "%s" in query object', $key));
-                }
-
-                $result->{$key} = $this->encodeIfSupported($value);
-            }
-        }
-
-        return $result;
-    }
-
-    /**
-     * For the $setWindowFields stage output parameter, the optional window parameter is encoded in the same object
-     * of the window operator.
-     *
-     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setWindowFields/
-     */
-    private function encodeOutputWindow(OutputWindow $outputWindow): stdClass
-    {
-        $result = $this->recursiveEncode($outputWindow->operator);
-
-        // Transform the result into an stdClass if a document is provided
-        if (! $outputWindow->operator instanceof WindowInterface && (is_array($result) || is_object($result))) {
-            if (! is_first_key_operator($result)) {
-                throw new LogicException(sprintf('Expected OutputWindow::$operator to be an operator. Got "%s"', array_key_first((array) $result)));
-            }
-
-            $result = (object) $result;
-        }
-
-        if (! $result instanceof stdClass) {
-            throw new LogicException(sprintf('Expected OutputWindow::$operator to be an stdClass, array or WindowInterface. Got "%s"', get_debug_type($result)));
-        }
-
-        if ($outputWindow->window !== Optional::Undefined) {
-            $result->window = $this->recursiveEncode($outputWindow->window);
-        }
-
-        return $result;
-    }
-
-    /**
-     * Nested arrays and objects must be encoded recursively.
-     */
-    private function recursiveEncode(mixed $value): mixed
-    {
-        if (is_array($value)) {
-            foreach ($value as $key => $val) {
-                $value[$key] = $this->recursiveEncode($val);
-            }
-
-            return $value;
-        }
-
-        if ($value instanceof stdClass) {
-            foreach (get_object_vars($value) as $key => $val) {
-                $value->{$key} = $this->recursiveEncode($val);
-            }
-
-            return $value;
-        }
-
-        return $this->encodeIfSupported($value);
-    }
-
-    private function wrap(OperatorInterface $value, mixed $result): stdClass
-    {
-        $object = new stdClass();
-        $object->{$value->getOperator()} = $result;
-
-        return $object;
+        return null;
     }
 }

--- a/src/Builder/BuilderEncoder.php
+++ b/src/Builder/BuilderEncoder.php
@@ -85,7 +85,7 @@ class BuilderEncoder implements Encoder
 
         // First attempt: match class name exactly
         foreach ($encoderList as $className => $encoderClass) {
-            if ($className == $valueClass) {
+            if ($className === $valueClass) {
                 return $this->cachedEncoders[$valueClass] = new $encoderClass($this);
             }
         }

--- a/src/Builder/BuilderEncoder.php
+++ b/src/Builder/BuilderEncoder.php
@@ -28,9 +28,10 @@ use stdClass;
 
 use function is_object;
 
-/** @template-implements Encoder<Pipeline|StageInterface|ExpressionInterface|QueryInterface, stdClass|array|string> */
+/** @template-implements Encoder<stdClass|array|string, Pipeline|StageInterface|ExpressionInterface|QueryInterface> */
 class BuilderEncoder implements Encoder
 {
+    /** @template-use EncodeIfSupported<stdClass|array|string, Pipeline|StageInterface|ExpressionInterface|QueryInterface> */
     use EncodeIfSupported;
 
     /** @var array<class-string, class-string<ExpressionEncoder>> */
@@ -52,10 +53,8 @@ class BuilderEncoder implements Encoder
     {
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function canEncode($value): bool
+    /** @psalm-assert-if-true object $value */
+    public function canEncode(mixed $value): bool
     {
         if (! is_object($value)) {
             return false;
@@ -66,10 +65,7 @@ class BuilderEncoder implements Encoder
         return $encoder !== null && $encoder->canEncode($value);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function encode($value): stdClass|array|string
+    public function encode(mixed $value): stdClass|array|string
     {
         $encoder = $this->getEncoderFor($value);
 

--- a/src/Builder/BuilderEncoder.php
+++ b/src/Builder/BuilderEncoder.php
@@ -44,7 +44,7 @@ class BuilderEncoder implements Encoder
         OperatorInterface::class => OperatorEncoder::class,
     ];
 
-    /** @var array<class-string, class-string<ExpressionEncoder>> */
+    /** @var array<class-string, ExpressionEncoder> */
     private array $cachedEncoders = [];
 
     /** @param array<class-string, class-string<ExpressionEncoder>> $customEncoders */
@@ -92,14 +92,14 @@ class BuilderEncoder implements Encoder
         // First attempt: match class name exactly
         foreach ($encoderList as $className => $encoderClass) {
             if ($className == $valueClass) {
-                return $this->cachedEncoders[$valueClass] = $encoderClass::createForEncoder($this);
+                return $this->cachedEncoders[$valueClass] = new $encoderClass($this);
             }
         }
 
         // Second attempt: catch child classes
         foreach ($encoderList as $className => $encoderClass) {
             if ($value instanceof $className) {
-                return $this->cachedEncoders[$valueClass] = $encoderClass::createForEncoder($this);
+                return $this->cachedEncoders[$valueClass] = new $encoderClass($this);
             }
         }
 

--- a/src/Builder/Encoder/AbstractExpressionEncoder.php
+++ b/src/Builder/Encoder/AbstractExpressionEncoder.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Encoder;
+
+use MongoDB\Builder\BuilderEncoder;
+use stdClass;
+
+use function get_object_vars;
+use function is_array;
+
+/**
+ * @template BSONType of stdClass|array|string
+ * @template NativeType
+ * @template-implements ExpressionEncoder<BSONType, NativeType>
+ */
+abstract class AbstractExpressionEncoder implements ExpressionEncoder
+{
+    final public function __construct(protected readonly BuilderEncoder $encoder)
+    {
+    }
+
+    /**
+     * Nested arrays and objects must be encoded recursively.
+     *
+     * @psalm-param T $value
+     *
+     * @psalm-return (T is object ? object : (T is array ? array : mixed))
+     *
+     * @template T
+     */
+    final protected function recursiveEncode(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            foreach ($value as $key => $val) {
+                $value[$key] = $this->recursiveEncode($val);
+            }
+
+            return $value;
+        }
+
+        if ($value instanceof stdClass) {
+            foreach (get_object_vars($value) as $key => $val) {
+                $value->{$key} = $this->recursiveEncode($val);
+            }
+
+            return $value;
+        }
+
+        return $this->encoder->encodeIfSupported($value);
+    }
+}

--- a/src/Builder/Encoder/AbstractExpressionEncoder.php
+++ b/src/Builder/Encoder/AbstractExpressionEncoder.php
@@ -26,7 +26,7 @@ abstract class AbstractExpressionEncoder implements ExpressionEncoder
      *
      * @psalm-param T $value
      *
-     * @psalm-return (T is object ? object : (T is array ? array : mixed))
+     * @psalm-return (T is stdClass ? stdClass : (T is array ? array : mixed))
      *
      * @template T
      */

--- a/src/Builder/Encoder/CombinedFieldQueryEncoder.php
+++ b/src/Builder/Encoder/CombinedFieldQueryEncoder.php
@@ -27,11 +27,6 @@ class CombinedFieldQueryEncoder implements ExpressionEncoder
     {
     }
 
-    public static function createForEncoder(BuilderEncoder $encoder): static
-    {
-        return new self($encoder);
-    }
-
     /** @psalm-assert-if-true CombinedFieldQuery $value */
     public function canEncode(mixed $value): bool
     {

--- a/src/Builder/Encoder/CombinedFieldQueryEncoder.php
+++ b/src/Builder/Encoder/CombinedFieldQueryEncoder.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace MongoDB\Builder\Encoder;
 
 use LogicException;
-use MongoDB\Builder\BuilderEncoder;
 use MongoDB\Builder\Type\CombinedFieldQuery;
 use MongoDB\Codec\EncodeIfSupported;
 use MongoDB\Exception\UnsupportedValueException;
@@ -17,26 +16,18 @@ use function is_array;
 use function is_object;
 use function sprintf;
 
-/** @template-implements ExpressionEncoder<CombinedFieldQuery, stdClass> */
-class CombinedFieldQueryEncoder implements ExpressionEncoder
+/** @template-extends AbstractExpressionEncoder<stdClass, CombinedFieldQuery> */
+class CombinedFieldQueryEncoder extends AbstractExpressionEncoder
 {
-    /** @template-use EncodeIfSupported<CombinedFieldQuery, string> */
+    /** @template-use EncodeIfSupported<stdClass, CombinedFieldQuery> */
     use EncodeIfSupported;
 
-    public function __construct(private readonly BuilderEncoder $encoder)
-    {
-    }
-
-    /** @psalm-assert-if-true CombinedFieldQuery $value */
     public function canEncode(mixed $value): bool
     {
         return $value instanceof CombinedFieldQuery;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function encode($value): stdClass
+    public function encode(mixed $value): stdClass
     {
         if (! $this->canEncode($value)) {
             throw UnsupportedValueException::invalidEncodableValue($value);
@@ -57,29 +48,5 @@ class CombinedFieldQueryEncoder implements ExpressionEncoder
         }
 
         return $result;
-    }
-
-    /**
-     * Nested arrays and objects must be encoded recursively.
-     */
-    private function recursiveEncode(mixed $value): mixed
-    {
-        if (is_array($value)) {
-            foreach ($value as $key => $val) {
-                $value[$key] = $this->recursiveEncode($val);
-            }
-
-            return $value;
-        }
-
-        if ($value instanceof stdClass) {
-            foreach (get_object_vars($value) as $key => $val) {
-                $value->{$key} = $this->recursiveEncode($val);
-            }
-
-            return $value;
-        }
-
-        return $this->encoder->encodeIfSupported($value);
     }
 }

--- a/src/Builder/Encoder/CombinedFieldQueryEncoder.php
+++ b/src/Builder/Encoder/CombinedFieldQueryEncoder.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Encoder;
+
+use LogicException;
+use MongoDB\Builder\BuilderEncoder;
+use MongoDB\Builder\Type\CombinedFieldQuery;
+use MongoDB\Codec\EncodeIfSupported;
+use MongoDB\Exception\UnsupportedValueException;
+use stdClass;
+
+use function get_debug_type;
+use function get_object_vars;
+use function is_array;
+use function is_object;
+use function sprintf;
+
+/** @template-implements ExpressionEncoder<CombinedFieldQuery, stdClass> */
+class CombinedFieldQueryEncoder implements ExpressionEncoder
+{
+    /** @template-use EncodeIfSupported<CombinedFieldQuery, string> */
+    use EncodeIfSupported;
+
+    public function __construct(private readonly BuilderEncoder $encoder)
+    {
+    }
+
+    public static function createForEncoder(BuilderEncoder $encoder): static
+    {
+        return new self($encoder);
+    }
+
+    /** @psalm-assert-if-true CombinedFieldQuery $value */
+    public function canEncode(mixed $value): bool
+    {
+        return $value instanceof CombinedFieldQuery;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function encode($value): stdClass
+    {
+        if (! $this->canEncode($value)) {
+            throw UnsupportedValueException::invalidEncodableValue($value);
+        }
+
+        $result = new stdClass();
+        foreach ($value->fieldQueries as $filter) {
+            $filter = $this->recursiveEncode($filter);
+            if (is_object($filter)) {
+                $filter = get_object_vars($filter);
+            } elseif (! is_array($filter)) {
+                throw new LogicException(sprintf('Query filters must an array or an object. Got "%s"', get_debug_type($filter)));
+            }
+
+            foreach ($filter as $key => $filterValue) {
+                $result->{$key} = $filterValue;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Nested arrays and objects must be encoded recursively.
+     */
+    private function recursiveEncode(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            foreach ($value as $key => $val) {
+                $value[$key] = $this->recursiveEncode($val);
+            }
+
+            return $value;
+        }
+
+        if ($value instanceof stdClass) {
+            foreach (get_object_vars($value) as $key => $val) {
+                $value->{$key} = $this->recursiveEncode($val);
+            }
+
+            return $value;
+        }
+
+        return $this->encoder->encodeIfSupported($value);
+    }
+}

--- a/src/Builder/Encoder/ExpressionEncoder.php
+++ b/src/Builder/Encoder/ExpressionEncoder.php
@@ -9,5 +9,5 @@ use MongoDB\Codec\Encoder;
 
 interface ExpressionEncoder extends Encoder
 {
-    public static function createForEncoder(BuilderEncoder $encoder): static;
+    public function __construct(BuilderEncoder $encoder);
 }

--- a/src/Builder/Encoder/ExpressionEncoder.php
+++ b/src/Builder/Encoder/ExpressionEncoder.php
@@ -6,10 +6,11 @@ namespace MongoDB\Builder\Encoder;
 
 use MongoDB\Builder\BuilderEncoder;
 use MongoDB\Codec\Encoder;
+use stdClass;
 
 /**
- * @psalm-template BSONType
- * @psalm-template NativeType
+ * @template BSONType of stdClass|array|string
+ * @template NativeType
  * @template-extends Encoder<BSONType, NativeType>
  */
 interface ExpressionEncoder extends Encoder

--- a/src/Builder/Encoder/ExpressionEncoder.php
+++ b/src/Builder/Encoder/ExpressionEncoder.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Encoder;
+
+use MongoDB\Builder\BuilderEncoder;
+use MongoDB\Codec\Encoder;
+
+interface ExpressionEncoder extends Encoder
+{
+    public static function createForEncoder(BuilderEncoder $encoder): static;
+}

--- a/src/Builder/Encoder/ExpressionEncoder.php
+++ b/src/Builder/Encoder/ExpressionEncoder.php
@@ -7,6 +7,11 @@ namespace MongoDB\Builder\Encoder;
 use MongoDB\Builder\BuilderEncoder;
 use MongoDB\Codec\Encoder;
 
+/**
+ * @psalm-template BSONType
+ * @psalm-template NativeType
+ * @template-extends Encoder<BSONType, NativeType>
+ */
 interface ExpressionEncoder extends Encoder
 {
     public function __construct(BuilderEncoder $encoder);

--- a/src/Builder/Encoder/FieldPathEncoder.php
+++ b/src/Builder/Encoder/FieldPathEncoder.php
@@ -9,7 +9,7 @@ use MongoDB\Builder\Type\FieldPathInterface;
 use MongoDB\Codec\EncodeIfSupported;
 use MongoDB\Exception\UnsupportedValueException;
 
-/** @template-implements Encoder<FieldPathInterface, string> */
+/** @template-implements ExpressionEncoder<FieldPathInterface, string> */
 class FieldPathEncoder implements ExpressionEncoder
 {
     /** @template-use EncodeIfSupported<FieldPathInterface, string> */
@@ -17,11 +17,6 @@ class FieldPathEncoder implements ExpressionEncoder
 
     public function __construct(private readonly BuilderEncoder $encoder)
     {
-    }
-
-    public static function createForEncoder(BuilderEncoder $encoder): static
-    {
-        return new self($encoder);
     }
 
     /** @psalm-assert-if-true FieldPathInterface $value */

--- a/src/Builder/Encoder/FieldPathEncoder.php
+++ b/src/Builder/Encoder/FieldPathEncoder.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Encoder;
+
+use MongoDB\Builder\BuilderEncoder;
+use MongoDB\Builder\Type\FieldPathInterface;
+use MongoDB\Codec\EncodeIfSupported;
+use MongoDB\Exception\UnsupportedValueException;
+
+/** @template-implements Encoder<FieldPathInterface, string> */
+class FieldPathEncoder implements ExpressionEncoder
+{
+    /** @template-use EncodeIfSupported<FieldPathInterface, string> */
+    use EncodeIfSupported;
+
+    public function __construct(private readonly BuilderEncoder $encoder)
+    {
+    }
+
+    public static function createForEncoder(BuilderEncoder $encoder): static
+    {
+        return new self($encoder);
+    }
+
+    /** @psalm-assert-if-true FieldPathInterface $value */
+    public function canEncode(mixed $value): bool
+    {
+        return $value instanceof FieldPathInterface;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function encode($value): string
+    {
+        if (! $this->canEncode($value)) {
+            throw UnsupportedValueException::invalidEncodableValue($value);
+        }
+
+        // TODO: needs method because of interface
+        return '$' . $value->name;
+    }
+}

--- a/src/Builder/Encoder/FieldPathEncoder.php
+++ b/src/Builder/Encoder/FieldPathEncoder.php
@@ -4,31 +4,22 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Encoder;
 
-use MongoDB\Builder\BuilderEncoder;
 use MongoDB\Builder\Type\FieldPathInterface;
 use MongoDB\Codec\EncodeIfSupported;
 use MongoDB\Exception\UnsupportedValueException;
 
-/** @template-implements ExpressionEncoder<FieldPathInterface, string> */
-class FieldPathEncoder implements ExpressionEncoder
+/** @template-extends AbstractExpressionEncoder<string, FieldPathInterface> */
+class FieldPathEncoder extends AbstractExpressionEncoder
 {
-    /** @template-use EncodeIfSupported<FieldPathInterface, string> */
+    /** @template-use EncodeIfSupported<string, FieldPathInterface> */
     use EncodeIfSupported;
 
-    public function __construct(private readonly BuilderEncoder $encoder)
-    {
-    }
-
-    /** @psalm-assert-if-true FieldPathInterface $value */
     public function canEncode(mixed $value): bool
     {
         return $value instanceof FieldPathInterface;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function encode($value): string
+    public function encode(mixed $value): string
     {
         if (! $this->canEncode($value)) {
             throw UnsupportedValueException::invalidEncodableValue($value);

--- a/src/Builder/Encoder/FieldPathEncoder.php
+++ b/src/Builder/Encoder/FieldPathEncoder.php
@@ -25,7 +25,7 @@ class FieldPathEncoder extends AbstractExpressionEncoder
             throw UnsupportedValueException::invalidEncodableValue($value);
         }
 
-        // TODO: needs method because of interface
+        // TODO: needs method because interfaces can't have properties
         return '$' . $value->name;
     }
 }

--- a/src/Builder/Encoder/OperatorEncoder.php
+++ b/src/Builder/Encoder/OperatorEncoder.php
@@ -32,11 +32,6 @@ class OperatorEncoder implements ExpressionEncoder
     {
     }
 
-    public static function createForEncoder(BuilderEncoder $encoder): static
-    {
-        return new self($encoder);
-    }
-
     /** @psalm-assert-if-true OperatorInterface $value */
     public function canEncode(mixed $value): bool
     {

--- a/src/Builder/Encoder/OperatorEncoder.php
+++ b/src/Builder/Encoder/OperatorEncoder.php
@@ -68,8 +68,8 @@ class OperatorEncoder extends AbstractExpressionEncoder
         $result = [];
         /** @var mixed $val */
         foreach (get_object_vars($value) as $val) {
-            // Skip optional arguments.
-            // $slice operator has the optional <position> argument in the middle of the array
+            // Skip optional arguments. For example, the $slice expression operator has an optional <position> argument
+            // in the middle of the array.
             if ($val === Optional::Undefined) {
                 continue;
             }

--- a/src/Builder/Encoder/OperatorEncoder.php
+++ b/src/Builder/Encoder/OperatorEncoder.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Encoder;
+
+use LogicException;
+use MongoDB\Builder\BuilderEncoder;
+use MongoDB\Builder\Stage\GroupStage;
+use MongoDB\Builder\Type\Encode;
+use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\Optional;
+use MongoDB\Codec\EncodeIfSupported;
+use MongoDB\Exception\UnsupportedValueException;
+use stdClass;
+
+use function array_key_exists;
+use function assert;
+use function get_object_vars;
+use function is_array;
+use function is_object;
+use function property_exists;
+use function sprintf;
+
+/** @template-implements ExpressionEncoder<OperatorInterface, object> */
+class OperatorEncoder implements ExpressionEncoder
+{
+    /** @template-use EncodeIfSupported<OperatorInterface, object> */
+    use EncodeIfSupported;
+
+    public function __construct(protected readonly BuilderEncoder $encoder)
+    {
+    }
+
+    public static function createForEncoder(BuilderEncoder $encoder): static
+    {
+        return new self($encoder);
+    }
+
+    /** @psalm-assert-if-true OperatorInterface $value */
+    public function canEncode(mixed $value): bool
+    {
+        return $value instanceof OperatorInterface;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function encode($value): stdClass|array|string
+    {
+        if (! $this->canEncode($value)) {
+            throw UnsupportedValueException::invalidEncodableValue($value);
+        }
+
+        switch ($value::ENCODE) {
+            case Encode::Single:
+                return $this->encodeAsSingle($value);
+
+            case Encode::Array:
+                return $this->encodeAsArray($value);
+
+            case Encode::Object:
+                return $this->encodeAsObject($value);
+
+            case Encode::DollarObject:
+                return $this->encodeAsDollarObject($value);
+
+            case Encode::Group:
+                assert($value instanceof GroupStage);
+
+                return $this->encodeAsGroup($value);
+        }
+
+        throw new LogicException(sprintf('Class "%s" does not have a valid ENCODE constant.', $value::class));
+    }
+
+    /**
+     * Encode the value as an array of properties, in the order they are defined in the class.
+     */
+    private function encodeAsArray(OperatorInterface $value): stdClass
+    {
+        $result = [];
+        /** @var mixed $val */
+        foreach (get_object_vars($value) as $val) {
+            // Skip optional arguments.
+            // $slice operator has the optional <position> argument in the middle of the array
+            if ($val === Optional::Undefined) {
+                continue;
+            }
+
+            $result[] = $this->recursiveEncode($val);
+        }
+
+        return $this->wrap($value, $result);
+    }
+
+    /**
+     * $group stage have a specific encoding because the _id argument is required and others are variadic
+     */
+    private function encodeAsGroup(GroupStage $value): stdClass
+    {
+        $result = new stdClass();
+        $result->_id = $this->recursiveEncode($value->_id);
+
+        foreach (get_object_vars($value->field) as $key => $val) {
+            $result->{$key} = $this->recursiveEncode($val);
+        }
+
+        return $this->wrap($value, $result);
+    }
+
+    private function encodeAsObject(OperatorInterface $value): stdClass
+    {
+        $result = new stdClass();
+        foreach (get_object_vars($value) as $key => $val) {
+            // Skip optional arguments. If they have a default value, it is resolved by the server.
+            if ($val === Optional::Undefined) {
+                continue;
+            }
+
+            $result->{$key} = $this->recursiveEncode($val);
+        }
+
+        return $this->wrap($value, $result);
+    }
+
+    private function encodeAsDollarObject(OperatorInterface $value): stdClass
+    {
+        $result = new stdClass();
+        foreach (get_object_vars($value) as $key => $val) {
+            // Skip optional arguments. If they have a default value, it is resolved by the server.
+            if ($val === Optional::Undefined) {
+                continue;
+            }
+
+            $val = $this->recursiveEncode($val);
+
+            if ($key === 'geometry') {
+                if (is_object($val) && property_exists($val, '$geometry')) {
+                    $result->{'$geometry'} = $val->{'$geometry'};
+                } elseif (is_array($val) && array_key_exists('$geometry', $val)) {
+                    $result->{'$geometry'} = $val->{'$geometry'};
+                } else {
+                    $result->{'$geometry'} = $val;
+                }
+            } else {
+                $result->{'$' . $key} = $val;
+            }
+        }
+
+        return $this->wrap($value, $result);
+    }
+
+    /**
+     * Get the unique property of the operator as value
+     */
+    private function encodeAsSingle(OperatorInterface $value): stdClass
+    {
+        foreach (get_object_vars($value) as $val) {
+            $result = $this->recursiveEncode($val);
+
+            return $this->wrap($value, $result);
+        }
+
+        throw new LogicException(sprintf('Class "%s" does not have a single property.', $value::class));
+    }
+
+    /**
+     * Nested arrays and objects must be encoded recursively.
+     */
+    private function recursiveEncode(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            foreach ($value as $key => $val) {
+                $value[$key] = $this->recursiveEncode($val);
+            }
+
+            return $value;
+        }
+
+        if ($value instanceof stdClass) {
+            foreach (get_object_vars($value) as $key => $val) {
+                $value->{$key} = $this->recursiveEncode($val);
+            }
+
+            return $value;
+        }
+
+        return $this->encoder->encodeIfSupported($value);
+    }
+
+    private function wrap(OperatorInterface $value, mixed $result): stdClass
+    {
+        $object = new stdClass();
+        $object->{$value->getOperator()} = $result;
+
+        return $object;
+    }
+}

--- a/src/Builder/Encoder/OutputWindowEncoder.php
+++ b/src/Builder/Encoder/OutputWindowEncoder.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Encoder;
+
+use LogicException;
+use MongoDB\Builder\BuilderEncoder;
+use MongoDB\Builder\Type\Optional;
+use MongoDB\Builder\Type\OutputWindow;
+use MongoDB\Builder\Type\WindowInterface;
+use MongoDB\Codec\EncodeIfSupported;
+use MongoDB\Exception\UnsupportedValueException;
+use stdClass;
+
+use function array_key_first;
+use function get_debug_type;
+use function get_object_vars;
+use function is_array;
+use function is_object;
+use function MongoDB\is_first_key_operator;
+use function sprintf;
+
+/** @template-implements ExpressionEncoder<OutputWindow, stdClass> */
+class OutputWindowEncoder implements ExpressionEncoder
+{
+    /** @template-use EncodeIfSupported<OutputWindow, stdClass> */
+    use EncodeIfSupported;
+
+    public function __construct(protected readonly BuilderEncoder $encoder)
+    {
+    }
+
+    public static function createForEncoder(BuilderEncoder $encoder): static
+    {
+        return new self($encoder);
+    }
+
+    /** @psalm-assert-if-true OutputWindow $value */
+    public function canEncode(mixed $value): bool
+    {
+        return $value instanceof OutputWindow;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function encode($value): stdClass
+    {
+        if (! $this->canEncode($value)) {
+            throw UnsupportedValueException::invalidEncodableValue($value);
+        }
+
+        $result = $this->recursiveEncode($value->operator);
+
+        // Transform the result into an stdClass if a document is provided
+        if (! $value->operator instanceof WindowInterface && (is_array($result) || is_object($result))) {
+            if (! is_first_key_operator($result)) {
+                throw new LogicException(sprintf('Expected OutputWindow::$operator to be an operator. Got "%s"', array_key_first((array) $result)));
+            }
+
+            $result = (object) $result;
+        }
+
+        if (! $result instanceof stdClass) {
+            throw new LogicException(sprintf('Expected OutputWindow::$operator to be an stdClass, array or WindowInterface. Got "%s"', get_debug_type($result)));
+        }
+
+        if ($value->window !== Optional::Undefined) {
+            $result->window = $this->recursiveEncode($value->window);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Nested arrays and objects must be encoded recursively.
+     */
+    private function recursiveEncode(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            foreach ($value as $key => $val) {
+                $value[$key] = $this->recursiveEncode($val);
+            }
+
+            return $value;
+        }
+
+        if ($value instanceof stdClass) {
+            foreach (get_object_vars($value) as $key => $val) {
+                $value->{$key} = $this->recursiveEncode($val);
+            }
+
+            return $value;
+        }
+
+        return $this->encoder->encodeIfSupported($value);
+    }
+}

--- a/src/Builder/Encoder/OutputWindowEncoder.php
+++ b/src/Builder/Encoder/OutputWindowEncoder.php
@@ -14,8 +14,6 @@ use stdClass;
 
 use function array_key_first;
 use function get_debug_type;
-use function is_array;
-use function is_object;
 use function MongoDB\is_first_key_operator;
 use function sprintf;
 
@@ -42,6 +40,7 @@ class OutputWindowEncoder extends AbstractExpressionEncoder
         if (! $value->operator instanceof WindowInterface) {
             if (! is_first_key_operator($result)) {
                 $firstKey = array_key_first((array) $result);
+
                 throw new LogicException(sprintf('Expected OutputWindow::$operator to be an operator. Got "%s"', $firstKey ?? 'null'));
             }
 

--- a/src/Builder/Encoder/OutputWindowEncoder.php
+++ b/src/Builder/Encoder/OutputWindowEncoder.php
@@ -31,11 +31,6 @@ class OutputWindowEncoder implements ExpressionEncoder
     {
     }
 
-    public static function createForEncoder(BuilderEncoder $encoder): static
-    {
-        return new self($encoder);
-    }
-
     /** @psalm-assert-if-true OutputWindow $value */
     public function canEncode(mixed $value): bool
     {

--- a/src/Builder/Encoder/PipelineEncoder.php
+++ b/src/Builder/Encoder/PipelineEncoder.php
@@ -20,11 +20,6 @@ class PipelineEncoder implements ExpressionEncoder
     {
     }
 
-    public static function createForEncoder(BuilderEncoder $encoder): static
-    {
-        return new self($encoder);
-    }
-
     /** @psalm-assert-if-true Pipeline $value */
     public function canEncode(mixed $value): bool
     {

--- a/src/Builder/Encoder/PipelineEncoder.php
+++ b/src/Builder/Encoder/PipelineEncoder.php
@@ -7,20 +7,21 @@ namespace MongoDB\Builder\Encoder;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Codec\EncodeIfSupported;
 use MongoDB\Exception\UnsupportedValueException;
-use stdClass;
 
-/** @template-extends AbstractExpressionEncoder<array, Pipeline> */
+/** @template-extends AbstractExpressionEncoder<list<mixed>, Pipeline> */
 class PipelineEncoder extends AbstractExpressionEncoder
 {
-    /** @template-use EncodeIfSupported<array, Pipeline> */
+    /** @template-use EncodeIfSupported<list<mixed>, Pipeline> */
     use EncodeIfSupported;
 
+    /** @psalm-assert-if-true Pipeline $value */
     public function canEncode(mixed $value): bool
     {
         return $value instanceof Pipeline;
     }
 
-    public function encode(mixed $value): stdClass|array|string
+    /** @return list<mixed> */
+    public function encode(mixed $value): array
     {
         if (! $this->canEncode($value)) {
             throw UnsupportedValueException::invalidEncodableValue($value);

--- a/src/Builder/Encoder/PipelineEncoder.php
+++ b/src/Builder/Encoder/PipelineEncoder.php
@@ -4,32 +4,23 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Encoder;
 
-use MongoDB\Builder\BuilderEncoder;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Codec\EncodeIfSupported;
 use MongoDB\Exception\UnsupportedValueException;
 use stdClass;
 
-/** @template-implements ExpressionEncoder<Pipeline, array> */
-class PipelineEncoder implements ExpressionEncoder
+/** @template-extends AbstractExpressionEncoder<array, Pipeline> */
+class PipelineEncoder extends AbstractExpressionEncoder
 {
-    /** @template-use EncodeIfSupported<Pipeline, array> */
+    /** @template-use EncodeIfSupported<array, Pipeline> */
     use EncodeIfSupported;
 
-    public function __construct(protected readonly BuilderEncoder $encoder)
-    {
-    }
-
-    /** @psalm-assert-if-true Pipeline $value */
     public function canEncode(mixed $value): bool
     {
         return $value instanceof Pipeline;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function encode($value): stdClass|array|string
+    public function encode(mixed $value): stdClass|array|string
     {
         if (! $this->canEncode($value)) {
             throw UnsupportedValueException::invalidEncodableValue($value);
@@ -37,7 +28,6 @@ class PipelineEncoder implements ExpressionEncoder
 
         $encoded = [];
         foreach ($value->getIterator() as $stage) {
-            // Todo: Needs StageEncoder
             $encoded[] = $this->encoder->encodeIfSupported($stage);
         }
 

--- a/src/Builder/Encoder/PipelineEncoder.php
+++ b/src/Builder/Encoder/PipelineEncoder.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Encoder;
+
+use MongoDB\Builder\BuilderEncoder;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Codec\EncodeIfSupported;
+use MongoDB\Exception\UnsupportedValueException;
+use stdClass;
+
+/** @template-implements ExpressionEncoder<Pipeline, array> */
+class PipelineEncoder implements ExpressionEncoder
+{
+    /** @template-use EncodeIfSupported<Pipeline, array> */
+    use EncodeIfSupported;
+
+    public function __construct(protected readonly BuilderEncoder $encoder)
+    {
+    }
+
+    public static function createForEncoder(BuilderEncoder $encoder): static
+    {
+        return new self($encoder);
+    }
+
+    /** @psalm-assert-if-true Pipeline $value */
+    public function canEncode(mixed $value): bool
+    {
+        return $value instanceof Pipeline;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function encode($value): stdClass|array|string
+    {
+        if (! $this->canEncode($value)) {
+            throw UnsupportedValueException::invalidEncodableValue($value);
+        }
+
+        $encoded = [];
+        foreach ($value->getIterator() as $stage) {
+            // Todo: Needs StageEncoder
+            $encoded[] = $this->encoder->encodeIfSupported($stage);
+        }
+
+        return $encoded;
+    }
+}

--- a/src/Builder/Encoder/QueryEncoder.php
+++ b/src/Builder/Encoder/QueryEncoder.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace MongoDB\Builder\Encoder;
 
 use LogicException;
-use MongoDB\Builder\BuilderEncoder;
-use MongoDB\Builder\Expression\Variable;
 use MongoDB\Builder\Type\QueryInterface;
 use MongoDB\Builder\Type\QueryObject;
 use MongoDB\Codec\EncodeIfSupported;
@@ -14,30 +12,21 @@ use MongoDB\Exception\UnsupportedValueException;
 use stdClass;
 
 use function get_object_vars;
-use function is_array;
 use function property_exists;
 use function sprintf;
 
-/** @template-implements ExpressionEncoder<Variable, stdClass> */
-class QueryEncoder implements ExpressionEncoder
+/** @template-extends AbstractExpressionEncoder<stdClass, QueryObject> */
+class QueryEncoder extends AbstractExpressionEncoder
 {
-    /** @template-use EncodeIfSupported<Variable, string> */
+    /** @template-use EncodeIfSupported<stdClass, QueryObject> */
     use EncodeIfSupported;
 
-    public function __construct(protected readonly BuilderEncoder $encoder)
-    {
-    }
-
-    /** @psalm-assert-if-true Variable $value */
     public function canEncode(mixed $value): bool
     {
         return $value instanceof QueryObject;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function encode($value): stdClass
+    public function encode(mixed $value): stdClass
     {
         if (! $this->canEncode($value)) {
             throw UnsupportedValueException::invalidEncodableValue($value);
@@ -48,7 +37,7 @@ class QueryEncoder implements ExpressionEncoder
             if ($value instanceof QueryInterface) {
                 // The sub-objects is merged into the main object, replacing duplicate keys
                 foreach (get_object_vars($this->recursiveEncode($value)) as $subKey => $subValue) {
-                    if (property_exists($result, (string) $subKey)) {
+                    if (property_exists($result, $subKey)) {
                         throw new LogicException(sprintf('Duplicate key "%s" in query object', $subKey));
                     }
 
@@ -64,29 +53,5 @@ class QueryEncoder implements ExpressionEncoder
         }
 
         return $result;
-    }
-
-    /**
-     * Nested arrays and objects must be encoded recursively.
-     */
-    private function recursiveEncode(mixed $value): mixed
-    {
-        if (is_array($value)) {
-            foreach ($value as $key => $val) {
-                $value[$key] = $this->recursiveEncode($val);
-            }
-
-            return $value;
-        }
-
-        if ($value instanceof stdClass) {
-            foreach (get_object_vars($value) as $key => $val) {
-                $value->{$key} = $this->recursiveEncode($val);
-            }
-
-            return $value;
-        }
-
-        return $this->encoder->encodeIfSupported($value);
     }
 }

--- a/src/Builder/Encoder/QueryEncoder.php
+++ b/src/Builder/Encoder/QueryEncoder.php
@@ -28,11 +28,6 @@ class QueryEncoder implements ExpressionEncoder
     {
     }
 
-    public static function createForEncoder(BuilderEncoder $encoder): static
-    {
-        return new self($encoder);
-    }
-
     /** @psalm-assert-if-true Variable $value */
     public function canEncode(mixed $value): bool
     {

--- a/src/Builder/Encoder/QueryEncoder.php
+++ b/src/Builder/Encoder/QueryEncoder.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Encoder;
+
+use LogicException;
+use MongoDB\Builder\BuilderEncoder;
+use MongoDB\Builder\Expression\Variable;
+use MongoDB\Builder\Type\QueryInterface;
+use MongoDB\Builder\Type\QueryObject;
+use MongoDB\Codec\EncodeIfSupported;
+use MongoDB\Exception\UnsupportedValueException;
+use stdClass;
+
+use function get_object_vars;
+use function is_array;
+use function property_exists;
+use function sprintf;
+
+/** @template-implements ExpressionEncoder<Variable, stdClass> */
+class QueryEncoder implements ExpressionEncoder
+{
+    /** @template-use EncodeIfSupported<Variable, string> */
+    use EncodeIfSupported;
+
+    public function __construct(protected readonly BuilderEncoder $encoder)
+    {
+    }
+
+    public static function createForEncoder(BuilderEncoder $encoder): static
+    {
+        return new self($encoder);
+    }
+
+    /** @psalm-assert-if-true Variable $value */
+    public function canEncode(mixed $value): bool
+    {
+        return $value instanceof QueryObject;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function encode($value): stdClass
+    {
+        if (! $this->canEncode($value)) {
+            throw UnsupportedValueException::invalidEncodableValue($value);
+        }
+
+        $result = new stdClass();
+        foreach ($value->queries as $key => $value) {
+            if ($value instanceof QueryInterface) {
+                // The sub-objects is merged into the main object, replacing duplicate keys
+                foreach (get_object_vars($this->recursiveEncode($value)) as $subKey => $subValue) {
+                    if (property_exists($result, (string) $subKey)) {
+                        throw new LogicException(sprintf('Duplicate key "%s" in query object', $subKey));
+                    }
+
+                    $result->{$subKey} = $subValue;
+                }
+            } else {
+                if (property_exists($result, (string) $key)) {
+                    throw new LogicException(sprintf('Duplicate key "%s" in query object', $key));
+                }
+
+                $result->{$key} = $this->encoder->encodeIfSupported($value);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Nested arrays and objects must be encoded recursively.
+     */
+    private function recursiveEncode(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            foreach ($value as $key => $val) {
+                $value[$key] = $this->recursiveEncode($val);
+            }
+
+            return $value;
+        }
+
+        if ($value instanceof stdClass) {
+            foreach (get_object_vars($value) as $key => $val) {
+                $value->{$key} = $this->recursiveEncode($val);
+            }
+
+            return $value;
+        }
+
+        return $this->encoder->encodeIfSupported($value);
+    }
+}

--- a/src/Builder/Encoder/VariableEncoder.php
+++ b/src/Builder/Encoder/VariableEncoder.php
@@ -25,6 +25,7 @@ class VariableEncoder extends AbstractExpressionEncoder
             throw UnsupportedValueException::invalidEncodableValue($value);
         }
 
+        // TODO: needs method because interfaces can't have properties
         return '$$' . $value->name;
     }
 }

--- a/src/Builder/Encoder/VariableEncoder.php
+++ b/src/Builder/Encoder/VariableEncoder.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Encoder;
+
+use MongoDB\Builder\BuilderEncoder;
+use MongoDB\Builder\Expression\Variable;
+use MongoDB\Codec\EncodeIfSupported;
+use MongoDB\Exception\UnsupportedValueException;
+
+/** @template-implements ExpressionEncoder<Variable, string> */
+class VariableEncoder implements ExpressionEncoder
+{
+    /** @template-use EncodeIfSupported<Variable, string> */
+    use EncodeIfSupported;
+
+    public function __construct(protected readonly BuilderEncoder $encoder)
+    {
+    }
+
+    public static function createForEncoder(BuilderEncoder $encoder): static
+    {
+        return new self($encoder);
+    }
+
+    /** @psalm-assert-if-true Variable $value */
+    public function canEncode(mixed $value): bool
+    {
+        return $value instanceof Variable;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function encode($value): string
+    {
+        if (! $this->canEncode($value)) {
+            throw UnsupportedValueException::invalidEncodableValue($value);
+        }
+
+        return '$$' . $value->name;
+    }
+}

--- a/src/Builder/Encoder/VariableEncoder.php
+++ b/src/Builder/Encoder/VariableEncoder.php
@@ -4,31 +4,22 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Encoder;
 
-use MongoDB\Builder\BuilderEncoder;
 use MongoDB\Builder\Expression\Variable;
 use MongoDB\Codec\EncodeIfSupported;
 use MongoDB\Exception\UnsupportedValueException;
 
-/** @template-implements ExpressionEncoder<Variable, string> */
-class VariableEncoder implements ExpressionEncoder
+/** @template-extends AbstractExpressionEncoder<string, Variable> */
+class VariableEncoder extends AbstractExpressionEncoder
 {
-    /** @template-use EncodeIfSupported<Variable, string> */
+    /** @template-use EncodeIfSupported<string, Variable> */
     use EncodeIfSupported;
 
-    public function __construct(protected readonly BuilderEncoder $encoder)
-    {
-    }
-
-    /** @psalm-assert-if-true Variable $value */
     public function canEncode(mixed $value): bool
     {
         return $value instanceof Variable;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function encode($value): string
+    public function encode(mixed $value): string
     {
         if (! $this->canEncode($value)) {
             throw UnsupportedValueException::invalidEncodableValue($value);

--- a/src/Builder/Encoder/VariableEncoder.php
+++ b/src/Builder/Encoder/VariableEncoder.php
@@ -19,11 +19,6 @@ class VariableEncoder implements ExpressionEncoder
     {
     }
 
-    public static function createForEncoder(BuilderEncoder $encoder): static
-    {
-        return new self($encoder);
-    }
-
     /** @psalm-assert-if-true Variable $value */
     public function canEncode(mixed $value): bool
     {

--- a/src/Builder/Type/CombinedFieldQuery.php
+++ b/src/Builder/Type/CombinedFieldQuery.php
@@ -37,15 +37,24 @@ class CombinedFieldQuery implements FieldQueryInterface
         }
 
         // Flatten nested CombinedFieldQuery
-        $this->fieldQueries = array_reduce($fieldQueries, static function (array $fieldQueries, QueryInterface|FieldQueryInterface|Type|stdClass|array|bool|float|int|string|null $fieldQuery): array {
-            if ($fieldQuery instanceof CombinedFieldQuery) {
-                return array_merge($fieldQueries, $fieldQuery->fieldQueries);
-            }
+        $this->fieldQueries = array_reduce(
+            $fieldQueries,
+            /**
+             * @param list<QueryInterface|FieldQueryInterface|Type|stdClass|array|bool|float|int|string|null> $fieldQueries
+             *
+             * @return list<QueryInterface|FieldQueryInterface|Type|stdClass|array|bool|float|int|string|null>
+             */
+            static function (array $fieldQueries, QueryInterface|FieldQueryInterface|Type|stdClass|array|bool|float|int|string|null $fieldQuery): array {
+                if ($fieldQuery instanceof CombinedFieldQuery) {
+                    return array_merge($fieldQueries, $fieldQuery->fieldQueries);
+                }
 
-            $fieldQueries[] = $fieldQuery;
+                $fieldQueries[] = $fieldQuery;
 
-            return $fieldQueries;
-        }, []);
+                return $fieldQueries;
+            },
+            [],
+        );
 
         // Validate FieldQuery types and non-duplicate operators
         $seenOperators = [];

--- a/src/Builder/Type/Encode.php
+++ b/src/Builder/Type/Encode.php
@@ -37,4 +37,9 @@ enum Encode
      * Specific for $group stage
      */
     case Group;
+
+    /**
+     * Default case used in the interface; implementing classes are expected to override this value
+     */
+    case Undefined;
 }

--- a/src/Builder/Type/OperatorInterface.php
+++ b/src/Builder/Type/OperatorInterface.php
@@ -9,5 +9,8 @@ namespace MongoDB\Builder\Type;
  */
 interface OperatorInterface
 {
+    /** To be overridden by implementing classes */
+    public const ENCODE = Encode::Single;
+
     public function getOperator(): string;
 }

--- a/src/Builder/Type/OperatorInterface.php
+++ b/src/Builder/Type/OperatorInterface.php
@@ -10,7 +10,7 @@ namespace MongoDB\Builder\Type;
 interface OperatorInterface
 {
     /** To be overridden by implementing classes */
-    public const ENCODE = Encode::Single;
+    public const ENCODE = Encode::Undefined;
 
     public function getOperator(): string;
 }

--- a/src/Builder/Type/QueryObject.php
+++ b/src/Builder/Type/QueryObject.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Type;
 
-use MongoDB\BSON\Decimal128;
-use MongoDB\BSON\Int64;
-use MongoDB\BSON\Regex;
+use MongoDB\BSON\Type;
 use MongoDB\Exception\InvalidArgumentException;
 use stdClass;
 
@@ -27,7 +25,7 @@ final class QueryObject implements QueryInterface
 {
     public readonly array $queries;
 
-    /** @param array<QueryInterface|FieldQueryInterface|Decimal128|Int64|Regex|stdClass|array|bool|float|int|string|null> $queries */
+    /** @param array<QueryInterface|FieldQueryInterface|Type|stdClass|array|bool|float|int|string|null> $queries */
     public static function create(array $queries): QueryInterface
     {
         // We don't wrap a single query in a QueryObject
@@ -38,7 +36,7 @@ final class QueryObject implements QueryInterface
         return new self($queries);
     }
 
-    /** @param array<QueryInterface|FieldQueryInterface|Decimal128|Int64|Regex|stdClass|array|bool|float|int|string|null> $queriesOrArrayOfQueries */
+    /** @param array<QueryInterface|FieldQueryInterface|Type|stdClass|array|bool|float|int|string|null> $queriesOrArrayOfQueries */
     private function __construct(array $queriesOrArrayOfQueries)
     {
         // If the first element is an array and not an operator, we assume variadic arguments were not used


### PR DESCRIPTION
PHPLIB-1250

This PR splits the main `BuilderEncoder` into multiple files. This allows for more isolation of separate code (which I'm sure can be improved further), but also allows for easy introduction of custom codecs (currently not tested yet).

In addition, this PR cleans up a number of psalm issues and adds other issues to the baseline. I'll comment on those as necessary.