### PR TITLE
PHPLIB-1342 Add tests on Arithmetic Expression Operators

### DIFF
--- a/generator/config/expression/abs.yaml
+++ b/generator/config/expression/abs.yaml
@@ -11,3 +11,15 @@ arguments:
         name: value
         type:
             - resolvesToNumber
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/abs/#example'
+        pipeline:
+            -
+                $project:
+                    delta:
+                        $abs:
+                            $subtract:
+                                - '$startTemp'
+                                - '$endTemp'

--- a/generator/config/expression/ceil.yaml
+++ b/generator/config/expression/ceil.yaml
@@ -13,3 +13,13 @@ arguments:
             - resolvesToNumber
         description: |
             If the argument resolves to a value of null or refers to a field that is missing, $ceil returns null. If the argument resolves to NaN, $ceil returns NaN.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/ceil/#example'
+        pipeline:
+            -
+                $project:
+                    value: 1
+                    ceilingValue:
+                        $ceil: '$value'

--- a/generator/config/expression/divide.yaml
+++ b/generator/config/expression/divide.yaml
@@ -17,3 +17,15 @@ arguments:
         name: divisor
         type:
             - resolvesToNumber
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/divide/#example'
+        pipeline:
+            -
+                $project:
+                    city: 1
+                    workdays:
+                        $divide:
+                            - '$hours'
+                            - 8

--- a/generator/config/expression/exp.yaml
+++ b/generator/config/expression/exp.yaml
@@ -11,3 +11,15 @@ arguments:
         name: exponent
         type:
             - resolvesToNumber
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/exp/#example'
+        pipeline:
+            -
+                $project:
+                    effectiveRate:
+                        $subtract:
+                            -
+                                $exp: '$interestRate'
+                            - 1

--- a/generator/config/expression/floor.yaml
+++ b/generator/config/expression/floor.yaml
@@ -11,3 +11,13 @@ arguments:
         name: expression
         type:
             - resolvesToNumber
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/floor/#example'
+        pipeline:
+            -
+                $project:
+                    value: 1
+                    floorValue:
+                        $floor: '$value'

--- a/generator/config/expression/ln.yaml
+++ b/generator/config/expression/ln.yaml
@@ -14,3 +14,13 @@ arguments:
             - resolvesToNumber
         description: |
             Any valid expression as long as it resolves to a non-negative number. For more information on expressions, see Expressions.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/ln/#example'
+        pipeline:
+            -
+                $project:
+                    x: '$year'
+                    y:
+                        $ln: '$sales'

--- a/generator/config/expression/log.yaml
+++ b/generator/config/expression/log.yaml
@@ -19,3 +19,18 @@ arguments:
             - resolvesToNumber
         description: |
             Any valid expression as long as it resolves to a positive number greater than 1.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/log/#example'
+        pipeline:
+            -
+                $project:
+                    bitsNeeded:
+                        $floor:
+                            $add:
+                                - 1
+                                -
+                                    $log:
+                                        - '$int'
+                                        - 2

--- a/generator/config/expression/log10.yaml
+++ b/generator/config/expression/log10.yaml
@@ -13,3 +13,15 @@ arguments:
             - resolvesToNumber
         description: |
             Any valid expression as long as it resolves to a non-negative number.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/log10/#example'
+        pipeline:
+            -
+                $project:
+                    pH:
+                        $multiply:
+                            - -1
+                            -
+                                $log10: '$H3O'

--- a/generator/config/expression/mod.yaml
+++ b/generator/config/expression/mod.yaml
@@ -17,3 +17,14 @@ arguments:
         name: divisor
         type:
             - resolvesToNumber
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/mod/#example'
+        pipeline:
+            -
+                $project:
+                    remainder:
+                        $mod:
+                            - '$hours'
+                            - '$tasks'

--- a/generator/config/expression/multiply.yaml
+++ b/generator/config/expression/multiply.yaml
@@ -15,3 +15,16 @@ arguments:
         description: |
             The arguments can be any valid expression as long as they resolve to numbers.
             Starting in MongoDB 6.1 you can optimize the $multiply operation. To improve performance, group references at the end of the argument list.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/multiply/#example'
+        pipeline:
+            -
+                $project:
+                    date: 1
+                    item: 1
+                    total:
+                        $multiply:
+                            - '$price'
+                            - '$quantity'

--- a/generator/config/expression/pow.yaml
+++ b/generator/config/expression/pow.yaml
@@ -15,3 +15,17 @@ arguments:
         name: exponent
         type:
             - resolvesToNumber
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/pow/#example'
+        pipeline:
+            -
+                $project:
+                    variance:
+                        $pow:
+                            -
+                                # The builder renders $stdDevPop with the array form, even with a single value
+                                # $stdDevPop: '$scores.score'
+                                $stdDevPop: ['$scores.score']
+                            - 2

--- a/generator/config/expression/round.yaml
+++ b/generator/config/expression/round.yaml
@@ -27,3 +27,14 @@ arguments:
         optional: true
         description: |
             Can be any valid expression that resolves to an integer between -20 and 100, exclusive.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/round/#example'
+        pipeline:
+            -
+                $project:
+                    roundedValue:
+                        $round:
+                            - '$value'
+                            - 1

--- a/generator/config/expression/sqrt.yaml
+++ b/generator/config/expression/sqrt.yaml
@@ -13,3 +13,27 @@ arguments:
             - resolvesToNumber
         description: |
             The argument can be any valid expression as long as it resolves to a non-negative number.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/sqrt/#example'
+        pipeline:
+            -
+                $project:
+                    distance:
+                        $sqrt:
+                            $add:
+                                -
+                                    $pow:
+                                        -
+                                            $subtract:
+                                                - '$p2.y'
+                                                - '$p1.y'
+                                        - 2
+                                -
+                                    $pow:
+                                        -
+                                            $subtract:
+                                                - '$p2.x'
+                                                - '$p1.x'
+                                        - 2

--- a/generator/config/expression/trunc.yaml
+++ b/generator/config/expression/trunc.yaml
@@ -21,3 +21,14 @@ arguments:
         optional: true
         description: |
             Can be any valid expression that resolves to an integer between -20 and 100, exclusive. e.g. -20 < place < 100. Defaults to 0.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/trunc/#example'
+        pipeline:
+            -
+                $project:
+                    truncatedValue:
+                        $trunc:
+                            - '$value'
+                            - 1

--- a/tests/Builder/Expression/AbsOperatorTest.php
+++ b/tests/Builder/Expression/AbsOperatorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $abs expression
+ */
+class AbsOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                delta: Expression::abs(
+                    Expression::subtract(
+                        Expression::numberFieldPath('startTemp'),
+                        Expression::numberFieldPath('endTemp'),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::AbsExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/CeilOperatorTest.php
+++ b/tests/Builder/Expression/CeilOperatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $ceil expression
+ */
+class CeilOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                value: 1,
+                ceilingValue: Expression::ceil(
+                    Expression::numberFieldPath('value'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::CeilExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/DivideOperatorTest.php
+++ b/tests/Builder/Expression/DivideOperatorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $divide expression
+ */
+class DivideOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                city: 1,
+                workdays: Expression::divide(
+                    Expression::numberFieldPath('hours'),
+                    8,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DivideExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/ExpOperatorTest.php
+++ b/tests/Builder/Expression/ExpOperatorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $exp expression
+ */
+class ExpOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                effectiveRate: Expression::subtract(
+                    Expression::exp(
+                        Expression::numberFieldPath('interestRate'),
+                    ),
+                    1,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ExpExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/FloorOperatorTest.php
+++ b/tests/Builder/Expression/FloorOperatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $floor expression
+ */
+class FloorOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                value: 1,
+                floorValue: Expression::floor(
+                    Expression::numberFieldPath('value'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::FloorExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/LnOperatorTest.php
+++ b/tests/Builder/Expression/LnOperatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $ln expression
+ */
+class LnOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                x: Expression::numberFieldPath('year'),
+                y: Expression::ln(
+                    Expression::numberFieldPath('sales'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::LnExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/Log10OperatorTest.php
+++ b/tests/Builder/Expression/Log10OperatorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $log10 expression
+ */
+class Log10OperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                pH: Expression::multiply(
+                    -1,
+                    Expression::log10(
+                        Expression::numberFieldPath('H3O'),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::Log10Example, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/LogOperatorTest.php
+++ b/tests/Builder/Expression/LogOperatorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $log expression
+ */
+class LogOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                bitsNeeded: Expression::floor(
+                    Expression::add(
+                        1,
+                        Expression::log(
+                            Expression::intFieldPath('int'),
+                            2,
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::LogExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/ModOperatorTest.php
+++ b/tests/Builder/Expression/ModOperatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $mod expression
+ */
+class ModOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                remainder: Expression::mod(
+                    Expression::intFieldPath('hours'),
+                    Expression::intFieldPath('tasks'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ModExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/MultiplyOperatorTest.php
+++ b/tests/Builder/Expression/MultiplyOperatorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $multiply expression
+ */
+class MultiplyOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                date: 1,
+                item: 1,
+                total: Expression::multiply(
+                    Expression::intFieldPath('price'),
+                    Expression::intFieldPath('quantity'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MultiplyExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -13,6 +13,28 @@ enum Pipelines: string
     /**
      * Example
      *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/abs/#example
+     */
+    case AbsExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "delta": {
+                    "$abs": {
+                        "$subtract": [
+                            "$startTemp",
+                            "$endTemp"
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/acos/#example
      */
     case AcosExample = <<<'JSON'
@@ -633,6 +655,26 @@ enum Pipelines: string
         {
             "$limit": {
                 "$numberInt": "1"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/ceil/#example
+     */
+    case CeilExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "value": {
+                    "$numberInt": "1"
+                },
+                "ceilingValue": {
+                    "$ceil": "$value"
+                }
             }
         }
     ]
@@ -1713,6 +1755,31 @@ enum Pipelines: string
     /**
      * Example
      *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/divide/#example
+     */
+    case DivideExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "city": {
+                    "$numberInt": "1"
+                },
+                "workdays": {
+                    "$divide": [
+                        "$hours",
+                        {
+                            "$numberInt": "8"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/eq/#example
      */
     case EqExample = <<<'JSON'
@@ -1735,6 +1802,30 @@ enum Pipelines: string
                 },
                 "_id": {
                     "$numberInt": "0"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/exp/#example
+     */
+    case ExpExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "effectiveRate": {
+                    "$subtract": [
+                        {
+                            "$exp": "$interestRate"
+                        },
+                        {
+                            "$numberInt": "1"
+                        }
+                    ]
                 }
             }
         }
@@ -1933,6 +2024,26 @@ enum Pipelines: string
                             "$numberInt": "3"
                         }
                     }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/floor/#example
+     */
+    case FloorExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "value": {
+                    "$numberInt": "1"
+                },
+                "floorValue": {
+                    "$floor": "$value"
                 }
             }
         }
@@ -2633,6 +2744,79 @@ enum Pipelines: string
     /**
      * Example
      *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/ln/#example
+     */
+    case LnExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "x": "$year",
+                "y": {
+                    "$ln": "$sales"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/log/#example
+     */
+    case LogExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "bitsNeeded": {
+                    "$floor": {
+                        "$add": [
+                            {
+                                "$numberInt": "1"
+                            },
+                            {
+                                "$log": [
+                                    "$int",
+                                    {
+                                        "$numberInt": "2"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/log10/#example
+     */
+    case Log10Example = <<<'JSON'
+    [
+        {
+            "$project": {
+                "pH": {
+                    "$multiply": [
+                        {
+                            "$numberInt": "-1"
+                        },
+                        {
+                            "$log10": "$H3O"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/lt/#example
      */
     case LtExample = <<<'JSON'
@@ -3020,6 +3204,26 @@ enum Pipelines: string
     /**
      * Example
      *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/mod/#example
+     */
+    case ModExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "remainder": {
+                    "$mod": [
+                        "$hours",
+                        "$tasks"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/month/#example
      */
     case MonthExample = <<<'JSON'
@@ -3030,6 +3234,32 @@ enum Pipelines: string
                     "$month": {
                         "date": "$date"
                     }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/multiply/#example
+     */
+    case MultiplyExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "date": {
+                    "$numberInt": "1"
+                },
+                "item": {
+                    "$numberInt": "1"
+                },
+                "total": {
+                    "$multiply": [
+                        "$price",
+                        "$quantity"
+                    ]
                 }
             }
         }
@@ -3215,6 +3445,32 @@ enum Pipelines: string
                         ],
                         "method": "approximate"
                     }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/pow/#example
+     */
+    case PowExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "variance": {
+                    "$pow": [
+                        {
+                            "$stdDevPop": [
+                                "$scores.score"
+                            ]
+                        },
+                        {
+                            "$numberInt": "2"
+                        }
+                    ]
                 }
             }
         }
@@ -3940,6 +4196,28 @@ enum Pipelines: string
     /**
      * Example
      *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/round/#example
+     */
+    case RoundExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "roundedValue": {
+                    "$round": [
+                        "$value",
+                        {
+                            "$numberInt": "1"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/rtrim/#example
      */
     case RtrimExample = <<<'JSON'
@@ -4637,6 +4915,52 @@ enum Pipelines: string
             "$sort": {
                 "total_qty": {
                     "$numberInt": "-1"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sqrt/#example
+     */
+    case SqrtExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "distance": {
+                    "$sqrt": {
+                        "$add": [
+                            {
+                                "$pow": [
+                                    {
+                                        "$subtract": [
+                                            "$p2.y",
+                                            "$p1.y"
+                                        ]
+                                    },
+                                    {
+                                        "$numberInt": "2"
+                                    }
+                                ]
+                            },
+                            {
+                                "$pow": [
+                                    {
+                                        "$subtract": [
+                                            "$p2.x",
+                                            "$p1.x"
+                                        ]
+                                    },
+                                    {
+                                        "$numberInt": "2"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
                 }
             }
         }
@@ -5429,6 +5753,28 @@ enum Pipelines: string
                     "$trim": {
                         "input": "$description"
                     }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/trunc/#example
+     */
+    case TruncExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "truncatedValue": {
+                    "$trunc": [
+                        "$value",
+                        {
+                            "$numberInt": "1"
+                        }
+                    ]
                 }
             }
         }

--- a/tests/Builder/Expression/PowOperatorTest.php
+++ b/tests/Builder/Expression/PowOperatorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $pow expression
+ */
+class PowOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                variance: Expression::pow(
+                    Expression::stdDevPop(
+                        Expression::intFieldPath('scores.score'),
+                    ),
+                    2,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::PowExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/RoundOperatorTest.php
+++ b/tests/Builder/Expression/RoundOperatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $round expression
+ */
+class RoundOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                roundedValue: Expression::round(
+                    Expression::intFieldPath('value'),
+                    1,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::RoundExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/SqrtOperatorTest.php
+++ b/tests/Builder/Expression/SqrtOperatorTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $sqrt expression
+ */
+class SqrtOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                distance: Expression::sqrt(
+                    Expression::add(
+                        Expression::pow(
+                            Expression::subtract(
+                                Expression::numberFieldPath('p2.y'),
+                                Expression::numberFieldPath('p1.y'),
+                            ),
+                            2,
+                        ),
+                        Expression::pow(
+                            Expression::subtract(
+                                Expression::numberFieldPath('p2.x'),
+                                Expression::numberFieldPath('p1.x'),
+                            ),
+                            2,
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SqrtExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/TruncOperatorTest.php
+++ b/tests/Builder/Expression/TruncOperatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $trunc expression
+ */
+class TruncOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                truncatedValue: Expression::trunc(
+                    Expression::numberFieldPath('value'),
+                    1,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TruncExample, $pipeline);
+    }
+}


### PR DESCRIPTION
Fix [PHPLIB-1342](https://jira.mongodb.org/browse/PHPLIB-1342)

https://www.mongodb.com/docs/manual/reference/operator/aggregation/#arithmetic-expression-operators

- `$abs`
- ~`$add`~
- `$ceil`
- `$divide`
- `$exp`
- `$floor`
- `$ln`
- `$log`
- `$log10`
- `$mod`
- `$multiply`
- `$pow`
- `$round`
- `$sqrt`
- ~`$subtract`~
- `$trunc`

Nothing special