### PR TITLE
PHPLIB-1358 Add tests on Type Expression Operators

### DIFF
--- a/generator/config/expression/convert.yaml
+++ b/generator/config/expression/convert.yaml
@@ -33,3 +33,50 @@ arguments:
         description: |
             The value to return if the input is null or missing. The arguments can be any valid expression.
             If unspecified, $convert returns null if the input is null or missing.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/convert/#example'
+        pipeline:
+            -
+                $addFields:
+                    convertedPrice:
+                        $convert:
+                            input: '$price'
+                            to: 'decimal'
+                            onError: 'Error'
+                            onNull: !bson_decimal128 '0'
+                    convertedQty:
+                        $convert:
+                            input: '$qty'
+                            to: 'int'
+                            onError:
+                                $concat:
+                                    - 'Could not convert '
+                                    -
+                                        $toString: '$qty'
+                                    - ' to type integer.'
+                            onNull: 0
+            -
+                $project:
+                    totalPrice:
+                        $switch:
+                            branches:
+                                -
+                                    case:
+                                        $eq:
+                                            -
+                                                $type: '$convertedPrice'
+                                            - 'string'
+                                    then: 'NaN'
+                                -
+                                    case:
+                                        $eq:
+                                            -
+                                                $type: '$convertedQty'
+                                            - 'string'
+                                    then: 'NaN'
+                            default:
+                                $multiply:
+                                    - '$convertedPrice'
+                                    - '$convertedQty'

--- a/generator/config/expression/isNumber.yaml
+++ b/generator/config/expression/isNumber.yaml
@@ -13,4 +13,63 @@ arguments:
         name: expression
         type:
             - expression
-        variadic: array
+tests:
+    -
+        name: 'Use $isNumber to Check if a Field is Numeric'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/isNumber/#use--isnumber-to-check-if-a-field-is-numeric'
+        pipeline:
+            -
+                $addFields:
+                    isNumber:
+                        $isNumber: '$reading'
+                    hasType:
+                        $type: '$reading'
+    -
+        name: 'Conditionally Modify Fields using $isNumber'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/isNumber/#conditionally-modify-fields-using--isnumber'
+        pipeline:
+            -
+                $addFields:
+                    points:
+                        $cond:
+                            if:
+                                $isNumber: '$grade'
+                            then: '$grade'
+                            else:
+                                $switch:
+                                    branches:
+                                        -
+                                            case:
+                                                $eq:
+                                                    - '$grade'
+                                                    - 'A'
+                                            then: 4
+                                        -
+                                            case:
+                                                $eq:
+                                                    - '$grade'
+                                                    - 'B'
+                                            then: 3
+                                        -
+                                            case:
+                                                $eq:
+                                                    - '$grade'
+                                                    - 'C'
+                                            then: 2
+                                        -
+                                            case:
+                                                $eq:
+                                                    - '$grade'
+                                                    - 'D'
+                                            then: 1
+                                        -
+                                            case:
+                                                $eq:
+                                                    - '$grade'
+                                                    - 'F'
+                                            then: 0
+            -
+                $group:
+                    _id: '$student_id'
+                    GPA:
+                        $avg: '$points'

--- a/generator/config/expression/toBool.yaml
+++ b/generator/config/expression/toBool.yaml
@@ -12,3 +12,30 @@ arguments:
         name: expression
         type:
             - expression
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/toBool/#example'
+        pipeline:
+            -
+                $addFields:
+                    convertedShippedFlag:
+                        $switch:
+                            branches:
+                                -
+                                    case:
+                                        $eq:
+                                            - '$shipped'
+                                            - 'false'
+                                    then: false
+                                -
+                                    case:
+                                        $eq:
+                                            - '$shipped'
+                                            - ''
+                                    then: false
+                            default:
+                                $toBool: '$shipped'
+            -
+                $match:
+                    convertedShippedFlag: false

--- a/generator/config/expression/toDecimal.yaml
+++ b/generator/config/expression/toDecimal.yaml
@@ -12,3 +12,12 @@ arguments:
         name: expression
         type:
             - expression
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/toDecimal/#example'
+        pipeline:
+            -
+                $addFields:
+                    convertedPrice:
+                        $toDecimal: '$price'

--- a/generator/config/expression/toDouble.yaml
+++ b/generator/config/expression/toDouble.yaml
@@ -12,3 +12,16 @@ arguments:
         name: expression
         type:
             - expression
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/toDouble/#example'
+        pipeline:
+            -
+                $addFields:
+                    degrees:
+                        $toDouble:
+                            $substrBytes:
+                                - '$temp'
+                                - 0
+                                - 4

--- a/generator/config/expression/toInt.yaml
+++ b/generator/config/expression/toInt.yaml
@@ -12,3 +12,12 @@ arguments:
         name: expression
         type:
             - expression
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/toInt/#example'
+        pipeline:
+            -
+                $addFields:
+                    convertedQty:
+                        $toInt: '$qty'

--- a/generator/config/expression/toLong.yaml
+++ b/generator/config/expression/toLong.yaml
@@ -12,3 +12,15 @@ arguments:
         name: expression
         type:
             - expression
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/toLong/#example'
+        pipeline:
+            -
+                $addFields:
+                    convertedQty:
+                        $toLong: '$qty'
+            -
+                $sort:
+                    convertedQty: -1

--- a/generator/config/expression/toObjectId.yaml
+++ b/generator/config/expression/toObjectId.yaml
@@ -12,3 +12,15 @@ arguments:
         name: expression
         type:
             - expression
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/toObjectId/#example'
+        pipeline:
+            -
+                $addFields:
+                    convertedId:
+                        $toObjectId: '$_id'
+            -
+                $sort:
+                    convertedId: -1

--- a/generator/config/expression/type.yaml
+++ b/generator/config/expression/type.yaml
@@ -11,3 +11,12 @@ arguments:
         name: expression
         type:
             - expression
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/type/#example'
+        pipeline:
+            -
+                $project:
+                    a:
+                        $type: '$a'

--- a/generator/js2yaml.html
+++ b/generator/js2yaml.html
@@ -74,6 +74,18 @@
         return new TaggedValue('bson_binary', value);
     }
 
+    function Decimal128(value) {
+        return new TaggedValue('bson_decimal128', value)
+    }
+
+    function Int32(value) {
+        return parseInt(value);
+    }
+
+    function Int64(value) {
+        return new TaggedValue('bson_int64', value)
+    }
+
     function convert(jsString) {
         try {
             return toYaml(eval(jsString), 1);

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -970,14 +970,13 @@ trait FactoryTrait
      * New in MongoDB 4.4.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/isNumber/
-     * @no-named-arguments
-     * @param ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass ...$expression
+     * @param ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass $expression
      */
     public static function isNumber(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
+        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): IsNumberOperator
     {
-        return new IsNumberOperator(...$expression);
+        return new IsNumberOperator($expression);
     }
 
     /**

--- a/src/Builder/Expression/IsNumberOperator.php
+++ b/src/Builder/Expression/IsNumberOperator.php
@@ -12,10 +12,7 @@ use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
 use MongoDB\Builder\Type\OperatorInterface;
-use MongoDB\Exception\InvalidArgumentException;
 use stdClass;
-
-use function array_is_list;
 
 /**
  * Returns boolean true if the specified expression resolves to an integer, decimal, double, or long.
@@ -28,23 +25,14 @@ class IsNumberOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 
-    /** @var list<ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass> $expression */
-    public readonly array $expression;
+    /** @var ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass $expression */
+    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass ...$expression
-     * @no-named-arguments
+     * @param ExpressionInterface|Type|array|bool|float|int|non-empty-string|null|stdClass $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression)
+    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
-        if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
-        }
-
-        if (! array_is_list($expression)) {
-            throw new InvalidArgumentException('Expected $expression arguments to be a list (array), named arguments are not supported');
-        }
-
         $this->expression = $expression;
     }
 

--- a/tests/Builder/Expression/ConvertOperatorTest.php
+++ b/tests/Builder/Expression/ConvertOperatorTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\BSON\Decimal128;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $convert expression
+ */
+class ConvertOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                convertedPrice: Expression::convert(
+                    input: Expression::fieldPath('price'),
+                    to: 'decimal',
+                    onError: 'Error',
+                    onNull: new Decimal128('0'),
+                ),
+                convertedQty: Expression::convert(
+                    input: Expression::fieldPath('qty'),
+                    to: 'int',
+                    onError: Expression::concat(
+                        'Could not convert ',
+                        Expression::toString(
+                            Expression::fieldPath('qty'),
+                        ),
+                        ' to type integer.',
+                    ),
+                    onNull: 0,
+                ),
+            ),
+            Stage::project(
+                totalPrice: Expression::switch(
+                    branches: [
+                        object(
+                            case: Expression::eq(
+                                Expression::type(
+                                    Expression::fieldPath('convertedPrice'),
+                                ),
+                                'string',
+                            ),
+                            then: 'NaN',
+                        ),
+                        object(
+                            case: Expression::eq(
+                                Expression::type(
+                                    Expression::fieldPath('convertedQty'),
+                                ),
+                                'string',
+                            ),
+                            then: 'NaN',
+                        ),
+                    ],
+                    default: Expression::multiply(
+                        Expression::fieldPath('convertedPrice'),
+                        Expression::fieldPath('convertedQty'),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ConvertExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/IsNumberOperatorTest.php
+++ b/tests/Builder/Expression/IsNumberOperatorTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $isNumber expression
+ */
+class IsNumberOperatorTest extends PipelineTestCase
+{
+    public function testConditionallyModifyFieldsUsingIsNumber(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                points: Expression::cond(
+                    if: Expression::isNumber(
+                        Expression::fieldPath('grade'),
+                    ),
+                    then: Expression::fieldPath('grade'),
+                    else: Expression::switch(
+                        branches: [
+                            object(
+                                case: Expression::eq(
+                                    Expression::fieldPath('grade'),
+                                    'A',
+                                ),
+                                then: 4,
+                            ),
+                            object(
+                                case: Expression::eq(
+                                    Expression::fieldPath('grade'),
+                                    'B',
+                                ),
+                                then: 3,
+                            ),
+                            object(
+                                case: Expression::eq(
+                                    Expression::fieldPath('grade'),
+                                    'C',
+                                ),
+                                then: 2,
+                            ),
+                            object(
+                                case: Expression::eq(
+                                    Expression::fieldPath('grade'),
+                                    'D',
+                                ),
+                                then: 1,
+                            ),
+                            object(
+                                case: Expression::eq(
+                                    Expression::fieldPath('grade'),
+                                    'F',
+                                ),
+                                then: 0,
+                            ),
+                        ],
+                    ),
+                ),
+            ),
+            Stage::group(
+                _id: Expression::fieldPath('student_id'),
+                GPA: Accumulator::avg(
+                    Expression::fieldPath('points'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::IsNumberConditionallyModifyFieldsUsingIsNumber, $pipeline);
+    }
+
+    public function testUseIsNumberToCheckIfAFieldIsNumeric(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                isNumber: Expression::isNumber(
+                    Expression::fieldPath('reading'),
+                ),
+                hasType: Expression::type(
+                    Expression::fieldPath('reading'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::IsNumberUseIsNumberToCheckIfAFieldIsNumeric, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -748,6 +748,86 @@ enum Pipelines: string
     /**
      * Example
      *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/convert/#example
+     */
+    case ConvertExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "convertedPrice": {
+                    "$convert": {
+                        "input": "$price",
+                        "to": "decimal",
+                        "onError": "Error",
+                        "onNull": {
+                            "$numberDecimal": "0"
+                        }
+                    }
+                },
+                "convertedQty": {
+                    "$convert": {
+                        "input": "$qty",
+                        "to": "int",
+                        "onError": {
+                            "$concat": [
+                                "Could not convert ",
+                                {
+                                    "$toString": "$qty"
+                                },
+                                " to type integer."
+                            ]
+                        },
+                        "onNull": {
+                            "$numberInt": "0"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "$project": {
+                "totalPrice": {
+                    "$switch": {
+                        "branches": [
+                            {
+                                "case": {
+                                    "$eq": [
+                                        {
+                                            "$type": "$convertedPrice"
+                                        },
+                                        "string"
+                                    ]
+                                },
+                                "then": "NaN"
+                            },
+                            {
+                                "case": {
+                                    "$eq": [
+                                        {
+                                            "$type": "$convertedQty"
+                                        },
+                                        "string"
+                                    ]
+                                },
+                                "then": "NaN"
+                            }
+                        ],
+                        "default": {
+                            "$multiply": [
+                                "$convertedPrice",
+                                "$convertedQty"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/cos/#example
      */
     case CosExample = <<<'JSON'
@@ -2248,6 +2328,117 @@ enum Pipelines: string
                         },
                         "else": "One or more fields is not an array."
                     }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use $isNumber to Check if a Field is Numeric
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/isNumber/#use--isnumber-to-check-if-a-field-is-numeric
+     */
+    case IsNumberUseIsNumberToCheckIfAFieldIsNumeric = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "isNumber": {
+                    "$isNumber": "$reading"
+                },
+                "hasType": {
+                    "$type": "$reading"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Conditionally Modify Fields using $isNumber
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/isNumber/#conditionally-modify-fields-using--isnumber
+     */
+    case IsNumberConditionallyModifyFieldsUsingIsNumber = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "points": {
+                    "$cond": {
+                        "if": {
+                            "$isNumber": "$grade"
+                        },
+                        "then": "$grade",
+                        "else": {
+                            "$switch": {
+                                "branches": [
+                                    {
+                                        "case": {
+                                            "$eq": [
+                                                "$grade",
+                                                "A"
+                                            ]
+                                        },
+                                        "then": {
+                                            "$numberInt": "4"
+                                        }
+                                    },
+                                    {
+                                        "case": {
+                                            "$eq": [
+                                                "$grade",
+                                                "B"
+                                            ]
+                                        },
+                                        "then": {
+                                            "$numberInt": "3"
+                                        }
+                                    },
+                                    {
+                                        "case": {
+                                            "$eq": [
+                                                "$grade",
+                                                "C"
+                                            ]
+                                        },
+                                        "then": {
+                                            "$numberInt": "2"
+                                        }
+                                    },
+                                    {
+                                        "case": {
+                                            "$eq": [
+                                                "$grade",
+                                                "D"
+                                            ]
+                                        },
+                                        "then": {
+                                            "$numberInt": "1"
+                                        }
+                                    },
+                                    {
+                                        "case": {
+                                            "$eq": [
+                                                "$grade",
+                                                "F"
+                                            ]
+                                        },
+                                        "then": {
+                                            "$numberInt": "0"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "$group": {
+                "_id": "$student_id",
+                "GPA": {
+                    "$avg": "$points"
                 }
             }
         }
@@ -4915,6 +5106,52 @@ enum Pipelines: string
     /**
      * Example
      *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toBool/#example
+     */
+    case ToBoolExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "convertedShippedFlag": {
+                    "$switch": {
+                        "branches": [
+                            {
+                                "case": {
+                                    "$eq": [
+                                        "$shipped",
+                                        "false"
+                                    ]
+                                },
+                                "then": false
+                            },
+                            {
+                                "case": {
+                                    "$eq": [
+                                        "$shipped",
+                                        ""
+                                    ]
+                                },
+                                "then": false
+                            }
+                        ],
+                        "default": {
+                            "$toBool": "$shipped"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "$match": {
+                "convertedShippedFlag": false
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toDate/#example
      */
     case ToDateExample = <<<'JSON'
@@ -4930,6 +5167,50 @@ enum Pipelines: string
             "$sort": {
                 "convertedDate": {
                     "$numberInt": "1"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toDecimal/#example
+     */
+    case ToDecimalExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "convertedPrice": {
+                    "$toDecimal": "$price"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toDouble/#example
+     */
+    case ToDoubleExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "degrees": {
+                    "$toDouble": {
+                        "$substrBytes": [
+                            "$temp",
+                            {
+                                "$numberInt": "0"
+                            },
+                            {
+                                "$numberInt": "4"
+                            }
+                        ]
+                    }
                 }
             }
         }
@@ -4963,6 +5244,47 @@ enum Pipelines: string
     /**
      * Example
      *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toInt/#example
+     */
+    case ToIntExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "convertedQty": {
+                    "$toInt": "$qty"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toLong/#example
+     */
+    case ToLongExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "convertedQty": {
+                    "$toLong": "$qty"
+                }
+            }
+        },
+        {
+            "$sort": {
+                "convertedQty": {
+                    "$numberInt": "-1"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toLower/#example
      */
     case ToLowerExample = <<<'JSON'
@@ -4974,6 +5296,30 @@ enum Pipelines: string
                 },
                 "description": {
                     "$toLower": "$description"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toObjectId/#example
+     */
+    case ToObjectIdExample = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "convertedId": {
+                    "$toObjectId": "$_id"
+                }
+            }
+        },
+        {
+            "$sort": {
+                "convertedId": {
+                    "$numberInt": "-1"
                 }
             }
         }
@@ -5134,6 +5480,23 @@ enum Pipelines: string
             "$addFields": {
                 "clusterTimeSeconds": {
                     "$tsSecond": "$clusterTime"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/type/#example
+     */
+    case TypeExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "a": {
+                    "$type": "$a"
                 }
             }
         }

--- a/tests/Builder/Expression/ToBoolOperatorTest.php
+++ b/tests/Builder/Expression/ToBoolOperatorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $toBool expression
+ */
+class ToBoolOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                convertedShippedFlag: Expression::switch(
+                    branches: [
+                        object(
+                            case: Expression::eq(
+                                Expression::fieldPath('shipped'),
+                                'false',
+                            ),
+                            then: false,
+                        ),
+                        object(
+                            case: Expression::eq(
+                                Expression::fieldPath('shipped'),
+                                '',
+                            ),
+                            then: false,
+                        ),
+                    ],
+                    default: Expression::toBool(
+                        Expression::fieldPath('shipped'),
+                    ),
+                ),
+            ),
+            Stage::match(
+                convertedShippedFlag: false,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ToBoolExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/ToDecimalOperatorTest.php
+++ b/tests/Builder/Expression/ToDecimalOperatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $toDecimal expression
+ */
+class ToDecimalOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                convertedPrice: Expression::toDecimal(
+                    Expression::fieldPath('price'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ToDecimalExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/ToDoubleOperatorTest.php
+++ b/tests/Builder/Expression/ToDoubleOperatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $toDouble expression
+ */
+class ToDoubleOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                degrees: Expression::toDouble(
+                    Expression::substrBytes(
+                        Expression::stringFieldPath('temp'),
+                        0,
+                        4,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ToDoubleExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/ToIntOperatorTest.php
+++ b/tests/Builder/Expression/ToIntOperatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $toInt expression
+ */
+class ToIntOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                convertedQty: Expression::toInt(
+                    Expression::fieldPath('qty'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ToIntExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/ToLongOperatorTest.php
+++ b/tests/Builder/Expression/ToLongOperatorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $toLong expression
+ */
+class ToLongOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                convertedQty: Expression::toLong(
+                    Expression::fieldPath('qty'),
+                ),
+            ),
+            Stage::sort(
+                object(
+                    convertedQty: -1,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ToLongExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/ToObjectIdOperatorTest.php
+++ b/tests/Builder/Expression/ToObjectIdOperatorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $toObjectId expression
+ */
+class ToObjectIdOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                convertedId: Expression::toObjectId(
+                    Expression::fieldPath('_id'),
+                ),
+            ),
+            Stage::sort(
+                object(
+                    convertedId: -1,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ToObjectIdExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/TypeOperatorTest.php
+++ b/tests/Builder/Expression/TypeOperatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $type expression
+ */
+class TypeOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                a: Expression::type(
+                    Expression::fieldPath('a'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TypeExample, $pipeline);
+    }
+}


### PR DESCRIPTION
Fix [PHPLIB-1358](https://jira.mongodb.org/browse/PHPLIB-1358)

https://www.mongodb.com/docs/manual/reference/operator/aggregation/#type-expression-operators

- `$convert`
- `$isNumber` fixed, as it get a single value
- `$toBool`
- ~`$toDate`~ already done
- `$toDecimal`
- `$toDouble`
- `$toInt`
- `$toLong`
- `$toObjectId`
- ~`$toString`~ already done
- `$type`