### PR TITLE
PHPLIB-1356 Add tests on Timestamp Expression Operators

### DIFF
--- a/generator/config/expression/tsIncrement.yaml
+++ b/generator/config/expression/tsIncrement.yaml
@@ -12,3 +12,28 @@ arguments:
         name: expression
         type:
             - resolvesToTimestamp
+tests:
+    -
+        name: 'Obtain the Incrementing Ordinal from a Timestamp Field'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/tsIncrement/#obtain-the-incrementing-ordinal-from-a-timestamp-field'
+        pipeline:
+            -
+                $project:
+                    _id: 0
+                    saleTimestamp: 1
+                    saleIncrement:
+                        $tsIncrement: '$saleTimestamp'
+    -
+        name: 'Use $tsSecond in a Change Stream Cursor to Monitor Collection Changes'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/tsSecond/#use--tssecond-in-a-change-stream-cursor-to-monitor-collection-changes'
+        pipeline:
+            -
+                $match:
+                    $expr:
+                        $eq:
+                            -
+                                $mod:
+                                    -
+                                        $tsIncrement: '$clusterTime'
+                                    - 2
+                            - 0

--- a/generator/config/expression/tsSecond.yaml
+++ b/generator/config/expression/tsSecond.yaml
@@ -12,3 +12,22 @@ arguments:
         name: expression
         type:
             - resolvesToTimestamp
+tests:
+    -
+        name: 'Obtain the Number of Seconds from a Timestamp Field'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/tsSecond/#obtain-the-number-of-seconds-from-a-timestamp-field'
+        pipeline:
+            -
+                $project:
+                    _id: 0
+                    saleTimestamp: 1
+                    saleSeconds:
+                        $tsSecond: '$saleTimestamp'
+    -
+        name: 'Use $tsSecond in a Change Stream Cursor to Monitor Collection Changes'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/tsSecond/#use--tssecond-in-a-change-stream-cursor-to-monitor-collection-changes'
+        pipeline:
+            -
+                $addFields:
+                    clusterTimeSeconds:
+                        $tsSecond: '$clusterTime'

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -4721,6 +4721,100 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Obtain the Incrementing Ordinal from a Timestamp Field
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/tsIncrement/#obtain-the-incrementing-ordinal-from-a-timestamp-field
+     */
+    case TsIncrementObtainTheIncrementingOrdinalFromATimestampField = <<<'JSON'
+    [
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "saleTimestamp": {
+                    "$numberInt": "1"
+                },
+                "saleIncrement": {
+                    "$tsIncrement": "$saleTimestamp"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use $tsSecond in a Change Stream Cursor to Monitor Collection Changes
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/tsSecond/#use--tssecond-in-a-change-stream-cursor-to-monitor-collection-changes
+     */
+    case TsIncrementUseTsSecondInAChangeStreamCursorToMonitorCollectionChanges = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$expr": {
+                    "$eq": [
+                        {
+                            "$mod": [
+                                {
+                                    "$tsIncrement": "$clusterTime"
+                                },
+                                {
+                                    "$numberInt": "2"
+                                }
+                            ]
+                        },
+                        {
+                            "$numberInt": "0"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Obtain the Number of Seconds from a Timestamp Field
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/tsSecond/#obtain-the-number-of-seconds-from-a-timestamp-field
+     */
+    case TsSecondObtainTheNumberOfSecondsFromATimestampField = <<<'JSON'
+    [
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "saleTimestamp": {
+                    "$numberInt": "1"
+                },
+                "saleSeconds": {
+                    "$tsSecond": "$saleTimestamp"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use $tsSecond in a Change Stream Cursor to Monitor Collection Changes
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/tsSecond/#use--tssecond-in-a-change-stream-cursor-to-monitor-collection-changes
+     */
+    case TsSecondUseTsSecondInAChangeStreamCursorToMonitorCollectionChanges = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "clusterTimeSeconds": {
+                    "$tsSecond": "$clusterTime"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Remove Fields that Contain Periods
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/unsetField/#remove-fields-that-contain-periods--.-

--- a/tests/Builder/Expression/TsIncrementOperatorTest.php
+++ b/tests/Builder/Expression/TsIncrementOperatorTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $tsIncrement expression
+ */
+class TsIncrementOperatorTest extends PipelineTestCase
+{
+    public function testObtainTheIncrementingOrdinalFromATimestampField(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                _id: 0,
+                saleTimestamp: 1,
+                saleIncrement: Expression::tsIncrement(
+                    Expression::timestampFieldPath('saleTimestamp'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TsIncrementObtainTheIncrementingOrdinalFromATimestampField, $pipeline);
+    }
+
+    public function testUseTsSecondInAChangeStreamCursorToMonitorCollectionChanges(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::expr(
+                    Expression::eq(
+                        Expression::mod(
+                            Expression::tsIncrement(
+                                Expression::timestampFieldPath('clusterTime'),
+                            ),
+                            2,
+                        ),
+                        0,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TsIncrementUseTsSecondInAChangeStreamCursorToMonitorCollectionChanges, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/TsSecondOperatorTest.php
+++ b/tests/Builder/Expression/TsSecondOperatorTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $tsSecond expression
+ */
+class TsSecondOperatorTest extends PipelineTestCase
+{
+    public function testObtainTheNumberOfSecondsFromATimestampField(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                _id: 0,
+                saleTimestamp: 1,
+                saleSeconds: Expression::tsSecond(
+                    Expression::timestampFieldPath('saleTimestamp'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TsSecondObtainTheNumberOfSecondsFromATimestampField, $pipeline);
+    }
+
+    public function testUseTsSecondInAChangeStreamCursorToMonitorCollectionChanges(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                clusterTimeSeconds: Expression::tsSecond(
+                    Expression::timestampFieldPath('clusterTime'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TsSecondUseTsSecondInAChangeStreamCursorToMonitorCollectionChanges, $pipeline);
+    }
+}


### PR DESCRIPTION
Fix [PHPLIB-1356](https://jira.mongodb.org/browse/PHPLIB-1356)

https://www.mongodb.com/docs/manual/reference/operator/aggregation/#timestamp-expression-operators

- `$tsIncrement`
- `$tsSecond`

Nothing special.