### PR TITLE
PHPLIB-1341 Add tests on Miscellaneous Query Operators

### DIFF
--- a/generator/config/query/comment.yaml
+++ b/generator/config/query/comment.yaml
@@ -11,3 +11,21 @@ arguments:
         name: comment
         type:
             - string
+tests:
+    -
+        name: 'Attach a Comment to an Aggregation Expression'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/comment/#attach-a-comment-to-an-aggregation-expression'
+        pipeline:
+            -
+                $match:
+                    x:
+                        $gt: 0
+                    $comment: 'Don''t allow negative inputs.'
+            -
+                $group:
+                    _id:
+                        $mod:
+                            - '$x'
+                            - 2
+                    total:
+                        $sum: '$x'

--- a/generator/config/query/rand.yaml
+++ b/generator/config/query/rand.yaml
@@ -6,3 +6,21 @@ type:
 encode: object
 description: |
     Generates a random float between 0 and 1.
+tests:
+    -
+        name: 'Select Random Items From a Collection'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/query/rand/#select-random-items-from-a-collection'
+        pipeline:
+            -
+                $match:
+                    district: 3
+                    $expr:
+                        $lt:
+                            - 0.5
+                            -
+                                $rand: {}
+            -
+                $project:
+                    _id: 0
+                    name: 1
+                    registered: 1

--- a/generator/js2yaml.html
+++ b/generator/js2yaml.html
@@ -124,7 +124,7 @@
             case 'boolean':
                 return object ? ' true' : ' false';
             case 'string':
-                return " '" + object.replace(/'/g, "\\'") + "'";
+                return " '" + object.replace(/'/g, "''") + "'";
             case 'number':
                 return ' ' + object.toString();
             case 'object':

--- a/tests/Builder/Query/CommentOperatorTest.php
+++ b/tests/Builder/Query/CommentOperatorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $comment query
+ */
+class CommentOperatorTest extends PipelineTestCase
+{
+    public function testAttachACommentToAnAggregationExpression(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::comment('Don\'t allow negative inputs.'),
+                x: Query::gt(0),
+            ),
+            Stage::group(
+                _id: Expression::mod(
+                    Expression::numberFieldPath('x'),
+                    2,
+                ),
+                total: Accumulator::sum(
+                    Expression::numberFieldPath('x'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::CommentAttachACommentToAnAggregationExpression, $pipeline);
+    }
+}

--- a/tests/Builder/Query/Pipelines.php
+++ b/tests/Builder/Query/Pipelines.php
@@ -404,6 +404,41 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Attach a Comment to an Aggregation Expression
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/comment/#attach-a-comment-to-an-aggregation-expression
+     */
+    case CommentAttachACommentToAnAggregationExpression = <<<'JSON'
+    [
+        {
+            "$match": {
+                "x": {
+                    "$gt": {
+                        "$numberInt": "0"
+                    }
+                },
+                "$comment": "Don't allow negative inputs."
+            }
+        },
+        {
+            "$group": {
+                "_id": {
+                    "$mod": [
+                        "$x",
+                        {
+                            "$numberInt": "2"
+                        }
+                    ]
+                },
+                "total": {
+                    "$sum": "$x"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Element Match
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/elemMatch/#element-match
@@ -1573,6 +1608,46 @@ enum Pipelines: string
                         }
                     }
                 ]
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Select Random Items From a Collection
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/query/rand/#select-random-items-from-a-collection
+     */
+    case RandSelectRandomItemsFromACollection = <<<'JSON'
+    [
+        {
+            "$match": {
+                "district": {
+                    "$numberInt": "3"
+                },
+                "$expr": {
+                    "$lt": [
+                        {
+                            "$numberDouble": "0.5"
+                        },
+                        {
+                            "$rand": {}
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "name": {
+                    "$numberInt": "1"
+                },
+                "registered": {
+                    "$numberInt": "1"
+                }
             }
         }
     ]

--- a/tests/Builder/Query/RandOperatorTest.php
+++ b/tests/Builder/Query/RandOperatorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Query;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $rand query
+ */
+class RandOperatorTest extends PipelineTestCase
+{
+    public function testSelectRandomItemsFromACollection(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::expr(
+                    Expression::lt(
+                        0.5,
+                        Expression::rand(),
+                    ),
+                ),
+                district: 3,
+            ),
+            Stage::project(
+                _id: 0,
+                name: 1,
+                registered: 1,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::RandSelectRandomItemsFromACollection, $pipeline);
+    }
+}


### PR DESCRIPTION
Fix [PHPLIB-1341](https://jira.mongodb.org/browse/PHPLIB-1341)

https://www.mongodb.com/docs/manual/reference/operator/query/#miscellaneous-operators

- `$comment`
- `$rand`