### PR TITLE
PHPLIB-1361 Add test on `$let` expression operator

### DIFF
--- a/generator/config/expression/let.yaml
+++ b/generator/config/expression/let.yaml
@@ -21,3 +21,26 @@ arguments:
             - expression
         description: |
             The expression to evaluate.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/let/#example'
+        pipeline:
+            -
+                $project:
+                    finalTotal:
+                        $let:
+                            vars:
+                                total:
+                                    $add:
+                                        - '$price'
+                                        - '$tax'
+                                discounted:
+                                    $cond:
+                                        if: '$applyDiscount'
+                                        then: 0.9
+                                        else: 1
+                            in:
+                                $multiply:
+                                    - '$$total'
+                                    - '$$discounted'

--- a/tests/Builder/Expression/LetOperatorTest.php
+++ b/tests/Builder/Expression/LetOperatorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $let expression
+ */
+class LetOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                finalTotal: Expression::let(
+                    vars: object(
+                        total: Expression::add(
+                            Expression::numberFieldPath('price'),
+                            Expression::numberFieldPath('tax'),
+                        ),
+                        discounted: Expression::cond(
+                            if: Expression::boolFieldPath('applyDiscount'),
+                            then: 0.9,
+                            else: 1,
+                        ),
+                    ),
+                    in: Expression::multiply(
+                        Expression::variable('total'),
+                        Expression::variable('discounted'),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::LetExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -2590,6 +2590,49 @@ enum Pipelines: string
     /**
      * Example
      *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/let/#example
+     */
+    case LetExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "finalTotal": {
+                    "$let": {
+                        "vars": {
+                            "total": {
+                                "$add": [
+                                    "$price",
+                                    "$tax"
+                                ]
+                            },
+                            "discounted": {
+                                "$cond": {
+                                    "if": "$applyDiscount",
+                                    "then": {
+                                        "$numberDouble": "0.9000000000000000222"
+                                    },
+                                    "else": {
+                                        "$numberInt": "1"
+                                    }
+                                }
+                            }
+                        },
+                        "in": {
+                            "$multiply": [
+                                "$$total",
+                                "$$discounted"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/lt/#example
      */
     case LtExample = <<<'JSON'


### PR DESCRIPTION
Fix [PHPLIB-1361](https://jira.mongodb.org/browse/PHPLIB-1361)

https://www.mongodb.com/docs/manual/reference/operator/aggregation/#variable-expression-operators

- `$let`