### PR TITLE
PHPLIB-1357 Add tests on Trigonometry Expression Operators

### DIFF
--- a/generator/config/expression/acos.yaml
+++ b/generator/config/expression/acos.yaml
@@ -16,3 +16,16 @@ arguments:
             $acos takes any valid expression that resolves to a number between -1 and 1, e.g. -1 <= value <= 1.
             $acos returns values in radians. Use $radiansToDegrees operator to convert the output value from radians to degrees.
             By default $acos returns values as a double. $acos can also return values as a 128-bit decimal as long as the expression resolves to a 128-bit decimal value.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/acos/#example'
+        pipeline:
+            -
+                $addFields:
+                    angle_a:
+                        $radiansToDegrees:
+                            $acos:
+                                $divide:
+                                    - '$side_b'
+                                    - '$hypotenuse'

--- a/generator/config/expression/acosh.yaml
+++ b/generator/config/expression/acosh.yaml
@@ -16,3 +16,13 @@ arguments:
             $acosh takes any valid expression that resolves to a number between 1 and +Infinity, e.g. 1 <= value <= +Infinity.
             $acosh returns values in radians. Use $radiansToDegrees operator to convert the output value from radians to degrees.
             By default $acosh returns values as a double. $acosh can also return values as a 128-bit decimal as long as the expression resolves to a 128-bit decimal value.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/acosh/#example'
+        pipeline:
+            -
+                $addFields:
+                    y-coordinate:
+                        $radiansToDegrees:
+                            $acosh: '$x-coordinate'

--- a/generator/config/expression/asin.yaml
+++ b/generator/config/expression/asin.yaml
@@ -16,3 +16,16 @@ arguments:
             $asin takes any valid expression that resolves to a number between -1 and 1, e.g. -1 <= value <= 1.
             $asin returns values in radians. Use $radiansToDegrees operator to convert the output value from radians to degrees.
             By default $asin returns values as a double. $asin can also return values as a 128-bit decimal as long as the expression resolves to a 128-bit decimal value.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/asin/#example'
+        pipeline:
+            -
+                $addFields:
+                    angle_a:
+                        $radiansToDegrees:
+                            $asin:
+                                $divide:
+                                    - '$side_a'
+                                    - '$hypotenuse'

--- a/generator/config/expression/asinh.yaml
+++ b/generator/config/expression/asinh.yaml
@@ -16,3 +16,13 @@ arguments:
             $asinh takes any valid expression that resolves to a number.
             $asinh returns values in radians. Use $radiansToDegrees operator to convert the output value from radians to degrees.
             By default $asinh returns values as a double. $asinh can also return values as a 128-bit decimal as long as the expression resolves to a 128-bit decimal value.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/asinh/#example'
+        pipeline:
+            -
+                $addFields:
+                    y-coordinate:
+                        $radiansToDegrees:
+                            $asinh: '$x-coordinate'

--- a/generator/config/expression/atan.yaml
+++ b/generator/config/expression/atan.yaml
@@ -16,3 +16,16 @@ arguments:
             $atan takes any valid expression that resolves to a number.
             $atan returns values in radians. Use $radiansToDegrees operator to convert the output value from radians to degrees.
             By default $atan returns values as a double. $atan can also return values as a 128-bit decimal as long as the expression resolves to a 128-bit decimal value.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/atan/#example'
+        pipeline:
+            -
+                $addFields:
+                    angle_a:
+                        $radiansToDegrees:
+                            $atan:
+                                $divide:
+                                    - '$side_b'
+                                    - '$side_a'

--- a/generator/config/expression/atan2.yaml
+++ b/generator/config/expression/atan2.yaml
@@ -20,3 +20,15 @@ arguments:
         name: x
         type:
             - resolvesToNumber
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/atan2/#example'
+        pipeline:
+            -
+                $addFields:
+                    angle_a:
+                        $radiansToDegrees:
+                            $atan2:
+                                - '$side_b'
+                                - '$side_a'

--- a/generator/config/expression/atanh.yaml
+++ b/generator/config/expression/atanh.yaml
@@ -16,3 +16,13 @@ arguments:
             $atanh takes any valid expression that resolves to a number between -1 and 1, e.g. -1 <= value <= 1.
             $atanh returns values in radians. Use $radiansToDegrees operator to convert the output value from radians to degrees.
             By default $atanh returns values as a double. $atanh can also return values as a 128-bit decimal as long as the expression resolves to a 128-bit decimal value.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/atanh/#example'
+        pipeline:
+            -
+                $addFields:
+                    y-coordinate:
+                        $radiansToDegrees:
+                            $atanh: '$x-coordinate'

--- a/generator/config/expression/cos.yaml
+++ b/generator/config/expression/cos.yaml
@@ -15,3 +15,16 @@ arguments:
         description: |
             $cos takes any valid expression that resolves to a number. If the expression returns a value in degrees, use the $degreesToRadians operator to convert the result to radians.
             By default $cos returns values as a double. $cos can also return values as a 128-bit decimal as long as the <expression> resolves to a 128-bit decimal value.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/cos/#example'
+        pipeline:
+            -
+                $addFields:
+                    side_a:
+                        $multiply:
+                            -
+                                $cos:
+                                    $degreesToRadians: '$angle_a'
+                            - '$hypotenuse'

--- a/generator/config/expression/cosh.yaml
+++ b/generator/config/expression/cosh.yaml
@@ -15,3 +15,13 @@ arguments:
         description: |
             $cosh takes any valid expression that resolves to a number, measured in radians. If the expression returns a value in degrees, use the $degreesToRadians operator to convert the value to radians.
             By default $cosh returns values as a double. $cosh can also return values as a 128-bit decimal if the <expression> resolves to a 128-bit decimal value.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/cosh/#example'
+        pipeline:
+            -
+                $addFields:
+                    cosh_output:
+                        $cosh:
+                            $degreesToRadians: '$angle'

--- a/generator/config/expression/degreesToRadians.yaml
+++ b/generator/config/expression/degreesToRadians.yaml
@@ -15,3 +15,16 @@ arguments:
         description: |
             $degreesToRadians takes any valid expression that resolves to a number.
             By default $degreesToRadians returns values as a double. $degreesToRadians can also return values as a 128-bit decimal as long as the <expression> resolves to a 128-bit decimal value.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/degreesToRadians/#example'
+        pipeline:
+            -
+                $addFields:
+                    angle_a_rad:
+                        $degreesToRadians: '$angle_a'
+                    angle_b_rad:
+                        $degreesToRadians: '$angle_b'
+                    angle_c_rad:
+                        $degreesToRadians: '$angle_c'

--- a/generator/config/expression/radiansToDegrees.yaml
+++ b/generator/config/expression/radiansToDegrees.yaml
@@ -12,3 +12,16 @@ arguments:
         name: expression
         type:
             - resolvesToNumber
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/radiansToDegrees/#example'
+        pipeline:
+            -
+                $addFields:
+                    angle_a_deg:
+                        $radiansToDegrees: '$angle_a'
+                    angle_b_deg:
+                        $radiansToDegrees: '$angle_b'
+                    angle_c_deg:
+                        $radiansToDegrees: '$angle_c'

--- a/generator/config/expression/sin.yaml
+++ b/generator/config/expression/sin.yaml
@@ -15,3 +15,16 @@ arguments:
         description: |
             $sin takes any valid expression that resolves to a number. If the expression returns a value in degrees, use the $degreesToRadians operator to convert the result to radians.
             By default $sin returns values as a double. $sin can also return values as a 128-bit decimal as long as the expression resolves to a 128-bit decimal value.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/sin/#example'
+        pipeline:
+            -
+                $addFields:
+                    side_b:
+                        $multiply:
+                            -
+                                $sin:
+                                    $degreesToRadians: '$angle_a'
+                            - '$hypotenuse'

--- a/generator/config/expression/sinh.yaml
+++ b/generator/config/expression/sinh.yaml
@@ -15,3 +15,13 @@ arguments:
         description: |
             $sinh takes any valid expression that resolves to a number, measured in radians. If the expression returns a value in degrees, use the $degreesToRadians operator to convert the value to radians.
             By default $sinh returns values as a double. $sinh can also return values as a 128-bit decimal if the expression resolves to a 128-bit decimal value.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/sinh/#example'
+        pipeline:
+            -
+                $addFields:
+                    sinh_output:
+                        $sinh:
+                            $degreesToRadians: '$angle'

--- a/generator/config/expression/tan.yaml
+++ b/generator/config/expression/tan.yaml
@@ -15,3 +15,16 @@ arguments:
         description: |
             $tan takes any valid expression that resolves to a number. If the expression returns a value in degrees, use the $degreesToRadians operator to convert the result to radians.
             By default $tan returns values as a double. $tan can also return values as a 128-bit decimal as long as the expression resolves to a 128-bit decimal value.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/tan/#example'
+        pipeline:
+            -
+                $addFields:
+                    side_b:
+                        $multiply:
+                            -
+                                $tan:
+                                    $degreesToRadians: '$angle_a'
+                            - '$side_a'

--- a/generator/config/expression/tanh.yaml
+++ b/generator/config/expression/tanh.yaml
@@ -15,3 +15,13 @@ arguments:
         description: |
             $tanh takes any valid expression that resolves to a number, measured in radians. If the expression returns a value in degrees, use the $degreesToRadians operator to convert the value to radians.
             By default $tanh returns values as a double. $tanh can also return values as a 128-bit decimal if the expression resolves to a 128-bit decimal value.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/tanh/#example'
+        pipeline:
+            -
+                $addFields:
+                    tanh_output:
+                        $tanh:
+                            $degreesToRadians: '$angle'

--- a/tests/Builder/Expression/AcosOperatorTest.php
+++ b/tests/Builder/Expression/AcosOperatorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $acos expression
+ */
+class AcosOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                angle_a: Expression::radiansToDegrees(
+                    Expression::acos(
+                        Expression::divide(
+                            Expression::numberFieldPath('side_b'),
+                            Expression::numberFieldPath('hypotenuse'),
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::AcosExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/AcoshOperatorTest.php
+++ b/tests/Builder/Expression/AcoshOperatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $acosh expression
+ */
+class AcoshOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                ...[
+                    'y-coordinate' => Expression::radiansToDegrees(
+                        Expression::acosh(
+                            Expression::numberFieldPath('x-coordinate'),
+                        ),
+                    ),
+                ],
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::AcoshExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/AsinOperatorTest.php
+++ b/tests/Builder/Expression/AsinOperatorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $asin expression
+ */
+class AsinOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                angle_a: Expression::radiansToDegrees(
+                    Expression::asin(
+                        Expression::divide(
+                            Expression::numberFieldPath('side_a'),
+                            Expression::numberFieldPath('hypotenuse'),
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::AsinExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/AsinhOperatorTest.php
+++ b/tests/Builder/Expression/AsinhOperatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $asinh expression
+ */
+class AsinhOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                ...[
+                    'y-coordinate' => Expression::radiansToDegrees(
+                        Expression::asinh(
+                            Expression::numberFieldPath('x-coordinate'),
+                        ),
+                    ),
+                ],
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::AsinhExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/Atan2OperatorTest.php
+++ b/tests/Builder/Expression/Atan2OperatorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $atan2 expression
+ */
+class Atan2OperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                angle_a: Expression::radiansToDegrees(
+                    Expression::atan2(
+                        Expression::numberFieldPath('side_b'),
+                        Expression::numberFieldPath('side_a'),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::Atan2Example, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/AtanOperatorTest.php
+++ b/tests/Builder/Expression/AtanOperatorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $atan expression
+ */
+class AtanOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                angle_a: Expression::radiansToDegrees(
+                    Expression::atan(
+                        Expression::divide(
+                            Expression::numberFieldPath('side_b'),
+                            Expression::numberFieldPath('side_a'),
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::AtanExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/AtanhOperatorTest.php
+++ b/tests/Builder/Expression/AtanhOperatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $atanh expression
+ */
+class AtanhOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                ...[
+                    'y-coordinate' => Expression::radiansToDegrees(
+                        Expression::atanh(
+                            Expression::numberFieldPath('x-coordinate'),
+                        ),
+                    ),
+                ],
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::AtanhExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/CosOperatorTest.php
+++ b/tests/Builder/Expression/CosOperatorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $cos expression
+ */
+class CosOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                side_a: Expression::multiply(
+                    Expression::cos(
+                        Expression::degreesToRadians(
+                            Expression::numberFieldPath('angle_a'),
+                        ),
+                    ),
+                    Expression::numberFieldPath('hypotenuse'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::CosExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/CoshOperatorTest.php
+++ b/tests/Builder/Expression/CoshOperatorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $cosh expression
+ */
+class CoshOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                cosh_output: Expression::cosh(
+                    Expression::degreesToRadians(
+                        Expression::numberFieldPath('angle'),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::CoshExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/DegreesToRadiansOperatorTest.php
+++ b/tests/Builder/Expression/DegreesToRadiansOperatorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $degreesToRadians expression
+ */
+class DegreesToRadiansOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                angle_a_rad: Expression::degreesToRadians(
+                    Expression::numberFieldPath('angle_a'),
+                ),
+                angle_b_rad: Expression::degreesToRadians(
+                    Expression::numberFieldPath('angle_b'),
+                ),
+                angle_c_rad: Expression::degreesToRadians(
+                    Expression::numberFieldPath('angle_c'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DegreesToRadiansExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -11,6 +11,49 @@ namespace MongoDB\Tests\Builder\Expression;
 enum Pipelines: string
 {
     /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/acos/#example
+     */
+    case AcosExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "angle_a": {
+                    "$radiansToDegrees": {
+                        "$acos": {
+                            "$divide": [
+                                "$side_b",
+                                "$hypotenuse"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/acosh/#example
+     */
+    case AcoshExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "y-coordinate": {
+                    "$radiansToDegrees": {
+                        "$acosh": "$x-coordinate"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Add Numbers
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/add/#add-numbers
@@ -242,6 +285,114 @@ enum Pipelines: string
                     "$arrayToObject": [
                         "$instock"
                     ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/asin/#example
+     */
+    case AsinExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "angle_a": {
+                    "$radiansToDegrees": {
+                        "$asin": {
+                            "$divide": [
+                                "$side_a",
+                                "$hypotenuse"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/asinh/#example
+     */
+    case AsinhExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "y-coordinate": {
+                    "$radiansToDegrees": {
+                        "$asinh": "$x-coordinate"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/atan/#example
+     */
+    case AtanExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "angle_a": {
+                    "$radiansToDegrees": {
+                        "$atan": {
+                            "$divide": [
+                                "$side_b",
+                                "$side_a"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/atan2/#example
+     */
+    case Atan2Example = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "angle_a": {
+                    "$radiansToDegrees": {
+                        "$atan2": [
+                            "$side_b",
+                            "$side_a"
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/atanh/#example
+     */
+    case AtanhExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "y-coordinate": {
+                    "$radiansToDegrees": {
+                        "$atanh": "$x-coordinate"
+                    }
                 }
             }
         }
@@ -587,6 +738,49 @@ enum Pipelines: string
                         "else": {
                             "$numberInt": "20"
                         }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/cos/#example
+     */
+    case CosExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "side_a": {
+                    "$multiply": [
+                        {
+                            "$cos": {
+                                "$degreesToRadians": "$angle_a"
+                            }
+                        },
+                        "$hypotenuse"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/cosh/#example
+     */
+    case CoshExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "cosh_output": {
+                    "$cosh": {
+                        "$degreesToRadians": "$angle"
                     }
                 }
             }
@@ -1407,6 +1601,29 @@ enum Pipelines: string
                     "$dayOfYear": {
                         "date": "$date"
                     }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/degreesToRadians/#example
+     */
+    case DegreesToRadiansExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "angle_a_rad": {
+                    "$degreesToRadians": "$angle_a"
+                },
+                "angle_b_rad": {
+                    "$degreesToRadians": "$angle_b"
+                },
+                "angle_c_rad": {
+                    "$degreesToRadians": "$angle_c"
                 }
             }
         }
@@ -2771,6 +2988,29 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/radiansToDegrees/#example
+     */
+    case RadiansToDegreesExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "angle_a_deg": {
+                    "$radiansToDegrees": "$angle_a"
+                },
+                "angle_b_deg": {
+                    "$radiansToDegrees": "$angle_b"
+                },
+                "angle_c_deg": {
+                    "$radiansToDegrees": "$angle_c"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Generate Random Data Points
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/rand/#generate-random-data-points
@@ -3829,6 +4069,49 @@ enum Pipelines: string
     /**
      * Example
      *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sin/#example
+     */
+    case SinExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "side_b": {
+                    "$multiply": [
+                        {
+                            "$sin": {
+                                "$degreesToRadians": "$angle_a"
+                            }
+                        },
+                        "$hypotenuse"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sinh/#example
+     */
+    case SinhExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "sinh_output": {
+                    "$sinh": {
+                        "$degreesToRadians": "$angle"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/size/#example
      */
     case SizeExample = <<<'JSON'
@@ -4579,6 +4862,49 @@ enum Pipelines: string
                             }
                         ],
                         "default": "No scores found."
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/tan/#example
+     */
+    case TanExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "side_b": {
+                    "$multiply": [
+                        {
+                            "$tan": {
+                                "$degreesToRadians": "$angle_a"
+                            }
+                        },
+                        "$side_a"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/tanh/#example
+     */
+    case TanhExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "tanh_output": {
+                    "$tanh": {
+                        "$degreesToRadians": "$angle"
                     }
                 }
             }

--- a/tests/Builder/Expression/RadiansToDegreesOperatorTest.php
+++ b/tests/Builder/Expression/RadiansToDegreesOperatorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $radiansToDegrees expression
+ */
+class RadiansToDegreesOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                angle_a_deg: Expression::radiansToDegrees(
+                    Expression::numberFieldPath('angle_a'),
+                ),
+                angle_b_deg: Expression::radiansToDegrees(
+                    Expression::numberFieldPath('angle_b'),
+                ),
+                angle_c_deg: Expression::radiansToDegrees(
+                    Expression::numberFieldPath('angle_c'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::RadiansToDegreesExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/SinOperatorTest.php
+++ b/tests/Builder/Expression/SinOperatorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $sin expression
+ */
+class SinOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                side_b: Expression::multiply(
+                    Expression::sin(
+                        Expression::degreesToRadians(
+                            Expression::numberFieldPath('angle_a'),
+                        ),
+                    ),
+                    Expression::numberFieldPath('hypotenuse'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SinExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/SinhOperatorTest.php
+++ b/tests/Builder/Expression/SinhOperatorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $sinh expression
+ */
+class SinhOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                sinh_output: Expression::sinh(
+                    Expression::degreesToRadians(
+                        Expression::numberFieldPath('angle'),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SinhExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/TanOperatorTest.php
+++ b/tests/Builder/Expression/TanOperatorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $tan expression
+ */
+class TanOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                side_b: Expression::multiply(
+                    Expression::tan(
+                        Expression::degreesToRadians(
+                            Expression::numberFieldPath('angle_a'),
+                        ),
+                    ),
+                    Expression::numberFieldPath('side_a'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TanExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/TanhOperatorTest.php
+++ b/tests/Builder/Expression/TanhOperatorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $tanh expression
+ */
+class TanhOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                tanh_output:
+                Expression::tanh(
+                    Expression::degreesToRadians(
+                        Expression::numberFieldPath('angle'),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TanhExample, $pipeline);
+    }
+}


### PR DESCRIPTION
Fix [PHPLIB-1357](https://jira.mongodb.org/browse/PHPLIB-1357)

https://www.mongodb.com/docs/manual/reference/operator/aggregation/#trigonometry-expression-operators

- `$sin`
- `$cos`
- `$tan`
- `$asin`
- `$acos`
- `$atan`
- `$atan2`
- `$asinh`
- `$acosh`
- `$atanh`
- `$sinh`
- `$cosh`
- `$tanh`
- `$degreesToRadians`
- `$radiansToDegrees`