### PR TITLE
PHPLIB-1374 Add tests on all stages

### DIFF
--- a/generator/config/accumulator/covariancePop.yaml
+++ b/generator/config/accumulator/covariancePop.yaml
@@ -30,6 +30,7 @@ tests:
                         covariancePopForState:
                             $covariancePop:
                                 -
+                                    # Example uses the short form, the builder always generates the verbose form
                                     # $year: '$orderDate'
                                     $year:
                                         date: '$orderDate'

--- a/generator/config/accumulator/covarianceSamp.yaml
+++ b/generator/config/accumulator/covarianceSamp.yaml
@@ -30,6 +30,7 @@ tests:
                         covarianceSampForState:
                             $covarianceSamp:
                                 -
+                                    # Example uses the short form, the builder always generates the verbose form
                                     # $year: '$orderDate'
                                     $year:
                                         date: '$orderDate'

--- a/generator/config/accumulator/push.yaml
+++ b/generator/config/accumulator/push.yaml
@@ -26,10 +26,12 @@ tests:
                 $group:
                     _id:
                         day:
+                            # Example uses the short form, the builder always generates the verbose form
                             # $dayOfYear: '$date'
                             $dayOfYear:
                                 date: '$date'
                         year:
+                            # Example uses the short form, the builder always generates the verbose form
                             # $year: '$date'
                             $year:
                                 date: '$date'

--- a/generator/config/accumulator/sum.yaml
+++ b/generator/config/accumulator/sum.yaml
@@ -22,10 +22,12 @@ tests:
                 $group:
                     _id:
                         day:
+                            # Example uses the short form, the builder always generates the verbose form
                             # $dayOfYear: '$date'
                             $dayOfYear:
                                 date: '$date'
                         year:
+                            # Example uses the short form, the builder always generates the verbose form
                             # $year: '$date'
                             $year:
                                 date: '$date'

--- a/generator/config/expression/arrayToObject.yaml
+++ b/generator/config/expression/arrayToObject.yaml
@@ -20,7 +20,7 @@ tests:
                 $project:
                     item: 1
                     dimensions:
-                        # The example renders a single value, but the builder generates an array for consistency
+                        # Example uses the short form, the builder always generates the verbose form
                         # $arrayToObject: '$dimensions'
                         $arrayToObject:
                             - '$dimensions'

--- a/generator/config/expression/avg.yaml
+++ b/generator/config/expression/avg.yaml
@@ -21,6 +21,7 @@ tests:
             -
                 $project:
                     quizAvg:
+                        # Example uses the short form, the builder always generates the verbose form
                         # $avg: '$quizzes'
                         $avg:
                             - '$quizzes'

--- a/generator/config/expression/dateAdd.yaml
+++ b/generator/config/expression/dateAdd.yaml
@@ -46,6 +46,7 @@ tests:
                             unit: 'day'
                             amount: 3
             -
+                # Example uses the short form, the builder always generates the verbose form
                 # $merge: 'shipping'
                 $merge:
                     into: 'shipping'

--- a/generator/config/expression/dateFromString.yaml
+++ b/generator/config/expression/dateFromString.yaml
@@ -76,6 +76,5 @@ tests:
                         $dateFromString:
                             dateString: '$date'
                             timezone: '$timezone'
-                            # onNull: new Date(0)
                             onNull: !bson_utcdatetime 0
 

--- a/generator/config/expression/dateSubtract.yaml
+++ b/generator/config/expression/dateSubtract.yaml
@@ -43,6 +43,7 @@ tests:
                     $expr:
                         $eq:
                             -
+                                # Example uses the short form, the builder always generates the verbose form
                                 # $month: '$logout'
                                 $month:
                                     date: '$logout'
@@ -55,6 +56,7 @@ tests:
                             unit: 'hour'
                             amount: 3
             -
+                # Example uses the short form, the builder always generates the verbose form
                 # $merge: 'connectionTime'
                 $merge:
                     into: 'connectionTime'

--- a/generator/config/expression/dayOfMonth.yaml
+++ b/generator/config/expression/dayOfMonth.yaml
@@ -30,6 +30,7 @@ tests:
             -
                 $project:
                     day:
+                        # Example uses the short form, the builder always generates the verbose form
                         # $dayOfMonth: '$date'
                         $dayOfMonth:
                             date: '$date'

--- a/generator/config/expression/dayOfWeek.yaml
+++ b/generator/config/expression/dayOfWeek.yaml
@@ -30,6 +30,7 @@ tests:
             -
                 $project:
                     dayOfWeek:
+                        # Example uses the short form, the builder always generates the verbose form
                         # $dayOfWeek: '$date'
                         $dayOfWeek:
                             date: '$date'

--- a/generator/config/expression/dayOfYear.yaml
+++ b/generator/config/expression/dayOfYear.yaml
@@ -30,6 +30,7 @@ tests:
             -
                 $project:
                     dayOfYear:
+                        # Example uses the short form, the builder always generates the verbose form
                         # $dayOfYear: '$date'
                         $dayOfYear:
                             date: '$date'

--- a/generator/config/expression/getField.yaml
+++ b/generator/config/expression/getField.yaml
@@ -33,7 +33,7 @@ tests:
                     $expr:
                         $gt:
                             -
-                                # the builder uses the verbose form with parameter names
+                                # Example uses the short form, the builder always generates the verbose form
                                 # $getField: 'price.usd'
                                 $getField:
                                     field: 'price.usd'
@@ -48,7 +48,7 @@ tests:
                         $gt:
                             -
                                 $getField:
-                                    # the builder uses the verbose form with parameter names
+                                    # Example uses the short form, the builder always generates the verbose form
                                     # $literal: '$price'
                                     field:
                                         $literal: '$price'

--- a/generator/config/expression/hour.yaml
+++ b/generator/config/expression/hour.yaml
@@ -30,6 +30,7 @@ tests:
             -
                 $project:
                     hour:
+                        # Example uses the short form, the builder always generates the verbose form
                         # $hour: '$date'
                         $hour:
                             date: '$date'

--- a/generator/config/expression/isArray.yaml
+++ b/generator/config/expression/isArray.yaml
@@ -22,8 +22,7 @@ tests:
                         $cond:
                             if:
                                 $and:
-                                    # The example in the docs uses the short syntax for $isArray,
-                                    # but the aggregation builder always uses the more verbose syntax.
+                                    # Example uses the short form, the builder always generates the verbose form
                                     -
                                         $isArray:
                                             - '$instock'

--- a/generator/config/expression/isoDayOfWeek.yaml
+++ b/generator/config/expression/isoDayOfWeek.yaml
@@ -32,6 +32,7 @@ tests:
                     _id: 0
                     name: '$name'
                     dayOfWeek:
+                        # Example uses the short form, the builder always generates the verbose form
                         # $isoDayOfWeek: '$birthday'
                         $isoDayOfWeek:
                             date: '$birthday'

--- a/generator/config/expression/isoWeek.yaml
+++ b/generator/config/expression/isoWeek.yaml
@@ -32,6 +32,7 @@ tests:
                     _id: 0
                     city: '$city'
                     weekNumber:
+                        # Example uses the short form, the builder always generates the verbose form
                         # $isoWeek: '$date'
                         $isoWeek:
                             date: '$date'

--- a/generator/config/expression/isoWeekYear.yaml
+++ b/generator/config/expression/isoWeekYear.yaml
@@ -30,6 +30,7 @@ tests:
             -
                 $project:
                     yearNumber:
+                        # Example uses the short form, the builder always generates the verbose form
                         # $isoWeekYear: '$date'
                         $isoWeekYear:
                             date: '$date'

--- a/generator/config/expression/map.yaml
+++ b/generator/config/expression/map.yaml
@@ -53,7 +53,7 @@ tests:
                             input: '$distances'
                             as: 'decimalValue'
                             in:
-                                # The example renders a single value, but the builder generates an array for consistency
+                                # Example uses the short form, the builder always generates the verbose form
                                 # $trunc: '$$decimalValue'
                                 $trunc:
                                     - '$$decimalValue'

--- a/generator/config/expression/max.yaml
+++ b/generator/config/expression/max.yaml
@@ -21,6 +21,7 @@ tests:
             -
                 $project:
                     quizMax:
+                        # Example uses the short form, the builder always generates the verbose form
                         # $max: '$quizzes'
                         $max:
                             - '$quizzes'

--- a/generator/config/expression/millisecond.yaml
+++ b/generator/config/expression/millisecond.yaml
@@ -30,6 +30,7 @@ tests:
             -
                 $project:
                     milliseconds:
+                        # Example uses the short form, the builder always generates the verbose form
                         # $millisecond: '$date'
                         $millisecond:
                             date: '$date'

--- a/generator/config/expression/min.yaml
+++ b/generator/config/expression/min.yaml
@@ -21,6 +21,7 @@ tests:
             -
                 $project:
                     quizMin:
+                        # Example uses the short form, the builder always generates the verbose form
                         # $min: '$quizzes'
                         $min:
                             - '$quizzes'

--- a/generator/config/expression/minute.yaml
+++ b/generator/config/expression/minute.yaml
@@ -30,6 +30,7 @@ tests:
             -
                 $project:
                     minutes:
+                        # Example uses the short form, the builder always generates the verbose form
                         # $minute: '$date'
                         $minute:
                             date: '$date'

--- a/generator/config/expression/month.yaml
+++ b/generator/config/expression/month.yaml
@@ -30,6 +30,7 @@ tests:
             -
                 $project:
                     month:
+                        # Example uses the short form, the builder always generates the verbose form
                         # $month: '$date'
                         $month:
                             date: '$date'

--- a/generator/config/expression/objectToArray.yaml
+++ b/generator/config/expression/objectToArray.yaml
@@ -33,8 +33,7 @@ tests:
                     warehouses:
                         $objectToArray: '$instock'
             -
-                # The example in the docs uses the short syntax for $unwind,
-                # but the aggregation builder always uses the more verbose syntax.
+                # The builder uses the verbose form of the $unwind operator
                 # $unwind: '$warehouses'
                 $unwind:
                     path: '$warehouses'

--- a/generator/config/expression/objectToArray.yaml
+++ b/generator/config/expression/objectToArray.yaml
@@ -33,7 +33,7 @@ tests:
                     warehouses:
                         $objectToArray: '$instock'
             -
-                # The builder uses the verbose form of the $unwind operator
+                # Example uses the short form, the builder always generates the verbose form
                 # $unwind: '$warehouses'
                 $unwind:
                     path: '$warehouses'

--- a/generator/config/expression/pow.yaml
+++ b/generator/config/expression/pow.yaml
@@ -25,7 +25,7 @@ tests:
                     variance:
                         $pow:
                             -
-                                # The builder renders $stdDevPop with the array form, even with a single value
+                                # Example uses the short form, the builder always generates the verbose form
                                 # $stdDevPop: '$scores.score'
                                 $stdDevPop: ['$scores.score']
                             - 2

--- a/generator/config/expression/rand.yaml
+++ b/generator/config/expression/rand.yaml
@@ -23,6 +23,7 @@ tests:
                     amount:
                         $floor: '$amount'
             -
+                # Example uses the short form, the builder always generates the verbose form
                 # $merge: 'donors'
                 $merge:
                     into: 'donors'

--- a/generator/config/expression/second.yaml
+++ b/generator/config/expression/second.yaml
@@ -30,6 +30,7 @@ tests:
             -
                 $project:
                     seconds:
+                        # Example uses the short form, the builder always generates the verbose form
                         # $second: '$date'
                         $second:
                             date: '$date'

--- a/generator/config/expression/setField.yaml
+++ b/generator/config/expression/setField.yaml
@@ -39,6 +39,7 @@ tests:
                         input: '$$ROOT'
                         value: '$price'
             -
+                # Example uses the short form, the builder always generates the verbose form
                 # $unset: 'price'
                 $unset:
                     - 'price'
@@ -54,6 +55,7 @@ tests:
                         input: '$$ROOT'
                         value: '$price'
             -
+                # Example uses the short form, the builder always generates the verbose form
                 # $unset: 'price'
                 $unset:
                     - 'price'

--- a/generator/config/expression/size.yaml
+++ b/generator/config/expression/size.yaml
@@ -24,8 +24,7 @@ tests:
                     numberOfColors:
                         $cond:
                             if:
-                                # The example in the docs uses the short syntax for $isArray,
-                                # but the aggregation builder always uses the more verbose syntax.
+                                # Example uses the short form, the builder always generates the verbose form
                                 # $isArray: '$colors'
                                 $isArray:
                                     - '$colors'

--- a/generator/config/expression/sortArray.yaml
+++ b/generator/config/expression/sortArray.yaml
@@ -101,8 +101,7 @@ tests:
                                     a:
                                         sale: true
                                         price: 19
-                                # Decimal128( "10.23" )
-                                - 10.23
+                                - !bson_decimal128 '10.23'
                                 -
                                     a: 'On sale'
                             sortBy: 1

--- a/generator/config/expression/stdDevPop.yaml
+++ b/generator/config/expression/stdDevPop.yaml
@@ -22,5 +22,6 @@ tests:
             -
                 $project:
                     stdDev:
+                        # Example uses the short form, the builder always generates the verbose form
                         # $stdDevPop: '$scores.score'
                         $stdDevPop: ['$scores.score']

--- a/generator/config/expression/sum.yaml
+++ b/generator/config/expression/sum.yaml
@@ -12,6 +12,7 @@ arguments:
         name: expression
         type:
             - resolvesToNumber
+            - resolvesToArray
         variadic: array
 tests:
     -

--- a/generator/config/expression/sum.yaml
+++ b/generator/config/expression/sum.yaml
@@ -22,6 +22,7 @@ tests:
             -
                 $project:
                     quizTotal:
+                        # Example uses the short form, the builder always generates the verbose form
                         # $sum: '$quizzes'
                         $sum:
                             - '$quizzes'

--- a/generator/config/expression/unsetField.yaml
+++ b/generator/config/expression/unsetField.yaml
@@ -53,6 +53,7 @@ tests:
                             $unsetField:
                                 field: 'euro'
                                 input:
+                                    # Example uses the short form, the builder always generates the verbose form
                                     # $getField: 'price'
                                     $getField:
                                         field: 'price'

--- a/generator/config/expression/week.yaml
+++ b/generator/config/expression/week.yaml
@@ -30,6 +30,7 @@ tests:
             -
                 $project:
                     week:
+                        # Example uses the short form, the builder always generates the verbose form
                         # $week: '$date'
                         $week:
                             date: '$date'

--- a/generator/config/expression/year.yaml
+++ b/generator/config/expression/year.yaml
@@ -30,6 +30,7 @@ tests:
             -
                 $project:
                     year:
+                        # Example uses the short form, the builder always generates the verbose form
                         # $year: '$date'
                         $year:
                             date: '$date'

--- a/generator/config/query/type.yaml
+++ b/generator/config/query/type.yaml
@@ -21,31 +21,31 @@ tests:
             -
                 $match:
                     zipCode:
-                        # Example uses the short form, the builder always generated the verbose form
+                        # Example uses the short form, the builder always generates the verbose form
                         # $type: 2
                         $type: [2]
             -
                 $match:
                     zipCode:
-                        # Example uses the short form, the builder always generated the verbose form
+                        # Example uses the short form, the builder always generates the verbose form
                         # $type: 'string'
                         $type: ['string']
             -
                 $match:
                     zipCode:
-                        # Example uses the short form, the builder always generated the verbose form
+                        # Example uses the short form, the builder always generates the verbose form
                         # $type: 1
                         $type: [1]
             -
                 $match:
                     zipCode:
-                        # Example uses the short form, the builder always generated the verbose form
+                        # Example uses the short form, the builder always generates the verbose form
                         # $type: 'double'
                         $type: ['double']
             -
                 $match:
                     zipCode:
-                        # Example uses the short form, the builder always generated the verbose form
+                        # Example uses the short form, the builder always generates the verbose form
                         # $type: 'number'
                         $type: ['number']
     -
@@ -67,13 +67,13 @@ tests:
             -
                 $match:
                     zipCode:
-                        # Example uses the short form, the builder always generated the verbose form
+                        # Example uses the short form, the builder always generates the verbose form
                         # $type: 'minKey'
                         $type: ['minKey']
             -
                 $match:
                     zipCode:
-                        # Example uses the short form, the builder always generated the verbose form
+                        # Example uses the short form, the builder always generates the verbose form
                         # $type: 'maxKey'
                         $type: ['maxKey']
     -
@@ -83,6 +83,6 @@ tests:
             -
                 $match:
                     zipCode:
-                        # Example uses the short form, the builder always generated the verbose form
+                        # Example uses the short form, the builder always generates the verbose form
                         # $type: 'array'
                         $type: ['array']

--- a/generator/config/stage/addFields.yaml
+++ b/generator/config/stage/addFields.yaml
@@ -22,9 +22,12 @@ tests:
             -
                 $addFields:
                     totalHomework:
-                        $sum: '$homework'
+                        # The example renders a single value, but the builder generates an array for consistency
+                        # $sum: '$homework'
+                        $sum: ['$homework']
                     totalQuiz:
-                        $sum: '$quiz'
+                        # $sum: '$quiz'
+                        $sum: ['$quiz']
             -
                 $addFields:
                     totalScore:
@@ -39,3 +42,23 @@ tests:
             -
                 $addFields:
                     specs.fuel_type: 'unleaded'
+    -
+        name: 'Overwriting an existing field'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/addFields/#overwriting-an-existing-field'
+        pipeline:
+            -
+                $addFields:
+                    cats: 20
+    -
+        name: 'Add Element to an Array'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/addFields/#add-element-to-an-array'
+        pipeline:
+            -
+                $match:
+                    _id: 1
+            -
+                $addFields:
+                    homework:
+                        $concatArrays:
+                            - '$homework'
+                            - [7]

--- a/generator/config/stage/bucket.yaml
+++ b/generator/config/stage/bucket.yaml
@@ -40,3 +40,62 @@ arguments:
             A document that specifies the fields to include in the output documents in addition to the _id field. To specify the field to include, you must use accumulator expressions.
             If you do not specify an output document, the operation returns a count field containing the number of documents in each bucket.
             If you specify an output document, only the fields specified in the document are returned; i.e. the count field is not returned unless it is explicitly included in the output document.
+tests:
+    -
+        name: 'Bucket by Year and Filter by Bucket Results'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucket/#bucket-by-year-and-filter-by-bucket-results'
+        pipeline:
+            -
+                $bucket:
+                    groupBy: '$year_born'
+                    boundaries: [1840, 1850, 1860, 1870, 1880]
+                    default: 'Other'
+                    output:
+                        count:
+                            $sum: 1
+                        artists:
+                            $push:
+                                name:
+                                    $concat:
+                                        - '$first_name'
+                                        - ' '
+                                        - '$last_name'
+                                year_born: '$year_born'
+            -
+                $match:
+                    count:
+                        $gt: 3
+    -
+        name: 'Use $bucket with $facet to Bucket by Multiple Fields'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucket/#use--bucket-with--facet-to-bucket-by-multiple-fields'
+        pipeline:
+            -
+                $facet:
+                    price:
+                        -
+                            $bucket:
+                                groupBy: '$price'
+                                boundaries: [0, 200, 400]
+                                default: 'Other'
+                                output:
+                                    count:
+                                        $sum: 1
+                                    artwork:
+                                        $push:
+                                            title: '$title'
+                                            price: '$price'
+                                    averagePrice:
+                                        $avg: '$price'
+                    year:
+                        -
+                            $bucket:
+                                groupBy: '$year'
+                                boundaries: [1890, 1910, 1920, 1940]
+                                default: 'Unknown'
+                                output:
+                                    count:
+                                        $sum: 1
+                                    artwork:
+                                        $push:
+                                            title: '$title'
+                                            year: '$year'

--- a/generator/config/stage/bucketAuto.yaml
+++ b/generator/config/stage/bucketAuto.yaml
@@ -35,3 +35,12 @@ arguments:
         description: |
             A string that specifies the preferred number series to use to ensure that the calculated boundary edges end on preferred round numbers or their powers of 10.
             Available only if the all groupBy values are numeric and none of them are NaN.
+tests:
+    -
+        name: 'Single Facet Aggregation'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucketAuto/#single-facet-aggregation'
+        pipeline:
+            -
+                $bucketAuto:
+                    groupBy: '$price'
+                    buckets: 4

--- a/generator/config/stage/changeStream.yaml
+++ b/generator/config/stage/changeStream.yaml
@@ -57,3 +57,10 @@ arguments:
         optional: true
         description: |
             Specifies a time as the logical starting point for the change stream. Cannot be used with resumeAfter or startAfter fields.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/changeStream/#examples'
+        pipeline:
+            -
+                $changeStream: {}

--- a/generator/config/stage/changeStreamSplitLargeEvent.yaml
+++ b/generator/config/stage/changeStreamSplitLargeEvent.yaml
@@ -7,3 +7,10 @@ encode: object
 description: |
     Splits large change stream events that exceed 16 MB into smaller fragments returned in a change stream cursor.
     You can only use $changeStreamSplitLargeEvent in a $changeStream pipeline and it must be the final stage in the pipeline.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/changeStreamSplitLargeEvent/#example'
+        pipeline:
+            -
+                $changeStreamSplitLargeEvent: {}

--- a/generator/config/stage/collStats.yaml
+++ b/generator/config/stage/collStats.yaml
@@ -3,14 +3,30 @@ name: $collStats
 link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/collStats/'
 type:
     - stage
-encode: single
+encode: object
 description: |
     Returns statistics regarding a collection or view.
 arguments:
     -
-        name: config
+        name: latencyStats
         type:
             - object
+        optional: true
+    -
+        name: storageStats
+        type:
+            - object
+        optional: true
+    -
+        name: count
+        type:
+            - object # empty object
+        optional: true
+    -
+        name: queryExecStats
+        type:
+            - object # empty object
+        optional: true
 tests:
     -
         name: 'latencyStats Document'

--- a/generator/config/stage/collStats.yaml
+++ b/generator/config/stage/collStats.yaml
@@ -11,3 +11,33 @@ arguments:
         name: config
         type:
             - object
+tests:
+    -
+        name: 'latencyStats Document'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/collStats/#latencystats-document'
+        pipeline:
+            -
+                $collStats:
+                    latencyStats:
+                        histograms: true
+    -
+        name: 'storageStats Document'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/collStats/#storagestats-document'
+        pipeline:
+            -
+                $collStats:
+                    storageStats: {}
+    -
+        name: 'count Field'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/collStats/#count-field'
+        pipeline:
+            -
+                $collStats:
+                    count: {}
+    -
+        name: 'queryExecStats Document'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/collStats/#queryexecstats-document'
+        pipeline:
+            -
+                $collStats:
+                    queryExecStats: {}

--- a/generator/config/stage/count.yaml
+++ b/generator/config/stage/count.yaml
@@ -14,3 +14,14 @@ arguments:
             - string
         description: |
             Name of the output field which has the count as its value. It must be a non-empty string, must not start with $ and must not contain the . character.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/count/#example'
+        pipeline:
+            -
+                $match:
+                    score:
+                        $gt: 80
+            -
+                $count: 'passing_scores'

--- a/generator/config/stage/currentOp.yaml
+++ b/generator/config/stage/currentOp.yaml
@@ -6,3 +6,54 @@ type:
 encode: object
 description: |
     Returns information on active and/or dormant operations for the MongoDB deployment. To run, use the db.aggregate() method.
+arguments:
+    -
+        name: allUsers
+        type:
+            - bool
+        optional: true
+    -
+        name: idleConnections
+        type:
+            - bool
+        optional: true
+    -
+        name: idleCursors
+        type:
+            - bool
+        optional: true
+    -
+        name: idleSessions
+        type:
+            - bool
+        optional: true
+    -
+        name: localOps
+        type:
+            - bool
+        optional: true
+tests:
+    -
+        name: 'Inactive Sessions'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/currentOp/#inactive-sessions'
+        pipeline:
+            -
+                $currentOp:
+                    allUsers: true
+                    idleSessions: true
+            -
+                $match:
+                    active: false
+                    transaction:
+                        $exists: true
+    -
+        name: 'Sampled Queries'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/currentOp/#sampled-queries'
+        pipeline:
+            -
+                $currentOp:
+                    allUsers: true
+                    localOps: true
+            -
+                $match:
+                    desc: 'query analyzer'

--- a/generator/config/stage/densify.yaml
+++ b/generator/config/stage/densify.yaml
@@ -28,3 +28,29 @@ arguments:
             - object # Range
         description: |
             Specification for range based densification.
+tests:
+    -
+        name: 'Densify Time Series Data'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/densify/#densify-time-series-data'
+        pipeline:
+            -
+                $densify:
+                    field: 'timestamp'
+                    range:
+                        step: 1
+                        unit: 'hour'
+                        bounds:
+                            - !bson_utcdatetime '2021-05-18T00:00:00.000Z'
+                            - !bson_utcdatetime '2021-05-18T08:00:00.000Z'
+    -
+        name: 'Densifiction with Partitions'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/densify/#densifiction-with-partitions'
+        pipeline:
+            -
+                $densify:
+                    field: 'altitude'
+                    partitionByFields:
+                        - 'variety'
+                    range:
+                        bounds: 'full'
+                        step: 200

--- a/generator/config/stage/documents.yaml
+++ b/generator/config/stage/documents.yaml
@@ -17,3 +17,37 @@ arguments:
             - $let expressions
             - variables in scope from $lookup expressions
             Expressions that do not resolve to a current document, like $myField or $$ROOT, will result in an error.
+tests:
+    -
+        name: 'Test a Pipeline Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/documents/#test-a-pipeline-stage'
+        pipeline:
+            -
+                $documents:
+                    - { x: 10 }
+                    - { x: 2 }
+                    - { x: 5 }
+            -
+                $bucketAuto:
+                    groupBy: '$x'
+                    buckets: 4
+    -
+        name: 'Use a $documents Stage in a $lookup Stage'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/documents/#use-a--documents-stage-in-a--lookup-stage'
+        pipeline:
+            -
+                $match: {}
+            -
+                $lookup:
+                    localField: 'zip'
+                    foreignField: 'zip_id'
+                    as: 'city_state'
+                    pipeline:
+                        -
+                            $documents:
+                                -
+                                    zip_id: 94301
+                                    name: 'Palo Alto, CA'
+                                -
+                                    zip_id: 10019
+                                    name: 'New York, NY'

--- a/generator/config/stage/facet.yaml
+++ b/generator/config/stage/facet.yaml
@@ -21,6 +21,7 @@ tests:
                 $facet:
                     categorizedByTags:
                         -
+                            # The builder uses the verbose form of the $unwind operator
                             # $unwind: '$tags'
                             $unwind:
                                 path: '$tags'

--- a/generator/config/stage/facet.yaml
+++ b/generator/config/stage/facet.yaml
@@ -12,3 +12,39 @@ arguments:
         type:
             - pipeline
         variadic: object
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/facet/#example'
+        pipeline:
+            -
+                $facet:
+                    categorizedByTags:
+                        -
+                            # $unwind: '$tags'
+                            $unwind:
+                                path: '$tags'
+                        -
+                            $sortByCount: '$tags'
+                    categorizedByPrice:
+                        -
+                            $match:
+                                price:
+                                    # The example uses an int, but the builder requires a bool
+                                    # $exists: 1
+                                    $exists: true
+                        -
+                            $bucket:
+                                groupBy: '$price'
+                                boundaries: [0, 150, 200, 300, 400]
+                                default: 'Other'
+                                output:
+                                    count:
+                                        $sum: 1
+                                    titles:
+                                        $push: '$title'
+                    categorizedByYears(Auto):
+                        -
+                            $bucketAuto:
+                                groupBy: '$year'
+                                buckets: 4

--- a/generator/config/stage/fill.yaml
+++ b/generator/config/stage/fill.yaml
@@ -40,3 +40,71 @@ arguments:
         description: |
             Specifies an object containing each field for which to fill missing values. You can specify multiple fields in the output object.
             The object name is the name of the field to fill. The object value specifies how the field is filled.
+tests:
+    -
+        name: 'Fill Missing Field Values with a Constant Value'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/fill/#fill-missing-field-values-with-a-constant-value'
+        pipeline:
+            -
+                $fill:
+                    output:
+                        bootsSold:
+                            value: 0
+                        sandalsSold:
+                            value: 0
+                        sneakersSold:
+                            value: 0
+    -
+        name: 'Fill Missing Field Values with Linear Interpolation'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/fill/#fill-missing-field-values-with-linear-interpolation'
+        pipeline:
+            -
+                $fill:
+                    sortBy:
+                        time: 1
+                    output:
+                        price:
+                            method: 'linear'
+    -
+        name: 'Fill Missing Field Values Based on the Last Observed Value'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/fill/#fill-missing-field-values-based-on-the-last-observed-value'
+        pipeline:
+            -
+                $fill:
+                    sortBy:
+                        date: 1
+                    output:
+                        score:
+                            method: 'locf'
+    -
+        name: 'Fill Data for Distinct Partitions'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/fill/#fill-data-for-distinct-partitions'
+        pipeline:
+            -
+                $fill:
+                    sortBy:
+                        date: 1
+                    partitionBy:
+                        restaurant: '$restaurant'
+                    output:
+                        score:
+                            method: 'locf'
+    -
+        name: 'Indicate if a Field was Populated Using $fill'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/fill/#indicate-if-a-field-was-populated-using--fill'
+        pipeline:
+            -
+                $set:
+                    valueExisted:
+                        $ifNull:
+                            -
+                                $toBool:
+                                    $toString: '$score'
+                            - false
+            -
+                $fill:
+                    sortBy:
+                        date: 1
+                    output:
+                        score:
+                            method: 'locf'

--- a/generator/config/stage/geoNear.yaml
+++ b/generator/config/stage/geoNear.yaml
@@ -54,6 +54,7 @@ arguments:
         name: near
         type:
             - object # GeoPoint
+            - resolvesToObject
         description: |
             The point for which to find the closest documents.
     -
@@ -74,3 +75,86 @@ arguments:
             - When true, MongoDB uses $nearSphere semantics and calculates distances using spherical geometry.
             - When false, MongoDB uses $near semantics: spherical geometry for 2dsphere indexes and planar geometry for 2d indexes.
             Default: false.
+tests:
+    -
+        name: 'Maximum Distance'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/geoNear/#maximum-distance'
+        pipeline:
+            -
+                $geoNear:
+                    near:
+                        type: 'Point'
+                        coordinates:
+                            - -73.99279
+                            - 40.719296
+                    distanceField: 'dist.calculated'
+                    maxDistance: 2
+                    query:
+                        category: 'Parks'
+                    includeLocs: 'dist.location'
+                    spherical: true
+    -
+        name: 'Minimum Distance'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/geoNear/#minimum-distance'
+        pipeline:
+            -
+                $geoNear:
+                    near:
+                        type: 'Point'
+                        coordinates:
+                            - -73.99279
+                            - 40.719296
+                    distanceField: 'dist.calculated'
+                    minDistance: 2
+                    query:
+                        category: 'Parks'
+                    includeLocs: 'dist.location'
+                    spherical: true
+    -
+        name: 'with the let option'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/geoNear/#-geonear-with-the-let-option'
+        pipeline:
+            -
+                $geoNear:
+                    near: '$$pt'
+                    distanceField: 'distance'
+                    maxDistance: 2
+                    query:
+                        category: 'Parks'
+                    includeLocs: 'dist.location'
+                    spherical: true
+    -
+        name: 'with Bound let Option'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/geoNear/#-geonear-with-bound-let-option'
+        pipeline:
+            -
+                $lookup:
+                    from: 'places'
+                    let:
+                        pt: '$location'
+                    pipeline:
+                        -
+                            $geoNear:
+                                near: '$$pt'
+                                distanceField: 'distance'
+                    as: 'joinedField'
+            -
+                $match:
+                    name: 'Sara D. Roosevelt Park'
+    -
+        name: 'Specify Which Geospatial Index to Use'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/geoNear/#specify-which-geospatial-index-to-use'
+        pipeline:
+            -
+                $geoNear:
+                    near:
+                        type: 'Point'
+                        coordinates:
+                            - -73.98142
+                            - 40.71782
+                    key: 'location'
+                    distanceField: 'dist.calculated'
+                    query:
+                        category: 'Parks'
+            -
+                $limit: 5

--- a/generator/config/stage/graphLookup.yaml
+++ b/generator/config/stage/graphLookup.yaml
@@ -60,3 +60,49 @@ arguments:
         optional: true
         description: |
             A document specifying additional conditions for the recursive search. The syntax is identical to query filter syntax.
+tests:
+    -
+        name: 'Within a Single Collection'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/graphLookup/#within-a-single-collection'
+        pipeline:
+            -
+                $graphLookup:
+                    from: 'employees'
+                    startWith: '$reportsTo'
+                    connectFromField: 'reportsTo'
+                    connectToField: 'name'
+                    as: 'reportingHierarchy'
+    -
+        name: 'Across Multiple Collections'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/graphLookup/#across-multiple-collections'
+        pipeline:
+            -
+                $graphLookup:
+                    from: 'airports'
+                    startWith: '$nearestAirport'
+                    connectFromField: 'connects'
+                    connectToField: 'airport'
+                    maxDepth: 2
+                    depthField: 'numConnections'
+                    as: 'destinations'
+    -
+        name: 'With a Query Filter'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/graphLookup/#with-a-query-filter'
+        pipeline:
+            -
+                $match:
+                    name: 'Tanya Jordan'
+            -
+                $graphLookup:
+                    from: 'people'
+                    startWith: '$friends'
+                    connectFromField: 'friends'
+                    connectToField: 'name'
+                    as: 'golfers'
+                    restrictSearchWithMatch:
+                        hobbies: 'golf'
+            -
+                $project:
+                    name: 1
+                    friends: 1
+                    connections who play golf: '$golfers.name'

--- a/generator/config/stage/group.yaml
+++ b/generator/config/stage/group.yaml
@@ -18,5 +18,105 @@ arguments:
         type:
             - accumulator
         variadic: object
+        variadicMin: 0
         description: |
             Computed using the accumulator operators.
+tests:
+    -
+        name: 'Count the Number of Documents in a Collection'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/#count-the-number-of-documents-in-a-collection'
+        pipeline:
+            -
+                $group:
+                    _id: ~
+                    count:
+                        $count: {}
+    -
+        name: 'Retrieve Distinct Values'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/#retrieve-distinct-values'
+        pipeline:
+            -
+                $group:
+                    _id: '$item'
+    -
+        name: 'Group by Item Having'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/#group-by-item-having'
+        pipeline:
+            -
+                $group:
+                    _id: '$item'
+                    totalSaleAmount:
+                        $sum:
+                            $multiply:
+                                - '$price'
+                                - '$quantity'
+            -
+                $match:
+                    totalSaleAmount:
+                        $gte: 100
+    -
+        name: 'Calculate Count Sum and Average'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/#calculate-count--sum--and-average'
+        pipeline:
+            -
+                $match:
+                    date:
+                        $gte: !bson_utcdatetime '2014-01-01'
+                        $lt: !bson_utcdatetime '2015-01-01'
+            -
+                $group:
+                    _id:
+                        $dateToString:
+                            format: '%Y-%m-%d'
+                            date: '$date'
+                    totalSaleAmount:
+                        $sum:
+                            $multiply:
+                                - '$price'
+                                - '$quantity'
+                    averageQuantity:
+                        $avg: '$quantity'
+                    count:
+                        $sum: 1
+            -
+                $sort:
+                    totalSaleAmount: -1
+    -
+        name: 'Group by null'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/#group-by-null'
+        pipeline:
+            -
+                $group:
+                    _id: ~
+                    totalSaleAmount:
+                        $sum:
+                            $multiply:
+                                - '$price'
+                                - '$quantity'
+                    averageQuantity:
+                        $avg: '$quantity'
+                    count:
+                        $sum: 1
+    -
+        name: 'Pivot Data'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/#pivot-data'
+        pipeline:
+            -
+                $group:
+                    _id: '$author'
+                    books:
+                        $push: '$title'
+    -
+        name: 'Group Documents by author'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/#group-documents-by-author'
+        pipeline:
+            -
+                $group:
+                    _id: '$author'
+                    books:
+                        $push: '$$ROOT'
+            -
+                $addFields:
+                    totalCopies:
+                        # $sum: '$books.copies'
+                        $sum: ['$books.copies']

--- a/generator/config/stage/indexStats.yaml
+++ b/generator/config/stage/indexStats.yaml
@@ -6,3 +6,10 @@ type:
 encode: object
 description: |
     Returns statistics regarding the use of each index for the collection.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/indexStats/#example'
+        pipeline:
+            -
+                $indexStats: {}

--- a/generator/config/stage/limit.yaml
+++ b/generator/config/stage/limit.yaml
@@ -11,3 +11,10 @@ arguments:
         name: limit
         type:
             - int
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/limit/#example'
+        pipeline:
+            -
+                $limit: 5

--- a/generator/config/stage/listLocalSessions.yaml
+++ b/generator/config/stage/listLocalSessions.yaml
@@ -21,3 +21,27 @@ arguments:
         optional: true
         description: |
             Returns all sessions for all users. If running with access control, the authenticated user must have privileges with listSessions action on the cluster.
+tests:
+    -
+        name: 'List All Local Sessions'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/listLocalSessions/#list-all-local-sessions'
+        pipeline:
+            -
+                $listLocalSessions:
+                    allUsers: true
+    -
+        name: 'List All Local Sessions for the Specified Users'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/listLocalSessions/#list-all-local-sessions-for-the-specified-users'
+        pipeline:
+            -
+                $listLocalSessions:
+                    users:
+                        -
+                            user: 'myAppReader'
+                            db: 'test'
+    -
+        name: 'List All Local Sessions for the Current User'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/listLocalSessions/#list-all-local-sessions-for-the-current-user'
+        pipeline:
+            -
+                $listLocalSessions: {}

--- a/generator/config/stage/listSampledQueries.yaml
+++ b/generator/config/stage/listSampledQueries.yaml
@@ -12,3 +12,18 @@ arguments:
         type:
             - string
         optional: true
+tests:
+    -
+        name: 'List Sampled Queries for All Collections'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSampledQueries/#list-sampled-queries-for-all-collections'
+        pipeline:
+            -
+                $listSampledQueries: {}
+
+    -
+        name: 'List Sampled Queries for A Specific Collection'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSampledQueries/#list-sampled-queries-for-a-specific-collection'
+        pipeline:
+            -
+                $listSampledQueries:
+                    namespace: 'social.post'

--- a/generator/config/stage/listSearchIndexes.yaml
+++ b/generator/config/stage/listSearchIndexes.yaml
@@ -21,3 +21,24 @@ arguments:
         optional: true
         description: |
             The name of the index to return information about.
+tests:
+    -
+        name: 'Return All Search Indexes'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSearchIndexes/#return-all-search-indexes'
+        pipeline:
+            -
+                $listSearchIndexes: {}
+    -
+        name: 'Return a Single Search Index by Name'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSearchIndexes/#return-a-single-search-index-by-name'
+        pipeline:
+            -
+                $listSearchIndexes:
+                    name: 'synonym-mappings'
+    -
+        name: 'Return a Single Search Index by id'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSearchIndexes/#return-a-single-search-index-by-id'
+        pipeline:
+            -
+                $listSearchIndexes:
+                    id: '6524096020da840844a4c4a7'

--- a/generator/config/stage/listSessions.yaml
+++ b/generator/config/stage/listSessions.yaml
@@ -21,3 +21,28 @@ arguments:
         optional: true
         description: |
             Returns all sessions for all users. If running with access control, the authenticated user must have privileges with listSessions action on the cluster.
+tests:
+    -
+        name: 'List All Sessions'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSessions/#list-all-sessions'
+        pipeline:
+            -
+                $listSessions:
+                    allUsers: true
+    -
+        name: 'List All Sessions for the Specified Users'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSessions/#list-all-sessions-for-the-specified-users'
+        pipeline:
+            -
+                $listSessions:
+                    users:
+                        -
+                            user: 'myAppReader'
+                            db: 'test'
+    -
+        name: 'List All Sessions for the Current User'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSessions/#list-all-sessions-for-the-current-user'
+        pipeline:
+            -
+                $listSessions: {}
+

--- a/generator/config/stage/lookup.yaml
+++ b/generator/config/stage/lookup.yaml
@@ -52,3 +52,114 @@ arguments:
             - string
         description: |
             Specifies the name of the new array field to add to the input documents. The new array field contains the matching documents from the from collection. If the specified name already exists in the input document, the existing field is overwritten.
+tests:
+    -
+        name: 'Perform a Single Equality Join with $lookup'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/lookup/#perform-a-single-equality-join-with--lookup'
+        pipeline:
+            -
+                $lookup:
+                    from: 'inventory'
+                    localField: 'item'
+                    foreignField: 'sku'
+                    as: 'inventory_docs'
+    -
+        name: 'Use $lookup with an Array'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/lookup/#use--lookup-with-an-array'
+        pipeline:
+            -
+                $lookup:
+                    from: 'members'
+                    localField: 'enrollmentlist'
+                    foreignField: 'name'
+                    as: 'enrollee_info'
+    -
+        name: 'Use $lookup with $mergeObjects'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/lookup/#use--lookup-with--mergeobjects'
+        pipeline:
+            -
+                $lookup:
+                    from: 'items'
+                    localField: 'item'
+                    foreignField: 'item'
+                    as: 'fromItems'
+            -
+                $replaceRoot:
+                    newRoot:
+                        $mergeObjects:
+                            -
+                                $arrayElemAt:
+                                    - '$fromItems'
+                                    - 0
+                            - '$$ROOT'
+            -
+                $project:
+                    fromItems: 0
+    -
+        name: 'Perform Multiple Joins and a Correlated Subquery with $lookup'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/lookup/#perform-multiple-joins-and-a-correlated-subquery-with--lookup'
+        pipeline:
+            -
+                $lookup:
+                    from: 'warehouses'
+                    let:
+                        order_item: '$item'
+                        order_qty: '$ordered'
+                    pipeline:
+                        -
+                            $match:
+                                $expr:
+                                    $and:
+                                        -
+                                            $eq:
+                                                - '$stock_item'
+                                                - '$$order_item'
+                                        -
+                                            $gte:
+                                                - '$instock'
+                                                - '$$order_qty'
+                        -
+                            $project:
+                                stock_item: 0
+                                _id: 0
+                    as: 'stockdata'
+    -
+        name: 'Perform an Uncorrelated Subquery with $lookup'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/lookup/#perform-an-uncorrelated-subquery-with--lookup'
+        pipeline:
+            -
+                $lookup:
+                    from: 'holidays'
+                    pipeline:
+                        -
+                            $match:
+                                year: 2018
+                        -
+                            $project:
+                                _id: 0
+                                date:
+                                    name: '$name'
+                                    date: '$date'
+                        -
+                            $replaceRoot:
+                                newRoot: '$date'
+                    as: 'holidays'
+    -
+        name: 'Perform a Concise Correlated Subquery with $lookup'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/lookup/#perform-a-concise-correlated-subquery-with--lookup'
+        pipeline:
+            -
+                $lookup:
+                    from: 'restaurants'
+                    localField: 'restaurant_name'
+                    foreignField: 'name'
+                    let:
+                        orders_drink: '$drink'
+                    pipeline:
+                        -
+                            $match:
+                                $expr:
+                                    $in:
+                                        - '$$orders_drink'
+                                        - '$beverages'
+                    as: 'matches'

--- a/generator/config/stage/match.yaml
+++ b/generator/config/stage/match.yaml
@@ -11,3 +11,30 @@ arguments:
         name: query
         type:
             - query
+tests:
+    -
+        name: 'Equality Match'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/match/#equality-match'
+        pipeline:
+            -
+                $match:
+                    author: 'dave'
+    -
+        name: 'Perform a Count'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/match/#perform-a-count'
+        pipeline:
+            -
+                $match:
+                    $or:
+                        -
+                            score:
+                                $gt: 70
+                                $lt: 90
+                        -
+                            views:
+                                $gte: 1000
+            -
+                $group:
+                    _id: ~
+                    count:
+                        $sum: 1

--- a/generator/config/stage/merge.yaml
+++ b/generator/config/stage/merge.yaml
@@ -12,7 +12,7 @@ arguments:
         name: into
         type:
             - string
-            #- OutCollection
+            - object # OutCollection
         description: |
             The output collection.
     -
@@ -34,6 +34,7 @@ arguments:
         name: whenMatched
         type:
             - string # WhenMatched
+            - pipeline
         optional: true
         description: |
             The behavior of $merge if a result document and an existing document in the collection have the same value for the specified on field(s).
@@ -44,3 +45,136 @@ arguments:
         optional: true
         description: |
             The behavior of $merge if a result document does not match an existing document in the out collection.
+tests:
+    -
+        name: 'On-Demand Materialized View Initial Creation'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/merge/#on-demand-materialized-view--initial-creation'
+        pipeline:
+            -
+                $group:
+                    _id:
+                        fiscal_year: '$fiscal_year'
+                        dept: '$dept'
+                    salaries:
+                        $sum: '$salary'
+            -
+                $merge:
+                    into:
+                        db: 'reporting'
+                        coll: 'budgets'
+                    on: '_id'
+                    whenMatched: 'replace'
+                    whenNotMatched: 'insert'
+    -
+        name: 'On-Demand Materialized View Update Replace Data'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/merge/#on-demand-materialized-view--update-replace-data'
+        pipeline:
+            -
+                $match:
+                    fiscal_year:
+                        $gte: 2019
+            -
+                $group:
+                    _id:
+                        fiscal_year: '$fiscal_year'
+                        dept: '$dept'
+                    salaries:
+                        $sum: '$salary'
+            -
+                $merge:
+                    into:
+                        db: 'reporting'
+                        coll: 'budgets'
+                    on: '_id'
+                    whenMatched: 'replace'
+                    whenNotMatched: 'insert'
+    -
+        name: 'Only Insert New Data'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/merge/#only-insert-new-data'
+        pipeline:
+            -
+                $match:
+                    fiscal_year: 2019
+            -
+                $group:
+                    _id:
+                        fiscal_year: '$fiscal_year'
+                        dept: '$dept'
+                    employees:
+                        $push: '$employee'
+            -
+                $project:
+                    _id: 0
+                    dept: '$_id.dept'
+                    fiscal_year: '$_id.fiscal_year'
+                    employees: 1
+            -
+                $merge:
+                    into:
+                        db: 'reporting'
+                        coll: 'orgArchive'
+                    on:
+                        - 'dept'
+                        - 'fiscal_year'
+                    whenMatched: 'fail'
+    -
+        name: 'Merge Results from Multiple Collections'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/merge/#merge-results-from-multiple-collections'
+        pipeline:
+            -
+                $group:
+                    _id: '$quarter'
+                    purchased:
+                        $sum: '$qty'
+            -
+                $merge:
+                    into: 'quarterlyreport'
+                    on: '_id'
+                    whenMatched: 'merge'
+                    whenNotMatched: 'insert'
+    -
+        name: 'Use the Pipeline to Customize the Merge'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/merge/#use-the-pipeline-to-customize-the-merge'
+        pipeline:
+            -
+                $match:
+                    date:
+                        $gte: !bson_utcdatetime 1557187200000
+                        $lt: !bson_utcdatetime 1557273600000
+            -
+                $project:
+                    _id:
+                        $dateToString:
+                            format: '%Y-%m'
+                            date: '$date'
+                    thumbsup: 1
+                    thumbsdown: 1
+            -
+                $merge:
+                    into: 'monthlytotals'
+                    on: '_id'
+                    whenMatched:
+                        -
+                            $addFields:
+                                thumbsup:
+                                    $add:
+                                        - '$thumbsup'
+                                        - '$$new.thumbsup'
+                                thumbsdown:
+                                    $add:
+                                        - '$thumbsdown'
+                                        - '$$new.thumbsdown'
+                    whenNotMatched: 'insert'
+    -
+        name: 'Use Variables to Customize the Merge'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/merge/#use-variables-to-customize-the-merge'
+        pipeline:
+            -
+                $merge:
+                    into: 'cakeSales'
+                    let:
+                        year: '2020'
+                    whenMatched:
+                        -
+                            $addFields:
+                                salesYear: '$$year'

--- a/generator/config/stage/merge.yaml
+++ b/generator/config/stage/merge.yaml
@@ -139,8 +139,8 @@ tests:
             -
                 $match:
                     date:
-                        $gte: !bson_utcdatetime 1557187200000
-                        $lt: !bson_utcdatetime 1557273600000
+                        $gte: !bson_utcdatetime '2019-05-07'
+                        $lt: !bson_utcdatetime '2019-05-08'
             -
                 $project:
                     _id:

--- a/generator/config/stage/out.yaml
+++ b/generator/config/stage/out.yaml
@@ -3,26 +3,38 @@ name: $out
 link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/out/'
 type:
     - stage
-encode: object
+encode: single
 description: |
     Writes the resulting documents of the aggregation pipeline to a collection. To use the $out stage, it must be the last stage in the pipeline.
 arguments:
-    -
-        name: db
+    -   name: coll
         type:
             - string
-        description: |
-            Target collection name to write documents from $out to.
-    -
-        name: coll
-        type:
-            - string
+            - object # OutCollection
         description: |
             Target database name to write documents from $out to.
+tests:
     -
-        name: timeseries
-        type:
-            - object
-        optional: true
-        description: |
-            If set, the aggregation stage will use these options to create or replace a time-series collection in the given namespace.
+        name: 'Output to Same Database'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/out/#output-to-same-database'
+        pipeline:
+            -
+                $group:
+                    _id: '$author'
+                    books:
+                        $push: '$title'
+            -
+                $out: 'authors'
+    -
+        name: 'Output to a Different Database'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/out/#output-to-a-different-database'
+        pipeline:
+            -
+                $group:
+                    _id: '$author'
+                    books:
+                        $push: '$title'
+            -
+                $out:
+                    db: 'reporting'
+                    coll: 'authors'

--- a/generator/config/stage/planCacheStats.yaml
+++ b/generator/config/stage/planCacheStats.yaml
@@ -6,3 +6,19 @@ type:
 encode: object
 description: |
     Returns plan cache information for a collection.
+tests:
+    -
+        name: 'Return Information for All Entries in the Query Cache'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/planCacheStats/#return-information-for-all-entries-in-the-query-cache'
+        pipeline:
+            -
+                $planCacheStats: {}
+    -
+        name: 'Find Cache Entry Details for a Query Hash'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/planCacheStats/#find-cache-entry-details-for-a-query-hash'
+        pipeline:
+            -
+                $planCacheStats: {}
+            -
+                $match:
+                    planCacheKey: 'B1435201'

--- a/generator/config/stage/project.yaml
+++ b/generator/config/stage/project.yaml
@@ -12,3 +12,113 @@ arguments:
         type:
             - expression
         variadic: object
+tests:
+    -
+        name: 'Include Specific Fields in Output Documents'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/#include-specific-fields-in-output-documents'
+        pipeline:
+            -
+                $project:
+                    title: 1
+                    author: 1
+    -
+        name: 'Suppress id Field in the Output Documents'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/#suppress-_id-field-in-the-output-documents'
+        pipeline:
+            -
+                $project:
+                    _id: 0
+                    title: 1
+                    author: 1
+    -
+        name: 'Exclude Fields from Output Documents'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/#exclude-fields-from-output-documents'
+        pipeline:
+            -
+                $project:
+                    lastModified: 0
+    -
+        name: 'Exclude Fields from Embedded Documents'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/#exclude-fields-from-embedded-documents'
+        pipeline:
+            -
+                $project:
+                    author.first: 0
+                    lastModified: 0
+            -
+                $project:
+                    author:
+                        first: 0
+                    lastModified: 0
+    -
+        name: 'Conditionally Exclude Fields'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/#conditionally-exclude-fields'
+        pipeline:
+            -
+                $project:
+                    title: 1
+                    author.first: 1
+                    author.last: 1
+                    author.middle:
+                        $cond:
+                            if:
+                                $eq:
+                                    - ''
+                                    - '$author.middle'
+                            then: '$$REMOVE'
+                            else: '$author.middle'
+    -
+        name: 'Include Specific Fields from Embedded Documents'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/#include-specific-fields-from-embedded-documents'
+        pipeline:
+            -
+                $project:
+                    stop.title: 1
+            -
+                $project:
+                    stop:
+                        title: 1
+    -
+        name: 'Include Computed Fields'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/#include-computed-fields'
+        pipeline:
+            -
+                $project:
+                    title: 1
+                    isbn:
+                        prefix:
+                            $substr:
+                                - '$isbn'
+                                - 0
+                                - 3
+                        group:
+                            $substr:
+                                - '$isbn'
+                                - 3
+                                - 2
+                        publisher:
+                            $substr:
+                                - '$isbn'
+                                - 5
+                                - 4
+                        title:
+                            $substr:
+                                - '$isbn'
+                                - 9
+                                - 3
+                        checkDigit:
+                            $substr:
+                                - '$isbn'
+                                - 12
+                                - 1
+                    lastName: '$author.last'
+                    copiesSold: '$copies'
+    -
+        name: 'Project New Array Fields'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/#project-new-array-fields'
+        pipeline:
+            -
+                $project:
+                    myArray:
+                        - '$x'
+                        - '$y'

--- a/generator/config/stage/redact.yaml
+++ b/generator/config/stage/redact.yaml
@@ -11,3 +11,42 @@ arguments:
         name: expression
         type:
             - expression
+tests:
+    -
+        name: 'Evaluate Access at Every Document Level'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/redact/#evaluate-access-at-every-document-level'
+        pipeline:
+            -
+                $match:
+                    year: 2014
+            -
+                $redact:
+                    $cond:
+                        if:
+                            $gt:
+                                -
+                                    $size:
+                                        $setIntersection:
+                                            - '$tags'
+                                            -
+                                                - 'STLW'
+                                                - 'G'
+                                - 0
+                        then: '$$DESCEND'
+                        else: '$$PRUNE'
+    -
+        name: 'Exclude All Fields at a Given Level'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/redact/#exclude-all-fields-at-a-given-level'
+        pipeline:
+            -
+                $match:
+                    status: 'A'
+            -
+                $redact:
+                    $cond:
+                        if:
+                            $eq:
+                                - '$level'
+                                - 5
+                        then: '$$PRUNE'
+                        else: '$$DESCEND'

--- a/generator/config/stage/replaceRoot.yaml
+++ b/generator/config/stage/replaceRoot.yaml
@@ -11,3 +11,60 @@ arguments:
         name: newRoot
         type:
             - resolvesToObject
+tests:
+    -
+        name: 'with an Embedded Document Field'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceRoot/#-replaceroot-with-an-embedded-document-field'
+        pipeline:
+            -
+                $replaceRoot:
+                    newRoot:
+                        $mergeObjects:
+                            -
+                                dogs: 0
+                                cats: 0
+                                birds: 0
+                                fish: 0
+                            - '$pets'
+    -
+        name: 'with a Document Nested in an Array'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceRoot/#-replaceroot-with-a-document-nested-in-an-array'
+        pipeline:
+            -
+                # $unwind: '$grades'
+                $unwind:
+                    path: '$grades'
+            -
+                $match:
+                    grades.grade:
+                        $gte: 90
+            -
+                $replaceRoot:
+                    newRoot: '$grades'
+    -
+        name: 'with a newly created document'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceRoot/#-replaceroot-with-a-newly-created-document'
+        pipeline:
+            -
+                $replaceRoot:
+                    newRoot:
+                        full_name:
+                            $concat:
+                                - '$first_name'
+                                - ' '
+                                - '$last_name'
+    -
+        name: 'with a New Document Created from $$ROOT and a Default Document'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceRoot/#-replaceroot-with-a-new-document-created-from---root-and-a-default-document'
+        pipeline:
+            -
+                $replaceRoot:
+                    newRoot:
+                        $mergeObjects:
+                            -
+                                _id: ''
+                                name: ''
+                                email: ''
+                                cell: ''
+                                home: ''
+                            - '$$ROOT'

--- a/generator/config/stage/replaceRoot.yaml
+++ b/generator/config/stage/replaceRoot.yaml
@@ -31,6 +31,7 @@ tests:
         link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceRoot/#-replaceroot-with-a-document-nested-in-an-array'
         pipeline:
             -
+                # The builder uses the verbose form of the $unwind operator
                 # $unwind: '$grades'
                 $unwind:
                     path: '$grades'

--- a/generator/config/stage/replaceWith.yaml
+++ b/generator/config/stage/replaceWith.yaml
@@ -12,3 +12,62 @@ arguments:
         name: expression
         type:
             - resolvesToObject
+tests:
+    -
+        name: 'an Embedded Document Field'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceWith/#-replacewith-an-embedded-document-field'
+        pipeline:
+            -
+                $replaceWith:
+                    $mergeObjects:
+                        -
+                            dogs: 0
+                            cats: 0
+                            birds: 0
+                            fish: 0
+                        - '$pets'
+    -
+        name: 'a Document Nested in an Array'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceWith/#-replacewith-a-document-nested-in-an-array'
+        pipeline:
+            -
+                # $unwind: '$grades'
+                $unwind:
+                    path: '$grades'
+            -
+                $match:
+                    grades.grade:
+                        $gte: 90
+            -
+                $replaceWith: '$grades'
+    -
+        name: 'a Newly Created Document'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceWith/#-replacewith-a-newly-created-document'
+        pipeline:
+            -
+                $match:
+                    status: 'C'
+            -
+                $replaceWith:
+                    _id: '$_id'
+                    item: '$item'
+                    amount:
+                        $multiply:
+                            - '$price'
+                            - '$quantity'
+                    status: 'Complete'
+                    asofDate: '$$NOW'
+    -
+        name: 'a New Document Created from $$ROOT and a Default Document'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceWith/#-replacewith-a-new-document-created-from---root-and-a-default-document'
+        pipeline:
+            -
+                $replaceWith:
+                    $mergeObjects:
+                        -
+                            _id: ''
+                            name: ''
+                            email: ''
+                            cell: ''
+                            home: ''
+                        - '$$ROOT'

--- a/generator/config/stage/replaceWith.yaml
+++ b/generator/config/stage/replaceWith.yaml
@@ -31,6 +31,7 @@ tests:
         link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceWith/#-replacewith-a-document-nested-in-an-array'
         pipeline:
             -
+                # The builder uses the verbose form of the $unwind operator
                 # $unwind: '$grades'
                 $unwind:
                     path: '$grades'

--- a/generator/config/stage/sample.yaml
+++ b/generator/config/stage/sample.yaml
@@ -13,3 +13,11 @@ arguments:
             - int
         description: |
             The number of documents to randomly select.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/#example'
+        pipeline:
+            -
+                $sample:
+                    size: 3

--- a/generator/config/stage/set.yaml
+++ b/generator/config/stage/set.yaml
@@ -13,3 +13,61 @@ arguments:
         type:
             - expression
         variadic: object
+tests:
+    -
+        name: 'Using Two $set Stages'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/set/#using-two--set-stages'
+        pipeline:
+            -
+                $set:
+                    totalHomework:
+                        # The $sum expression is always build as an array, even if the value is an array field name
+                        # $sum: '$homework'
+                        $sum: ['$homework']
+                    totalQuiz:
+                        # $sum: '$quiz'
+                        $sum: ['$quiz']
+            -
+                $set:
+                    totalScore:
+                        $add:
+                            - '$totalHomework'
+                            - '$totalQuiz'
+                            - '$extraCredit'
+    -
+        name: 'Adding Fields to an Embedded Document'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/set/#adding-fields-to-an-embedded-document'
+        pipeline:
+            -
+                $set:
+                    specs.fuel_type: 'unleaded'
+    -
+        name: 'Overwriting an existing field'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/set/#overwriting-an-existing-field'
+        pipeline:
+            -
+                $set:
+                    cats: 20
+    -
+        name: 'Add Element to an Array'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/set/#add-element-to-an-array'
+        pipeline:
+            -
+                $match:
+                    _id: 1
+            -
+                $set:
+                    homework:
+                        $concatArrays:
+                            - '$homework'
+                            -
+                                - 7
+    -
+        name: 'Creating a New Field with Existing Fields'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/set/#creating-a-new-field-with-existing-fields'
+        pipeline:
+            -
+                $set:
+                    quizAverage:
+                        # $avg: '$quiz'
+                        $avg: ['$quiz']

--- a/generator/config/stage/setWindowFields.yaml
+++ b/generator/config/stage/setWindowFields.yaml
@@ -28,3 +28,117 @@ arguments:
         description: |
             Specifies an expression to group the documents. In the $setWindowFields stage, the group of documents is known as a partition. Default is one partition for the entire collection.
         optional: true
+tests:
+    -
+        name: 'Use Documents Window to Obtain Cumulative Quantity for Each State'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/setWindowFields/#use-documents-window-to-obtain-cumulative-quantity-for-each-state'
+        pipeline:
+            -
+                $setWindowFields:
+                    partitionBy: '$state'
+                    sortBy:
+                        orderDate: 1
+                    output:
+                        cumulativeQuantityForState:
+                            $sum: '$quantity'
+                            window:
+                                documents: ['unbounded', 'current']
+    -
+        name: 'Use Documents Window to Obtain Cumulative Quantity for Each Year'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/setWindowFields/#use-documents-window-to-obtain-cumulative-quantity-for-each-year'
+        pipeline:
+            -
+                $setWindowFields:
+                    partitionBy:
+                        # $year: '$orderDate'
+                        $year:
+                            date: '$orderDate'
+                    sortBy:
+                        orderDate: 1
+                    output:
+                        cumulativeQuantityForYear:
+                            $sum: '$quantity'
+                            window:
+                                documents: ['unbounded', 'current']
+    -
+        name: 'Use Documents Window to Obtain Moving Average Quantity for Each Year'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/setWindowFields/#use-documents-window-to-obtain-moving-average-quantity-for-each-year'
+        pipeline:
+            -
+                $setWindowFields:
+                    partitionBy:
+                        # $year: '$orderDate'
+                        $year:
+                            date: '$orderDate'
+                    sortBy:
+                        orderDate: 1
+                    output:
+                        averageQuantity:
+                            $avg: '$quantity'
+                            window:
+                                documents: [-1, 0]
+    -
+        name: 'Use Documents Window to Obtain Cumulative and Maximum Quantity for Each Year'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/setWindowFields/#use-documents-window-to-obtain-cumulative-and-maximum-quantity-for-each-year'
+        pipeline:
+            -
+                $setWindowFields:
+                    partitionBy:
+                        # $year: '$orderDate'
+                        $year:
+                            date: '$orderDate'
+                    sortBy:
+                        orderDate: 1
+                    output:
+                        cumulativeQuantityForYear:
+                            $sum: '$quantity'
+                            window:
+                                documents: ['unbounded', 'current']
+                        maximumQuantityForYear:
+                            $max: '$quantity'
+                            window:
+                                documents: ['unbounded', 'unbounded']
+    -
+        name: 'Range Window Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/setWindowFields/#range-window-example'
+        pipeline:
+            -
+                $setWindowFields:
+                    partitionBy: '$state'
+                    sortBy:
+                        price: 1
+                    output:
+                        quantityFromSimilarOrders:
+                            $sum: '$quantity'
+                            window:
+                                range: [-10, 10]
+    -
+        name: 'Use a Time Range Window with a Positive Upper Bound'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/setWindowFields/#use-a-time-range-window-with-a-positive-upper-bound'
+        pipeline:
+            -
+                $setWindowFields:
+                    partitionBy: '$state'
+                    sortBy:
+                        orderDate: 1
+                    output:
+                        recentOrders:
+                            $push: '$orderDate'
+                            window:
+                                range: ['unbounded', 10]
+                                unit: 'month'
+    -
+        name: 'Use a Time Range Window with a Negative Upper Bound'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/setWindowFields/#use-a-time-range-window-with-a-negative-upper-bound'
+        pipeline:
+            -
+                $setWindowFields:
+                    partitionBy: '$state'
+                    sortBy:
+                        orderDate: 1
+                    output:
+                        recentOrders:
+                            $push: '$orderDate'
+                            window:
+                                range: ['unbounded', -10]
+                                unit: 'month'

--- a/generator/config/stage/shardedDataDistribution.yaml
+++ b/generator/config/stage/shardedDataDistribution.yaml
@@ -7,3 +7,10 @@ encode: object
 description: |
     Provides data and size distribution information on sharded collections.
     New in MongoDB 6.0.3.
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/shardedDataDistribution/#examples'
+        pipeline:
+            -
+                $shardedDataDistribution: {}

--- a/generator/config/stage/skip.yaml
+++ b/generator/config/stage/skip.yaml
@@ -11,3 +11,10 @@ arguments:
         name: skip
         type:
             - int
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/skip/#example'
+        pipeline:
+            -
+                $skip: 5

--- a/generator/config/stage/sort.yaml
+++ b/generator/config/stage/sort.yaml
@@ -11,3 +11,25 @@ arguments:
         name: sort
         type:
             - object # SortSpec
+tests:
+    -
+        name: 'Ascending Descending Sort'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/sort/#ascending-descending-sort'
+        pipeline:
+            -
+                $sort:
+                    age: -1
+                    posts: 1
+    -
+        name: 'Text Score Metadata Sort'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/sort/#text-score-metadata-sort'
+        pipeline:
+            -
+                $match:
+                    $text:
+                        $search: 'operating'
+            -
+                $sort:
+                    score:
+                        $meta: 'textScore'
+                    posts: -1

--- a/generator/config/stage/sortByCount.yaml
+++ b/generator/config/stage/sortByCount.yaml
@@ -3,7 +3,7 @@ name: $sortByCount
 link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/sortByCount/'
 type:
     - stage
-encode: object
+encode: single
 description: |
     Groups incoming documents based on the value of a specified expression, then computes the count of documents in each distinct group.
 arguments:
@@ -11,3 +11,14 @@ arguments:
         name: expression
         type:
             - expression
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/sortByCount/#example'
+        pipeline:
+            -
+                # $unwind: '$tags'
+                $unwind:
+                    path: '$tags'
+            -
+                $sortByCount: '$tags'

--- a/generator/config/stage/sortByCount.yaml
+++ b/generator/config/stage/sortByCount.yaml
@@ -17,6 +17,7 @@ tests:
         link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/sortByCount/#example'
         pipeline:
             -
+                # The builder uses the verbose form of the $unwind operator
                 # $unwind: '$tags'
                 $unwind:
                     path: '$tags'

--- a/generator/config/stage/unionWith.yaml
+++ b/generator/config/stage/unionWith.yaml
@@ -61,6 +61,7 @@ tests:
         link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/unionWith/#report-2--aggregated-sales-by-items'
         pipeline:
             -
+                # Example uses the short form, the builder always generates the verbose form
                 # $unionWith: 'sales_2018'
                 $unionWith:
                     coll: 'sales_2018'
@@ -80,4 +81,3 @@ tests:
             -
                 $sort:
                     total: -1
-

--- a/generator/config/stage/unionWith.yaml
+++ b/generator/config/stage/unionWith.yaml
@@ -22,3 +22,62 @@ arguments:
         description: |
             An aggregation pipeline to apply to the specified coll.
             The pipeline cannot include the $out and $merge stages. Starting in v6.0, the pipeline can contain the Atlas Search $search stage as the first stage inside the pipeline.
+tests:
+    -
+        name: 'Report 1 All Sales by Year and Stores and Items'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/unionWith/#report-1--all-sales-by-year-and-stores-and-items'
+        pipeline:
+            -
+                $set:
+                    _id: '2017'
+            -
+                $unionWith:
+                    coll: 'sales_2018'
+                    pipeline:
+                        -
+                            $set:
+                                _id: '2018'
+            -
+                $unionWith:
+                    coll: 'sales_2019'
+                    pipeline:
+                        -
+                            $set:
+                                _id: '2019'
+            -
+                $unionWith:
+                    coll: 'sales_2020'
+                    pipeline:
+                        -
+                            $set:
+                                _id: '2020'
+            -
+                $sort:
+                    _id: 1
+                    store: 1
+                    item: 1
+    -
+        name: 'Report 2 Aggregated Sales by Items'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/unionWith/#report-2--aggregated-sales-by-items'
+        pipeline:
+            -
+                # $unionWith: 'sales_2018'
+                $unionWith:
+                    coll: 'sales_2018'
+            -
+                # $unionWith: 'sales_2019'
+                $unionWith:
+                    coll: 'sales_2019'
+            -
+                # $unionWith: 'sales_2020'
+                $unionWith:
+                    coll: 'sales_2020'
+            -
+                $group:
+                    _id: '$item'
+                    total:
+                        $sum: '$quantity'
+            -
+                $sort:
+                    total: -1
+

--- a/generator/config/stage/unset.yaml
+++ b/generator/config/stage/unset.yaml
@@ -19,7 +19,8 @@ tests:
         link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/unset/#remove-a-single-field'
         pipeline:
             -
-                # The aggregation builder always generate the array form
+                # The example in the docs uses the short syntax whereas
+                # the aggregation builder always uses the equivalent array syntax.
                 # $unset: 'copies'
                 $unset: ['copies']
     -

--- a/generator/config/stage/unset.yaml
+++ b/generator/config/stage/unset.yaml
@@ -13,3 +13,29 @@ arguments:
         type:
             - fieldPath
         variadic: array
+tests:
+    -
+        name: 'Remove a Single Field'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/unset/#remove-a-single-field'
+        pipeline:
+            -
+                # The aggregation builder always generate the array form
+                # $unset: 'copies'
+                $unset: ['copies']
+    -
+        name: 'Remove Top-Level Fields'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/unset/#remove-top-level-fields'
+        pipeline:
+            -
+                $unset:
+                    - 'isbn'
+                    - 'copies'
+    -
+        name: 'Remove Embedded Fields'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/unset/#remove-embedded-fields'
+        pipeline:
+            -
+                $unset:
+                    - 'isbn'
+                    - 'author.first'
+                    - 'copies.warehouse'

--- a/generator/config/stage/unwind.yaml
+++ b/generator/config/stage/unwind.yaml
@@ -35,7 +35,7 @@ tests:
         link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/unwind/#unwind-array'
         pipeline:
             -
-                # The aggregation builder always generated the object form
+                # Example uses the short form, the builder always generates the verbose form
                 # $unwind: '$sizes'
                 $unwind:
                     path: '$sizes'
@@ -76,10 +76,12 @@ tests:
         link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/unwind/#unwind-embedded-arrays'
         pipeline:
             -
+                # Example uses the short form, the builder always generates the verbose form
                 # $unwind: '$items'
                 $unwind:
                     path: '$items'
             -
+                # Example uses the short form, the builder always generates the verbose form
                 # $unwind: '$items.tags'
                 $unwind:
                     path: '$items.tags'

--- a/generator/config/stage/unwind.yaml
+++ b/generator/config/stage/unwind.yaml
@@ -29,3 +29,65 @@ arguments:
             If true, if the path is null, missing, or an empty array, $unwind outputs the document.
             If false, if path is null, missing, or an empty array, $unwind does not output a document.
             The default value is false.
+tests:
+    -
+        name: 'Unwind Array'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/unwind/#unwind-array'
+        pipeline:
+            -
+                # The aggregation builder always generated the object form
+                # $unwind: '$sizes'
+                $unwind:
+                    path: '$sizes'
+    -
+        name: 'preserveNullAndEmptyArrays'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/unwind/#preservenullandemptyarrays'
+        pipeline:
+            -
+                $unwind:
+                    path: '$sizes'
+                    preserveNullAndEmptyArrays: true
+    -
+        name: 'includeArrayIndex'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/unwind/#includearrayindex'
+        pipeline:
+            -
+                $unwind:
+                    path: '$sizes'
+                    includeArrayIndex: 'arrayIndex'
+    -
+        name: 'Group by Unwound Values'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/unwind/#group-by-unwound-values'
+        pipeline:
+            -
+                $unwind:
+                    path: '$sizes'
+                    preserveNullAndEmptyArrays: true
+            -
+                $group:
+                    _id: '$sizes'
+                    averagePrice:
+                        $avg: '$price'
+            -
+                $sort:
+                    averagePrice: -1
+    -
+        name: 'Unwind Embedded Arrays'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/unwind/#unwind-embedded-arrays'
+        pipeline:
+            -
+                # $unwind: '$items'
+                $unwind:
+                    path: '$items'
+            -
+                # $unwind: '$items.tags'
+                $unwind:
+                    path: '$items.tags'
+            -
+                $group:
+                    _id: '$items.tags'
+                    totalSalesAmount:
+                        $sum:
+                            $multiply:
+                                - '$items.price'
+                                - '$items.quantity'

--- a/generator/js2yaml.html
+++ b/generator/js2yaml.html
@@ -74,6 +74,10 @@
         return new TaggedValue('bson_binary', value);
     }
 
+    function ISODate(value) {
+        return new TaggedValue('bson_utcdatetime', value);
+    }
+
     function Decimal128(value) {
         return new TaggedValue('bson_decimal128', value)
     }

--- a/generator/src/OperatorTestGenerator.php
+++ b/generator/src/OperatorTestGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MongoDB\CodeGenerator;
 
+use DateTimeImmutable;
 use InvalidArgumentException;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\Decimal128;
@@ -27,6 +28,7 @@ use function base64_decode;
 use function basename;
 use function get_object_vars;
 use function is_array;
+use function is_numeric;
 use function is_object;
 use function json_decode;
 use function json_encode;
@@ -141,7 +143,7 @@ class OperatorTestGenerator extends OperatorGenerator
                 'bson_regex' => new Regex(...(array) $value),
                 'bson_int128' => new Int64($value),
                 'bson_decimal128' => new Decimal128($value),
-                'bson_utcdatetime' => new UTCDateTime($value),
+                'bson_utcdatetime' => new UTCDateTime(is_numeric($value) ? $value : new DateTimeImmutable($value)),
                 'bson_binary' => new Binary(base64_decode($value)),
                 default => throw new InvalidArgumentException(sprintf('Yaml tag "%s" is not supported.', $object->getTag())),
             };

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -1969,9 +1969,11 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sum/
      * @no-named-arguments
-     * @param Decimal128|Int64|ResolvesToNumber|float|int ...$expression
+     * @param BSONArray|Decimal128|Int64|PackedArray|ResolvesToArray|ResolvesToNumber|array|float|int ...$expression
      */
-    public static function sum(Decimal128|Int64|ResolvesToNumber|float|int ...$expression): SumOperator
+    public static function sum(
+        Decimal128|Int64|PackedArray|ResolvesToArray|ResolvesToNumber|BSONArray|array|float|int ...$expression,
+    ): SumOperator
     {
         return new SumOperator(...$expression);
     }

--- a/src/Builder/Expression/SumOperator.php
+++ b/src/Builder/Expression/SumOperator.php
@@ -10,9 +10,11 @@ namespace MongoDB\Builder\Expression;
 
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Int64;
+use MongoDB\BSON\PackedArray;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Model\BSONArray;
 
 use function array_is_list;
 
@@ -26,15 +28,16 @@ class SumOperator implements ResolvesToNumber, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 
-    /** @var list<Decimal128|Int64|ResolvesToNumber|float|int> $expression */
+    /** @var list<BSONArray|Decimal128|Int64|PackedArray|ResolvesToArray|ResolvesToNumber|array|float|int> $expression */
     public readonly array $expression;
 
     /**
-     * @param Decimal128|Int64|ResolvesToNumber|float|int ...$expression
+     * @param BSONArray|Decimal128|Int64|PackedArray|ResolvesToArray|ResolvesToNumber|array|float|int ...$expression
      * @no-named-arguments
      */
-    public function __construct(Decimal128|Int64|ResolvesToNumber|float|int ...$expression)
-    {
+    public function __construct(
+        Decimal128|Int64|PackedArray|ResolvesToArray|ResolvesToNumber|BSONArray|array|float|int ...$expression,
+    ) {
         if (\count($expression) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }

--- a/src/Builder/Stage/CollStatsStage.php
+++ b/src/Builder/Stage/CollStatsStage.php
@@ -12,6 +12,7 @@ use MongoDB\BSON\Document;
 use MongoDB\BSON\Serializable;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\Optional;
 use MongoDB\Builder\Type\StageInterface;
 use stdClass;
 
@@ -22,17 +23,36 @@ use stdClass;
  */
 class CollStatsStage implements StageInterface, OperatorInterface
 {
-    public const ENCODE = Encode::Single;
+    public const ENCODE = Encode::Object;
 
-    /** @var Document|Serializable|array|stdClass $config */
-    public readonly Document|Serializable|stdClass|array $config;
+    /** @var Optional|Document|Serializable|array|stdClass $latencyStats */
+    public readonly Optional|Document|Serializable|stdClass|array $latencyStats;
+
+    /** @var Optional|Document|Serializable|array|stdClass $storageStats */
+    public readonly Optional|Document|Serializable|stdClass|array $storageStats;
+
+    /** @var Optional|Document|Serializable|array|stdClass $count */
+    public readonly Optional|Document|Serializable|stdClass|array $count;
+
+    /** @var Optional|Document|Serializable|array|stdClass $queryExecStats */
+    public readonly Optional|Document|Serializable|stdClass|array $queryExecStats;
 
     /**
-     * @param Document|Serializable|array|stdClass $config
+     * @param Optional|Document|Serializable|array|stdClass $latencyStats
+     * @param Optional|Document|Serializable|array|stdClass $storageStats
+     * @param Optional|Document|Serializable|array|stdClass $count
+     * @param Optional|Document|Serializable|array|stdClass $queryExecStats
      */
-    public function __construct(Document|Serializable|stdClass|array $config)
-    {
-        $this->config = $config;
+    public function __construct(
+        Optional|Document|Serializable|stdClass|array $latencyStats = Optional::Undefined,
+        Optional|Document|Serializable|stdClass|array $storageStats = Optional::Undefined,
+        Optional|Document|Serializable|stdClass|array $count = Optional::Undefined,
+        Optional|Document|Serializable|stdClass|array $queryExecStats = Optional::Undefined,
+    ) {
+        $this->latencyStats = $latencyStats;
+        $this->storageStats = $storageStats;
+        $this->count = $count;
+        $this->queryExecStats = $queryExecStats;
     }
 
     public function getOperator(): string

--- a/src/Builder/Stage/CurrentOpStage.php
+++ b/src/Builder/Stage/CurrentOpStage.php
@@ -10,6 +10,7 @@ namespace MongoDB\Builder\Stage;
 
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\Optional;
 use MongoDB\Builder\Type\StageInterface;
 
 /**
@@ -21,8 +22,40 @@ class CurrentOpStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
-    public function __construct()
-    {
+    /** @var Optional|bool $allUsers */
+    public readonly Optional|bool $allUsers;
+
+    /** @var Optional|bool $idleConnections */
+    public readonly Optional|bool $idleConnections;
+
+    /** @var Optional|bool $idleCursors */
+    public readonly Optional|bool $idleCursors;
+
+    /** @var Optional|bool $idleSessions */
+    public readonly Optional|bool $idleSessions;
+
+    /** @var Optional|bool $localOps */
+    public readonly Optional|bool $localOps;
+
+    /**
+     * @param Optional|bool $allUsers
+     * @param Optional|bool $idleConnections
+     * @param Optional|bool $idleCursors
+     * @param Optional|bool $idleSessions
+     * @param Optional|bool $localOps
+     */
+    public function __construct(
+        Optional|bool $allUsers = Optional::Undefined,
+        Optional|bool $idleConnections = Optional::Undefined,
+        Optional|bool $idleCursors = Optional::Undefined,
+        Optional|bool $idleSessions = Optional::Undefined,
+        Optional|bool $localOps = Optional::Undefined,
+    ) {
+        $this->allUsers = $allUsers;
+        $this->idleConnections = $idleConnections;
+        $this->idleCursors = $idleCursors;
+        $this->idleSessions = $idleSessions;
+        $this->localOps = $localOps;
     }
 
     public function getOperator(): string

--- a/src/Builder/Stage/FactoryTrait.php
+++ b/src/Builder/Stage/FactoryTrait.php
@@ -156,10 +156,21 @@ trait FactoryTrait
      * Returns information on active and/or dormant operations for the MongoDB deployment. To run, use the db.aggregate() method.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/currentOp/
+     * @param Optional|bool $allUsers
+     * @param Optional|bool $idleConnections
+     * @param Optional|bool $idleCursors
+     * @param Optional|bool $idleSessions
+     * @param Optional|bool $localOps
      */
-    public static function currentOp(): CurrentOpStage
+    public static function currentOp(
+        Optional|bool $allUsers = Optional::Undefined,
+        Optional|bool $idleConnections = Optional::Undefined,
+        Optional|bool $idleCursors = Optional::Undefined,
+        Optional|bool $idleSessions = Optional::Undefined,
+        Optional|bool $localOps = Optional::Undefined,
+    ): CurrentOpStage
     {
-        return new CurrentOpStage();
+        return new CurrentOpStage($allUsers, $idleConnections, $idleCursors, $idleSessions, $localOps);
     }
 
     /**
@@ -236,7 +247,7 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/geoNear/
      * @param string $distanceField The output field that contains the calculated distance. To specify a field within an embedded document, use dot notation.
-     * @param Document|Serializable|array|stdClass $near The point for which to find the closest documents.
+     * @param Document|ResolvesToObject|Serializable|array|stdClass $near The point for which to find the closest documents.
      * @param Optional|Decimal128|Int64|float|int $distanceMultiplier The factor to multiply all distances returned by the query. For example, use the distanceMultiplier to convert radians, as returned by a spherical query, to kilometers by multiplying by the radius of the Earth.
      * @param Optional|string $includeLocs This specifies the output field that identifies the location used to calculate the distance. This option is useful when a location field contains multiple locations. To specify a field within an embedded document, use dot notation.
      * @param Optional|string $key Specify the geospatial indexed field to use when calculating the distance.
@@ -253,7 +264,7 @@ trait FactoryTrait
      */
     public static function geoNear(
         string $distanceField,
-        Document|Serializable|stdClass|array $near,
+        Document|Serializable|ResolvesToObject|stdClass|array $near,
         Optional|Decimal128|Int64|float|int $distanceMultiplier = Optional::Undefined,
         Optional|string $includeLocs = Optional::Undefined,
         Optional|string $key = Optional::Undefined,
@@ -431,17 +442,17 @@ trait FactoryTrait
      * New in MongoDB 4.2.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/merge/
-     * @param string $into The output collection.
+     * @param Document|Serializable|array|stdClass|string $into The output collection.
      * @param Optional|BSONArray|PackedArray|array|string $on Field or fields that act as a unique identifier for a document. The identifier determines if a results document matches an existing document in the output collection.
      * @param Optional|Document|Serializable|array|stdClass $let Specifies variables for use in the whenMatched pipeline.
-     * @param Optional|string $whenMatched The behavior of $merge if a result document and an existing document in the collection have the same value for the specified on field(s).
+     * @param Optional|BSONArray|PackedArray|Pipeline|array|string $whenMatched The behavior of $merge if a result document and an existing document in the collection have the same value for the specified on field(s).
      * @param Optional|string $whenNotMatched The behavior of $merge if a result document does not match an existing document in the out collection.
      */
     public static function merge(
-        string $into,
+        Document|Serializable|stdClass|array|string $into,
         Optional|PackedArray|BSONArray|array|string $on = Optional::Undefined,
         Optional|Document|Serializable|stdClass|array $let = Optional::Undefined,
-        Optional|string $whenMatched = Optional::Undefined,
+        Optional|PackedArray|Pipeline|BSONArray|array|string $whenMatched = Optional::Undefined,
         Optional|string $whenNotMatched = Optional::Undefined,
     ): MergeStage
     {
@@ -452,17 +463,11 @@ trait FactoryTrait
      * Writes the resulting documents of the aggregation pipeline to a collection. To use the $out stage, it must be the last stage in the pipeline.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/out/
-     * @param string $db Target collection name to write documents from $out to.
-     * @param string $coll Target database name to write documents from $out to.
-     * @param Optional|Document|Serializable|array|stdClass $timeseries If set, the aggregation stage will use these options to create or replace a time-series collection in the given namespace.
+     * @param Document|Serializable|array|stdClass|string $coll Target database name to write documents from $out to.
      */
-    public static function out(
-        string $db,
-        string $coll,
-        Optional|Document|Serializable|stdClass|array $timeseries = Optional::Undefined,
-    ): OutStage
+    public static function out(Document|Serializable|stdClass|array|string $coll): OutStage
     {
-        return new OutStage($db, $coll, $timeseries);
+        return new OutStage($coll);
     }
 
     /**

--- a/src/Builder/Stage/FactoryTrait.php
+++ b/src/Builder/Stage/FactoryTrait.php
@@ -133,11 +133,19 @@ trait FactoryTrait
      * Returns statistics regarding a collection or view.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/collStats/
-     * @param Document|Serializable|array|stdClass $config
+     * @param Optional|Document|Serializable|array|stdClass $latencyStats
+     * @param Optional|Document|Serializable|array|stdClass $storageStats
+     * @param Optional|Document|Serializable|array|stdClass $count
+     * @param Optional|Document|Serializable|array|stdClass $queryExecStats
      */
-    public static function collStats(Document|Serializable|stdClass|array $config): CollStatsStage
+    public static function collStats(
+        Optional|Document|Serializable|stdClass|array $latencyStats = Optional::Undefined,
+        Optional|Document|Serializable|stdClass|array $storageStats = Optional::Undefined,
+        Optional|Document|Serializable|stdClass|array $count = Optional::Undefined,
+        Optional|Document|Serializable|stdClass|array $queryExecStats = Optional::Undefined,
+    ): CollStatsStage
     {
-        return new CollStatsStage($config);
+        return new CollStatsStage($latencyStats, $storageStats, $count, $queryExecStats);
     }
 
     /**

--- a/src/Builder/Stage/GeoNearStage.php
+++ b/src/Builder/Stage/GeoNearStage.php
@@ -12,6 +12,7 @@ use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\Int64;
 use MongoDB\BSON\Serializable;
+use MongoDB\Builder\Expression\ResolvesToObject;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
 use MongoDB\Builder\Type\Optional;
@@ -34,8 +35,8 @@ class GeoNearStage implements StageInterface, OperatorInterface
     /** @var string $distanceField The output field that contains the calculated distance. To specify a field within an embedded document, use dot notation. */
     public readonly string $distanceField;
 
-    /** @var Document|Serializable|array|stdClass $near The point for which to find the closest documents. */
-    public readonly Document|Serializable|stdClass|array $near;
+    /** @var Document|ResolvesToObject|Serializable|array|stdClass $near The point for which to find the closest documents. */
+    public readonly Document|Serializable|ResolvesToObject|stdClass|array $near;
 
     /** @var Optional|Decimal128|Int64|float|int $distanceMultiplier The factor to multiply all distances returned by the query. For example, use the distanceMultiplier to convert radians, as returned by a spherical query, to kilometers by multiplying by the radius of the Earth. */
     public readonly Optional|Decimal128|Int64|float|int $distanceMultiplier;
@@ -74,7 +75,7 @@ class GeoNearStage implements StageInterface, OperatorInterface
 
     /**
      * @param string $distanceField The output field that contains the calculated distance. To specify a field within an embedded document, use dot notation.
-     * @param Document|Serializable|array|stdClass $near The point for which to find the closest documents.
+     * @param Document|ResolvesToObject|Serializable|array|stdClass $near The point for which to find the closest documents.
      * @param Optional|Decimal128|Int64|float|int $distanceMultiplier The factor to multiply all distances returned by the query. For example, use the distanceMultiplier to convert radians, as returned by a spherical query, to kilometers by multiplying by the radius of the Earth.
      * @param Optional|string $includeLocs This specifies the output field that identifies the location used to calculate the distance. This option is useful when a location field contains multiple locations. To specify a field within an embedded document, use dot notation.
      * @param Optional|string $key Specify the geospatial indexed field to use when calculating the distance.
@@ -91,7 +92,7 @@ class GeoNearStage implements StageInterface, OperatorInterface
      */
     public function __construct(
         string $distanceField,
-        Document|Serializable|stdClass|array $near,
+        Document|Serializable|ResolvesToObject|stdClass|array $near,
         Optional|Decimal128|Int64|float|int $distanceMultiplier = Optional::Undefined,
         Optional|string $includeLocs = Optional::Undefined,
         Optional|string $key = Optional::Undefined,

--- a/src/Builder/Stage/GroupStage.php
+++ b/src/Builder/Stage/GroupStage.php
@@ -45,10 +45,6 @@ class GroupStage implements StageInterface, OperatorInterface
         Document|Serializable|AccumulatorInterface|stdClass|array ...$field,
     ) {
         $this->_id = $_id;
-        if (\count($field) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $field, got %d.', 1, \count($field)));
-        }
-
         foreach($field as $key => $value) {
             if (! is_string($key)) {
                 throw new InvalidArgumentException('Expected $field arguments to be a map (object), named arguments (<name>:<value>) or array unpacking ...[\'<name>\' => <value>] must be used');

--- a/src/Builder/Stage/MergeStage.php
+++ b/src/Builder/Stage/MergeStage.php
@@ -11,6 +11,7 @@ namespace MongoDB\Builder\Stage;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\PackedArray;
 use MongoDB\BSON\Serializable;
+use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
 use MongoDB\Builder\Type\Optional;
@@ -32,8 +33,8 @@ class MergeStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
-    /** @var string $into The output collection. */
-    public readonly string $into;
+    /** @var Document|Serializable|array|stdClass|string $into The output collection. */
+    public readonly Document|Serializable|stdClass|array|string $into;
 
     /** @var Optional|BSONArray|PackedArray|array|string $on Field or fields that act as a unique identifier for a document. The identifier determines if a results document matches an existing document in the output collection. */
     public readonly Optional|PackedArray|BSONArray|array|string $on;
@@ -41,24 +42,24 @@ class MergeStage implements StageInterface, OperatorInterface
     /** @var Optional|Document|Serializable|array|stdClass $let Specifies variables for use in the whenMatched pipeline. */
     public readonly Optional|Document|Serializable|stdClass|array $let;
 
-    /** @var Optional|string $whenMatched The behavior of $merge if a result document and an existing document in the collection have the same value for the specified on field(s). */
-    public readonly Optional|string $whenMatched;
+    /** @var Optional|BSONArray|PackedArray|Pipeline|array|string $whenMatched The behavior of $merge if a result document and an existing document in the collection have the same value for the specified on field(s). */
+    public readonly Optional|PackedArray|Pipeline|BSONArray|array|string $whenMatched;
 
     /** @var Optional|string $whenNotMatched The behavior of $merge if a result document does not match an existing document in the out collection. */
     public readonly Optional|string $whenNotMatched;
 
     /**
-     * @param string $into The output collection.
+     * @param Document|Serializable|array|stdClass|string $into The output collection.
      * @param Optional|BSONArray|PackedArray|array|string $on Field or fields that act as a unique identifier for a document. The identifier determines if a results document matches an existing document in the output collection.
      * @param Optional|Document|Serializable|array|stdClass $let Specifies variables for use in the whenMatched pipeline.
-     * @param Optional|string $whenMatched The behavior of $merge if a result document and an existing document in the collection have the same value for the specified on field(s).
+     * @param Optional|BSONArray|PackedArray|Pipeline|array|string $whenMatched The behavior of $merge if a result document and an existing document in the collection have the same value for the specified on field(s).
      * @param Optional|string $whenNotMatched The behavior of $merge if a result document does not match an existing document in the out collection.
      */
     public function __construct(
-        string $into,
+        Document|Serializable|stdClass|array|string $into,
         Optional|PackedArray|BSONArray|array|string $on = Optional::Undefined,
         Optional|Document|Serializable|stdClass|array $let = Optional::Undefined,
-        Optional|string $whenMatched = Optional::Undefined,
+        Optional|PackedArray|Pipeline|BSONArray|array|string $whenMatched = Optional::Undefined,
         Optional|string $whenNotMatched = Optional::Undefined,
     ) {
         $this->into = $into;
@@ -68,6 +69,10 @@ class MergeStage implements StageInterface, OperatorInterface
 
         $this->on = $on;
         $this->let = $let;
+        if (is_array($whenMatched) && ! array_is_list($whenMatched)) {
+            throw new InvalidArgumentException('Expected $whenMatched argument to be a list, got an associative array.');
+        }
+
         $this->whenMatched = $whenMatched;
         $this->whenNotMatched = $whenNotMatched;
     }

--- a/src/Builder/Stage/OutStage.php
+++ b/src/Builder/Stage/OutStage.php
@@ -12,7 +12,6 @@ use MongoDB\BSON\Document;
 use MongoDB\BSON\Serializable;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
-use MongoDB\Builder\Type\Optional;
 use MongoDB\Builder\Type\StageInterface;
 use stdClass;
 
@@ -23,30 +22,17 @@ use stdClass;
  */
 class OutStage implements StageInterface, OperatorInterface
 {
-    public const ENCODE = Encode::Object;
+    public const ENCODE = Encode::Single;
 
-    /** @var string $db Target collection name to write documents from $out to. */
-    public readonly string $db;
-
-    /** @var string $coll Target database name to write documents from $out to. */
-    public readonly string $coll;
-
-    /** @var Optional|Document|Serializable|array|stdClass $timeseries If set, the aggregation stage will use these options to create or replace a time-series collection in the given namespace. */
-    public readonly Optional|Document|Serializable|stdClass|array $timeseries;
+    /** @var Document|Serializable|array|stdClass|string $coll Target database name to write documents from $out to. */
+    public readonly Document|Serializable|stdClass|array|string $coll;
 
     /**
-     * @param string $db Target collection name to write documents from $out to.
-     * @param string $coll Target database name to write documents from $out to.
-     * @param Optional|Document|Serializable|array|stdClass $timeseries If set, the aggregation stage will use these options to create or replace a time-series collection in the given namespace.
+     * @param Document|Serializable|array|stdClass|string $coll Target database name to write documents from $out to.
      */
-    public function __construct(
-        string $db,
-        string $coll,
-        Optional|Document|Serializable|stdClass|array $timeseries = Optional::Undefined,
-    ) {
-        $this->db = $db;
+    public function __construct(Document|Serializable|stdClass|array|string $coll)
+    {
         $this->coll = $coll;
-        $this->timeseries = $timeseries;
     }
 
     public function getOperator(): string

--- a/src/Builder/Stage/SortByCountStage.php
+++ b/src/Builder/Stage/SortByCountStage.php
@@ -22,7 +22,7 @@ use stdClass;
  */
 class SortByCountStage implements StageInterface, OperatorInterface
 {
-    public const ENCODE = Encode::Object;
+    public const ENCODE = Encode::Single;
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -4850,7 +4850,7 @@ enum Pipelines: string
                                 }
                             },
                             {
-                                "$numberDouble": "10.230000000000000426"
+                                "$numberDecimal": "10.23"
                             },
                             {
                                 "a": "On sale"

--- a/tests/Builder/Expression/SortArrayOperatorTest.php
+++ b/tests/Builder/Expression/SortArrayOperatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Tests\Builder\Expression;
 
+use MongoDB\BSON\Decimal128;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
@@ -83,7 +84,7 @@ class SortArrayOperatorTest extends PipelineTestCase
                         'Gratis',
                         ['a' => null],
                         object(a: object(sale: true, price: 19)),
-                        10.23,
+                        new Decimal128('10.23'),
                         ['a' => 'On sale'],
                     ],
                     sortBy: 1,

--- a/tests/Builder/Stage/AddFieldsStageTest.php
+++ b/tests/Builder/Stage/AddFieldsStageTest.php
@@ -14,6 +14,23 @@ use MongoDB\Tests\Builder\PipelineTestCase;
  */
 class AddFieldsStageTest extends PipelineTestCase
 {
+    public function testAddElementToAnArray(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                _id: 1,
+            ),
+            Stage::addFields(
+                homework: Expression::concatArrays(
+                    Expression::arrayFieldPath('homework'),
+                    [7],
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::AddFieldsAddElementToAnArray, $pipeline);
+    }
+
     public function testAddingFieldsToAnEmbeddedDocument(): void
     {
         $pipeline = new Pipeline(
@@ -25,10 +42,19 @@ class AddFieldsStageTest extends PipelineTestCase
         $this->assertSamePipeline(Pipelines::AddFieldsAddingFieldsToAnEmbeddedDocument, $pipeline);
     }
 
+    public function testOverwritingAnExistingField(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::addFields(
+                cats: 20,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::AddFieldsOverwritingAnExistingField, $pipeline);
+    }
+
     public function testUsingTwoAddFieldsStages(): void
     {
-        $this->markTestSkipped('$sum must accept arrayFieldPath and render it as a single value: https://jira.mongodb.org/browse/PHPLIB-1287');
-
         $pipeline = new Pipeline(
             Stage::addFields(
                 totalHomework: Expression::sum(Expression::fieldPath('homework')),

--- a/tests/Builder/Stage/BucketAutoStageTest.php
+++ b/tests/Builder/Stage/BucketAutoStageTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $bucketAuto stage
+ */
+class BucketAutoStageTest extends PipelineTestCase
+{
+    public function testSingleFacetAggregation(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::bucketAuto(
+                groupBy: Expression::fieldPath('price'),
+                buckets: 4,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::BucketAutoSingleFacetAggregation, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/BucketStageTest.php
+++ b/tests/Builder/Stage/BucketStageTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $bucket stage
+ */
+class BucketStageTest extends PipelineTestCase
+{
+    public function testBucketByYearAndFilterByBucketResults(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::bucket(
+                groupBy: Expression::fieldPath('year_born'),
+                boundaries: [1840, 1850, 1860, 1870, 1880],
+                default: 'Other',
+                output: object(
+                    count: Accumulator::sum(1),
+                    artists: Accumulator::push(
+                        object(
+                            name: Expression::concat(
+                                Expression::stringFieldPath('first_name'),
+                                ' ',
+                                Expression::stringFieldPath('last_name'),
+                            ),
+                            year_born: Expression::fieldPath('year_born'),
+                        ),
+                    ),
+                ),
+            ),
+            Stage::match(
+                count: Query::gt(3),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::BucketBucketByYearAndFilterByBucketResults, $pipeline);
+    }
+
+    public function testUseBucketWithFacetToBucketByMultipleFields(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::facet(
+                price: new Pipeline(
+                    Stage::bucket(
+                        groupBy: Expression::numberFieldPath('price'),
+                        boundaries: [0, 200, 400],
+                        default: 'Other',
+                        output: object(
+                            count: Accumulator::sum(1),
+                            artwork: Accumulator::push(
+                                object(
+                                    title: Expression::stringFieldPath('title'),
+                                    price: Expression::stringFieldPath('price'),
+                                ),
+                            ),
+                            averagePrice: Accumulator::avg(
+                                Expression::numberFieldPath('price'),
+                            ),
+                        ),
+                    ),
+                ),
+                year: new Pipeline(
+                    Stage::bucket(
+                        groupBy: Expression::stringFieldPath('year'),
+                        boundaries: [1890, 1910, 1920, 1940],
+                        default: 'Unknown',
+                        output: object(
+                            count: Accumulator::sum(1),
+                            artwork: Accumulator::push(
+                                object(
+                                    title: Expression::stringFieldPath('title'),
+                                    year: Expression::stringFieldPath('year'),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::BucketUseBucketWithFacetToBucketByMultipleFields, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/ChangeStreamSplitLargeEventStageTest.php
+++ b/tests/Builder/Stage/ChangeStreamSplitLargeEventStageTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $changeStreamSplitLargeEvent stage
+ */
+class ChangeStreamSplitLargeEventStageTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::changeStreamSplitLargeEvent(),
+        );
+
+        $this->assertSamePipeline(Pipelines::ChangeStreamSplitLargeEventExample, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/ChangeStreamStageTest.php
+++ b/tests/Builder/Stage/ChangeStreamStageTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $changeStream stage
+ */
+class ChangeStreamStageTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::changeStream(),
+        );
+
+        $this->assertSamePipeline(Pipelines::ChangeStreamExample, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/CollStatsStageTest.php
+++ b/tests/Builder/Stage/CollStatsStageTest.php
@@ -19,9 +19,7 @@ class CollStatsStageTest extends PipelineTestCase
     {
         $pipeline = new Pipeline(
             Stage::collStats(
-                object(
-                    count: object(),
-                ),
+                count: object(),
             ),
         );
 
@@ -32,10 +30,8 @@ class CollStatsStageTest extends PipelineTestCase
     {
         $pipeline = new Pipeline(
             Stage::collStats(
-                object(
-                    latencyStats: object(
-                        histograms: true,
-                    ),
+                latencyStats: object(
+                    histograms: true,
                 ),
             ),
         );
@@ -47,9 +43,7 @@ class CollStatsStageTest extends PipelineTestCase
     {
         $pipeline = new Pipeline(
             Stage::collStats(
-                object(
-                    queryExecStats: object(),
-                ),
+                queryExecStats: object(),
             ),
         );
 
@@ -60,9 +54,7 @@ class CollStatsStageTest extends PipelineTestCase
     {
         $pipeline = new Pipeline(
             Stage::collStats(
-                object(
-                    storageStats: object(),
-                ),
+                storageStats: object(),
             ),
         );
 

--- a/tests/Builder/Stage/CollStatsStageTest.php
+++ b/tests/Builder/Stage/CollStatsStageTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $collStats stage
+ */
+class CollStatsStageTest extends PipelineTestCase
+{
+    public function testCountField(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::collStats(
+                object(
+                    count: object(),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::CollStatsCountField, $pipeline);
+    }
+
+    public function testLatencyStatsDocument(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::collStats(
+                object(
+                    latencyStats: object(
+                        histograms: true,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::CollStatsLatencyStatsDocument, $pipeline);
+    }
+
+    public function testQueryExecStatsDocument(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::collStats(
+                object(
+                    queryExecStats: object(),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::CollStatsQueryExecStatsDocument, $pipeline);
+    }
+
+    public function testStorageStatsDocument(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::collStats(
+                object(
+                    storageStats: object(),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::CollStatsStorageStatsDocument, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/CountStageTest.php
+++ b/tests/Builder/Stage/CountStageTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $count stage
+ */
+class CountStageTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                score: Query::gt(80),
+            ),
+            Stage::count('passing_scores'),
+        );
+
+        $this->assertSamePipeline(Pipelines::CountExample, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/CurrentOpStageTest.php
+++ b/tests/Builder/Stage/CurrentOpStageTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $currentOp stage
+ */
+class CurrentOpStageTest extends PipelineTestCase
+{
+    public function testInactiveSessions(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::currentOp(
+                allUsers: true,
+                idleSessions: true,
+            ),
+            Stage::match(
+                active: false,
+                transaction: Query::exists(true),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::CurrentOpInactiveSessions, $pipeline);
+    }
+
+    public function testSampledQueries(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::currentOp(
+                allUsers: true,
+                localOps: true,
+            ),
+            Stage::match(
+                desc: 'query analyzer',
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::CurrentOpSampledQueries, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/DensifyStageTest.php
+++ b/tests/Builder/Stage/DensifyStageTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use DateTimeImmutable;
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $densify stage
+ */
+class DensifyStageTest extends PipelineTestCase
+{
+    public function testDensifictionWithPartitions(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::densify(
+                field: 'altitude',
+                partitionByFields: ['variety'],
+                range: object(
+                    bounds: 'full',
+                    step: 200,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DensifyDensifictionWithPartitions, $pipeline);
+    }
+
+    public function testDensifyTimeSeriesData(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::densify(
+                field: 'timestamp',
+                range: object(
+                    step: 1,
+                    unit: 'hour',
+                    bounds: [
+                        new UTCDateTime(new DateTimeImmutable('2021-05-18T00:00:00.000Z')),
+                        new UTCDateTime(new DateTimeImmutable('2021-05-18T08:00:00.000Z')),
+                    ],
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DensifyDensifyTimeSeriesData, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/DocumentsStageTest.php
+++ b/tests/Builder/Stage/DocumentsStageTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\BSON\Document;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $documents stage
+ */
+class DocumentsStageTest extends PipelineTestCase
+{
+    public function testTestAPipelineStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::documents([
+                object(x: 10),
+                object(x: 2),
+                object(x: 5),
+            ]),
+            Stage::bucketAuto(
+                groupBy: Expression::intFieldPath('x'),
+                buckets: 4,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DocumentsTestAPipelineStage, $pipeline);
+    }
+
+    public function testUseADocumentsStageInALookupStage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(),
+            Stage::lookup(
+                localField: 'zip',
+                foreignField: 'zip_id',
+                as: 'city_state',
+                pipeline: new Pipeline(
+                    Stage::documents([
+                        Document::fromPHP(object(zip_id: 94301, name: 'Palo Alto, CA')),
+                        Document::fromPHP(object(zip_id: 10019, name: 'New York, NY')),
+                    ]),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::DocumentsUseADocumentsStageInALookupStage, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/FacetStageTest.php
+++ b/tests/Builder/Stage/FacetStageTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $facet stage
+ */
+class FacetStageTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::facet(
+                ...[
+                    'categorizedByYears(Auto)' => new Pipeline(
+                        Stage::bucketAuto(
+                            groupBy: Expression::stringFieldPath('year'),
+                            buckets: 4,
+                        ),
+                    ),
+                ],
+                categorizedByTags: new Pipeline(
+                    Stage::unwind(
+                        Expression::arrayFieldPath('tags'),
+                    ),
+                    Stage::sortByCount(
+                        Expression::arrayFieldPath('tags'),
+                    ),
+                ),
+                categorizedByPrice: new Pipeline(
+                    Stage::match(
+                        price: Query::exists(true),
+                    ),
+                    Stage::bucket(
+                        groupBy: Expression::numberFieldPath('price'),
+                        boundaries: [0, 150, 200, 300, 400],
+                        default: 'Other',
+                        output: object(
+                            count: Accumulator::sum(1),
+                            titles: Accumulator::push(
+                                Expression::stringFieldPath('title'),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::FacetExample, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/FillStageTest.php
+++ b/tests/Builder/Stage/FillStageTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $fill stage
+ */
+class FillStageTest extends PipelineTestCase
+{
+    public function testFillDataForDistinctPartitions(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::fill(
+                sortBy: object(
+                    date: 1,
+                ),
+                partitionBy: object(
+                    restaurant: Expression::stringFieldPath('restaurant'),
+                ),
+                output: object(
+                    score: object(method: 'locf'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::FillFillDataForDistinctPartitions, $pipeline);
+    }
+
+    public function testFillMissingFieldValuesBasedOnTheLastObservedValue(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::fill(
+                sortBy: object(
+                    date: 1,
+                ),
+                output: object(
+                    score: object(method: 'locf'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::FillFillMissingFieldValuesBasedOnTheLastObservedValue, $pipeline);
+    }
+
+    public function testFillMissingFieldValuesWithAConstantValue(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::fill(
+                output: object(
+                    bootsSold: object(value: 0),
+                    sandalsSold: object(value: 0),
+                    sneakersSold: object(value: 0),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::FillFillMissingFieldValuesWithAConstantValue, $pipeline);
+    }
+
+    public function testFillMissingFieldValuesWithLinearInterpolation(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::fill(
+                sortBy: object(
+                    time: 1,
+                ),
+                output: object(
+                    price: object(method: 'linear'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::FillFillMissingFieldValuesWithLinearInterpolation, $pipeline);
+    }
+
+    public function testIndicateIfAFieldWasPopulatedUsingFill(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::set(
+                valueExisted: Expression::ifNull(
+                    Expression::toBool(
+                        Expression::toString(
+                            Expression::fieldPath('score'),
+                        ),
+                    ),
+                    false,
+                ),
+            ),
+            Stage::fill(
+                sortBy: object(
+                    date: 1,
+                ),
+                output: object(
+                    score: object(method: 'locf'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::FillIndicateIfAFieldWasPopulatedUsingFill, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/GeoNearStageTest.php
+++ b/tests/Builder/Stage/GeoNearStageTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $geoNear stage
+ */
+class GeoNearStageTest extends PipelineTestCase
+{
+    public function testMaximumDistance(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::geoNear(
+                near: object(
+                    type: 'Point',
+                    coordinates: [-73.99279, 40.719296],
+                ),
+                distanceField: 'dist.calculated',
+                maxDistance: 2,
+                query: Query::query(
+                    category: 'Parks',
+                ),
+                includeLocs: 'dist.location',
+                spherical: true,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GeoNearMaximumDistance, $pipeline);
+    }
+
+    public function testMinimumDistance(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::geoNear(
+                near: object(
+                    type: 'Point',
+                    coordinates: [-73.99279, 40.719296],
+                ),
+                distanceField: 'dist.calculated',
+                minDistance: 2,
+                query: Query::query(
+                    category: 'Parks',
+                ),
+                includeLocs: 'dist.location',
+                spherical: true,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GeoNearMinimumDistance, $pipeline);
+    }
+
+    public function testSpecifyWhichGeospatialIndexToUse(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::geoNear(
+                near: object(
+                    type: 'Point',
+                    coordinates: [-73.98142, 40.71782],
+                ),
+                key: 'location',
+                distanceField: 'dist.calculated',
+                query: Query::query(
+                    category: 'Parks',
+                ),
+            ),
+            Stage::limit(5),
+        );
+
+        $this->assertSamePipeline(Pipelines::GeoNearSpecifyWhichGeospatialIndexToUse, $pipeline);
+    }
+
+    public function testWithBoundLetOption(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::lookup(
+                from: 'places',
+                let: object(
+                    pt: Expression::stringFieldPath('location'),
+                ),
+                pipeline: new Pipeline(
+                    Stage::geoNear(
+                        near: Expression::variable('pt'),
+                        distanceField: 'distance',
+                    ),
+                ),
+                as: 'joinedField',
+            ),
+            Stage::match(
+                name: 'Sara D. Roosevelt Park',
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GeoNearWithBoundLetOption, $pipeline);
+    }
+
+    public function testWithTheLetOption(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::geoNear(
+                near: Expression::variable('pt'),
+                distanceField: 'distance',
+                maxDistance: 2,
+                query: Query::query(
+                    category: 'Parks',
+                ),
+                includeLocs: 'dist.location',
+                spherical: true,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GeoNearWithTheLetOption, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/GraphLookupStageTest.php
+++ b/tests/Builder/Stage/GraphLookupStageTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $graphLookup stage
+ */
+class GraphLookupStageTest extends PipelineTestCase
+{
+    public function testAcrossMultipleCollections(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::graphLookup(
+                from: 'airports',
+                startWith: Expression::stringFieldPath('nearestAirport'),
+                connectFromField: 'connects',
+                connectToField: 'airport',
+                maxDepth: 2,
+                depthField: 'numConnections',
+                as: 'destinations',
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GraphLookupAcrossMultipleCollections, $pipeline);
+    }
+
+    public function testWithAQueryFilter(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                name: 'Tanya Jordan',
+            ),
+            Stage::graphLookup(
+                from: 'people',
+                startWith: Expression::stringFieldPath('friends'),
+                connectFromField: 'friends',
+                connectToField: 'name',
+                as: 'golfers',
+                restrictSearchWithMatch: Query::query(
+                    hobbies: 'golf',
+                ),
+            ),
+            Stage::project(
+                ...[
+                    'connections who play golf' => Expression::stringFieldPath('golfers.name'),
+                ],
+                name: 1,
+                friends: 1,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GraphLookupWithAQueryFilter, $pipeline);
+    }
+
+    public function testWithinASingleCollection(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::graphLookup(
+                from: 'employees',
+                startWith: Expression::stringFieldPath('reportsTo'),
+                connectFromField: 'reportsTo',
+                connectToField: 'name',
+                as: 'reportingHierarchy',
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GraphLookupWithinASingleCollection, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/GroupStageTest.php
+++ b/tests/Builder/Stage/GroupStageTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use DateTimeImmutable;
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $group stage
+ */
+class GroupStageTest extends PipelineTestCase
+{
+    public function testCalculateCountSumAndAverage(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                date: [
+                    Query::gte(new UTCDateTime(new DateTimeImmutable('2014-01-01'))),
+                    Query::lt(new UTCDateTime(new DateTimeImmutable('2015-01-01'))),
+                ],
+            ),
+            Stage::group(
+                _id: Expression::dateToString(Expression::dateFieldPath('date'), '%Y-%m-%d'),
+                totalSaleAmount: Accumulator::sum(
+                    Expression::multiply(
+                        Expression::numberFieldPath('price'),
+                        Expression::numberFieldPath('quantity'),
+                    ),
+                ),
+                averageQuantity: Accumulator::avg(
+                    Expression::numberFieldPath('quantity'),
+                ),
+                count: Accumulator::sum(1),
+            ),
+            Stage::sort(
+                object(
+                    totalSaleAmount: -1,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GroupCalculateCountSumAndAverage, $pipeline);
+    }
+
+    public function testCountTheNumberOfDocumentsInACollection(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: null,
+                count: Accumulator::count(),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GroupCountTheNumberOfDocumentsInACollection, $pipeline);
+    }
+
+    public function testGroupByItemHaving(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: Expression::fieldPath('item'),
+                totalSaleAmount: Accumulator::sum(
+                    Expression::multiply(
+                        Expression::numberFieldPath('price'),
+                        Expression::numberFieldPath('quantity'),
+                    ),
+                ),
+            ),
+            Stage::match(
+                totalSaleAmount: Query::gte(100),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GroupGroupByItemHaving, $pipeline);
+    }
+
+    public function testGroupByNull(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: null,
+                totalSaleAmount: Accumulator::sum(
+                    Expression::multiply(
+                        Expression::numberFieldPath('price'),
+                        Expression::numberFieldPath('quantity'),
+                    ),
+                ),
+                averageQuantity: Accumulator::avg(
+                    Expression::numberFieldPath('quantity'),
+                ),
+                count: Accumulator::sum(1),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GroupGroupByNull, $pipeline);
+    }
+
+    public function testGroupDocumentsByAuthor(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: Expression::fieldPath('author'),
+                books: Accumulator::push(
+                    Expression::variable('ROOT'),
+                ),
+            ),
+            Stage::addFields(
+                totalCopies: Expression::sum(
+                    Expression::numberFieldPath('books.copies'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GroupGroupDocumentsByAuthor, $pipeline);
+    }
+
+    public function testPivotData(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: Expression::fieldPath('author'),
+                books: Accumulator::push(
+                    Expression::stringFieldPath('title'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GroupPivotData, $pipeline);
+    }
+
+    public function testRetrieveDistinctValues(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: Expression::stringFieldPath('item'),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::GroupRetrieveDistinctValues, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/IndexStatsStageTest.php
+++ b/tests/Builder/Stage/IndexStatsStageTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $indexStats stage
+ */
+class IndexStatsStageTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::indexStats(),
+        );
+
+        $this->assertSamePipeline(Pipelines::IndexStatsExample, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/LimitStageTest.php
+++ b/tests/Builder/Stage/LimitStageTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $limit stage
+ */
+class LimitStageTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::limit(5),
+        );
+
+        $this->assertSamePipeline(Pipelines::LimitExample, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/ListLocalSessionsStageTest.php
+++ b/tests/Builder/Stage/ListLocalSessionsStageTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $listLocalSessions stage
+ */
+class ListLocalSessionsStageTest extends PipelineTestCase
+{
+    public function testListAllLocalSessions(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::listLocalSessions(
+                allUsers: true,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ListLocalSessionsListAllLocalSessions, $pipeline);
+    }
+
+    public function testListAllLocalSessionsForTheCurrentUser(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::listLocalSessions(),
+        );
+
+        $this->assertSamePipeline(Pipelines::ListLocalSessionsListAllLocalSessionsForTheCurrentUser, $pipeline);
+    }
+
+    public function testListAllLocalSessionsForTheSpecifiedUsers(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::listLocalSessions(
+                users: [
+                    object(user: 'myAppReader', db: 'test'),
+                ],
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ListLocalSessionsListAllLocalSessionsForTheSpecifiedUsers, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/ListSampledQueriesStageTest.php
+++ b/tests/Builder/Stage/ListSampledQueriesStageTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $listSampledQueries stage
+ */
+class ListSampledQueriesStageTest extends PipelineTestCase
+{
+    public function testListSampledQueriesForASpecificCollection(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::listSampledQueries(
+                namespace: 'social.post',
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ListSampledQueriesListSampledQueriesForASpecificCollection, $pipeline);
+    }
+
+    public function testListSampledQueriesForAllCollections(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::listSampledQueries(),
+        );
+
+        $this->assertSamePipeline(Pipelines::ListSampledQueriesListSampledQueriesForAllCollections, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/ListSearchIndexesStageTest.php
+++ b/tests/Builder/Stage/ListSearchIndexesStageTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $listSearchIndexes stage
+ */
+class ListSearchIndexesStageTest extends PipelineTestCase
+{
+    public function testReturnASingleSearchIndexById(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::listSearchIndexes(
+                id: '6524096020da840844a4c4a7',
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ListSearchIndexesReturnASingleSearchIndexById, $pipeline);
+    }
+
+    public function testReturnASingleSearchIndexByName(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::listSearchIndexes(
+                name: 'synonym-mappings',
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ListSearchIndexesReturnASingleSearchIndexByName, $pipeline);
+    }
+
+    public function testReturnAllSearchIndexes(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::listSearchIndexes(),
+        );
+
+        $this->assertSamePipeline(Pipelines::ListSearchIndexesReturnAllSearchIndexes, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/ListSessionsStageTest.php
+++ b/tests/Builder/Stage/ListSessionsStageTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $listSessions stage
+ */
+class ListSessionsStageTest extends PipelineTestCase
+{
+    public function testListAllSessions(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::listSessions(
+                allUsers: true,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ListSessionsListAllSessions, $pipeline);
+    }
+
+    public function testListAllSessionsForTheCurrentUser(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::listSessions(),
+        );
+
+        $this->assertSamePipeline(Pipelines::ListSessionsListAllSessionsForTheCurrentUser, $pipeline);
+    }
+
+    public function testListAllSessionsForTheSpecifiedUsers(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::listSessions(
+                users: [
+                    object(user: 'myAppReader', db: 'test'),
+                ],
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ListSessionsListAllSessionsForTheSpecifiedUsers, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/LookupStageTest.php
+++ b/tests/Builder/Stage/LookupStageTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $lookup stage
+ */
+class LookupStageTest extends PipelineTestCase
+{
+    public function testPerformAConciseCorrelatedSubqueryWithLookup(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::lookup(
+                from: 'restaurants',
+                localField: 'restaurant_name',
+                foreignField: 'name',
+                let: object(
+                    orders_drink: Expression::fieldPath('drink'),
+                ),
+                pipeline: new Pipeline(
+                    Stage::match(
+                        Query::expr(
+                            Expression::in(
+                                Expression::variable('orders_drink'),
+                                Expression::fieldPath('beverages'),
+                            ),
+                        ),
+                    ),
+                ),
+                as: 'matches',
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::LookupPerformAConciseCorrelatedSubqueryWithLookup, $pipeline);
+    }
+
+    public function testPerformASingleEqualityJoinWithLookup(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::lookup(
+                from: 'inventory',
+                localField: 'item',
+                foreignField: 'sku',
+                as: 'inventory_docs',
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::LookupPerformASingleEqualityJoinWithLookup, $pipeline);
+    }
+
+    public function testPerformAnUncorrelatedSubqueryWithLookup(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::lookup(
+                from: 'holidays',
+                pipeline: new Pipeline(
+                    Stage::match(
+                        year: 2018,
+                    ),
+                    Stage::project(
+                        _id: 0,
+                        date: object(
+                            name: Expression::stringFieldPath('name'),
+                            date: Expression::dateFieldPath('date'),
+                        ),
+                    ),
+                    Stage::replaceRoot(Expression::objectFieldPath('date')),
+                ),
+                as: 'holidays',
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::LookupPerformAnUncorrelatedSubqueryWithLookup, $pipeline);
+    }
+
+    public function testPerformMultipleJoinsAndACorrelatedSubqueryWithLookup(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::lookup(
+                from: 'warehouses',
+                let: object(
+                    order_item: Expression::fieldPath('item'),
+                    order_qty: Expression::intFieldPath('ordered'),
+                ),
+                pipeline: new Pipeline(
+                    Stage::match(
+                        Query::expr(
+                            Expression::and(
+                                Expression::eq(
+                                    Expression::stringFieldPath('stock_item'),
+                                    Expression::variable('order_item'),
+                                ),
+                                Expression::gte(
+                                    Expression::intFieldPath('instock'),
+                                    Expression::variable('order_qty'),
+                                ),
+                            ),
+                        ),
+                    ),
+                    Stage::project(
+                        stock_item: 0,
+                        _id: 0,
+                    ),
+                ),
+                as: 'stockdata',
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::LookupPerformMultipleJoinsAndACorrelatedSubqueryWithLookup, $pipeline);
+    }
+
+    public function testUseLookupWithAnArray(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::lookup(
+                from: 'members',
+                localField: 'enrollmentlist',
+                foreignField: 'name',
+                as: 'enrollee_info',
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::LookupUseLookupWithAnArray, $pipeline);
+    }
+
+    public function testUseLookupWithMergeObjects(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::lookup(
+                from: 'items',
+                localField: 'item',
+                foreignField: 'item',
+                as: 'fromItems',
+            ),
+            Stage::replaceRoot(
+                Expression::mergeObjects(
+                    Expression::arrayElemAt(
+                        Expression::arrayFieldPath('fromItems'),
+                        0,
+                    ),
+                    Expression::variable('ROOT'),
+                ),
+            ),
+            Stage::project(
+                fromItems: 0,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::LookupUseLookupWithMergeObjects, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/MatchStageTest.php
+++ b/tests/Builder/Stage/MatchStageTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $match stage
+ */
+class MatchStageTest extends PipelineTestCase
+{
+    public function testEqualityMatch(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                author: 'dave',
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MatchEqualityMatch, $pipeline);
+    }
+
+    public function testPerformACount(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::or(
+                    Query::query(
+                        score: [
+                            Query::gt(70),
+                            Query::lt(90),
+                        ],
+                    ),
+                    Query::query(
+                        views: Query::gte(1000),
+                    ),
+                ),
+            ),
+            Stage::group(
+                _id: null,
+                count: Accumulator::sum(1),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MatchPerformACount, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/MergeStageTest.php
+++ b/tests/Builder/Stage/MergeStageTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $merge stage
+ */
+class MergeStageTest extends PipelineTestCase
+{
+    public function testMergeResultsFromMultipleCollections(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: Expression::stringFieldPath('quarter'),
+                purchased: Accumulator::sum(
+                    Expression::intFieldPath('qty'),
+                ),
+            ),
+            Stage::merge(
+                into: 'quarterlyreport',
+                on: '_id',
+                whenMatched: 'merge',
+                whenNotMatched: 'insert',
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MergeMergeResultsFromMultipleCollections, $pipeline);
+    }
+
+    public function testOnDemandMaterializedViewInitialCreation(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: object(
+                    fiscal_year: Expression::stringFieldPath('fiscal_year'),
+                    dept: Expression::stringFieldPath('dept'),
+                ),
+                salaries: Accumulator::sum(
+                    Expression::numberFieldPath('salary'),
+                ),
+            ),
+            Stage::merge(
+                into: object(
+                    db: 'reporting',
+                    coll: 'budgets',
+                ),
+                on: '_id',
+                whenMatched: 'replace',
+                whenNotMatched: 'insert',
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MergeOnDemandMaterializedViewInitialCreation, $pipeline);
+    }
+
+    public function testOnDemandMaterializedViewUpdateReplaceData(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                fiscal_year: Query::gte(2019),
+            ),
+            Stage::group(
+                _id: object(
+                    fiscal_year: Expression::stringFieldPath('fiscal_year'),
+                    dept: Expression::stringFieldPath('dept'),
+                ),
+                salaries: Accumulator::sum(
+                    Expression::numberFieldPath('salary'),
+                ),
+            ),
+            Stage::merge(
+                into: object(
+                    db: 'reporting',
+                    coll: 'budgets',
+                ),
+                on: '_id',
+                whenMatched: 'replace',
+                whenNotMatched: 'insert',
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MergeOnDemandMaterializedViewUpdateReplaceData, $pipeline);
+    }
+
+    public function testOnlyInsertNewData(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                fiscal_year: 2019,
+            ),
+            Stage::group(
+                _id: object(
+                    fiscal_year: Expression::stringFieldPath('fiscal_year'),
+                    dept: Expression::stringFieldPath('dept'),
+                ),
+                employees: Accumulator::push(
+                    Expression::numberFieldPath('employee'),
+                ),
+            ),
+            Stage::project(
+                _id: 0,
+                dept: Expression::fieldPath('_id.dept'),
+                fiscal_year: Expression::fieldPath('_id.fiscal_year'),
+                employees: 1,
+            ),
+            Stage::merge(
+                into: object(
+                    db: 'reporting',
+                    coll: 'orgArchive',
+                ),
+                on: ['dept', 'fiscal_year'],
+                whenMatched: 'fail',
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MergeOnlyInsertNewData, $pipeline);
+    }
+
+    public function testUseThePipelineToCustomizeTheMerge(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                date: [
+                    Query::gte(new UTCDateTime(1557187200000)),
+                    Query::lt(new UTCDateTime(1557273600000)),
+                ],
+            ),
+            Stage::project(
+                _id: Expression::dateToString(
+                    format: '%Y-%m',
+                    date: Expression::dateFieldPath('date'),
+                ),
+                thumbsup: 1,
+                thumbsdown: 1,
+            ),
+            Stage::merge(
+                into: 'monthlytotals',
+                on: '_id',
+                whenMatched: new Pipeline(
+                    Stage::addFields(
+                        thumbsup: Expression::add(
+                            Expression::numberFieldPath('thumbsup'),
+                            Expression::variable('new.thumbsup'),
+                        ),
+                        thumbsdown: Expression::add(
+                            Expression::numberFieldPath('thumbsdown'),
+                            Expression::variable('new.thumbsdown'),
+                        ),
+                    ),
+                ),
+                whenNotMatched: 'insert',
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MergeUseThePipelineToCustomizeTheMerge, $pipeline);
+    }
+
+    public function testUseVariablesToCustomizeTheMerge(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::merge(
+                into: 'cakeSales',
+                let: object(
+                    year: '2020',
+                ),
+                whenMatched: new Pipeline(
+                    Stage::addFields(
+                        salesYear: Expression::variable('year'),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MergeUseVariablesToCustomizeTheMerge, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/OutStageTest.php
+++ b/tests/Builder/Stage/OutStageTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $out stage
+ */
+class OutStageTest extends PipelineTestCase
+{
+    public function testOutputToADifferentDatabase(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: Expression::stringFieldPath('author'),
+                books: Accumulator::push(
+                    Expression::stringFieldPath('title'),
+                ),
+            ),
+            Stage::out(
+                object(
+                    db: 'reporting',
+                    coll: 'authors',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::OutOutputToADifferentDatabase, $pipeline);
+    }
+
+    public function testOutputToSameDatabase(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::group(
+                _id: Expression::stringFieldPath('author'),
+                books: Accumulator::push(
+                    Expression::stringFieldPath('title'),
+                ),
+            ),
+            Stage::out('authors'),
+        );
+
+        $this->assertSamePipeline(Pipelines::OutOutputToSameDatabase, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/Pipelines.php
+++ b/tests/Builder/Stage/Pipelines.php
@@ -20,10 +20,14 @@ enum Pipelines: string
         {
             "$addFields": {
                 "totalHomework": {
-                    "$sum": "$homework"
+                    "$sum": [
+                        "$homework"
+                    ]
                 },
                 "totalQuiz": {
-                    "$sum": "$quiz"
+                    "$sum": [
+                        "$quiz"
+                    ]
                 }
             }
         },
@@ -51,6 +55,3225 @@ enum Pipelines: string
         {
             "$addFields": {
                 "specs.fuel_type": "unleaded"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Overwriting an existing field
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/addFields/#overwriting-an-existing-field
+     */
+    case AddFieldsOverwritingAnExistingField = <<<'JSON'
+    [
+        {
+            "$addFields": {
+                "cats": {
+                    "$numberInt": "20"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Add Element to an Array
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/addFields/#add-element-to-an-array
+     */
+    case AddFieldsAddElementToAnArray = <<<'JSON'
+    [
+        {
+            "$match": {
+                "_id": {
+                    "$numberInt": "1"
+                }
+            }
+        },
+        {
+            "$addFields": {
+                "homework": {
+                    "$concatArrays": [
+                        "$homework",
+                        [
+                            {
+                                "$numberInt": "7"
+                            }
+                        ]
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Bucket by Year and Filter by Bucket Results
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucket/#bucket-by-year-and-filter-by-bucket-results
+     */
+    case BucketBucketByYearAndFilterByBucketResults = <<<'JSON'
+    [
+        {
+            "$bucket": {
+                "groupBy": "$year_born",
+                "boundaries": [
+                    {
+                        "$numberInt": "1840"
+                    },
+                    {
+                        "$numberInt": "1850"
+                    },
+                    {
+                        "$numberInt": "1860"
+                    },
+                    {
+                        "$numberInt": "1870"
+                    },
+                    {
+                        "$numberInt": "1880"
+                    }
+                ],
+                "default": "Other",
+                "output": {
+                    "count": {
+                        "$sum": {
+                            "$numberInt": "1"
+                        }
+                    },
+                    "artists": {
+                        "$push": {
+                            "name": {
+                                "$concat": [
+                                    "$first_name",
+                                    " ",
+                                    "$last_name"
+                                ]
+                            },
+                            "year_born": "$year_born"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "$match": {
+                "count": {
+                    "$gt": {
+                        "$numberInt": "3"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use $bucket with $facet to Bucket by Multiple Fields
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucket/#use--bucket-with--facet-to-bucket-by-multiple-fields
+     */
+    case BucketUseBucketWithFacetToBucketByMultipleFields = <<<'JSON'
+    [
+        {
+            "$facet": {
+                "price": [
+                    {
+                        "$bucket": {
+                            "groupBy": "$price",
+                            "boundaries": [
+                                {
+                                    "$numberInt": "0"
+                                },
+                                {
+                                    "$numberInt": "200"
+                                },
+                                {
+                                    "$numberInt": "400"
+                                }
+                            ],
+                            "default": "Other",
+                            "output": {
+                                "count": {
+                                    "$sum": {
+                                        "$numberInt": "1"
+                                    }
+                                },
+                                "artwork": {
+                                    "$push": {
+                                        "title": "$title",
+                                        "price": "$price"
+                                    }
+                                },
+                                "averagePrice": {
+                                    "$avg": "$price"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "year": [
+                    {
+                        "$bucket": {
+                            "groupBy": "$year",
+                            "boundaries": [
+                                {
+                                    "$numberInt": "1890"
+                                },
+                                {
+                                    "$numberInt": "1910"
+                                },
+                                {
+                                    "$numberInt": "1920"
+                                },
+                                {
+                                    "$numberInt": "1940"
+                                }
+                            ],
+                            "default": "Unknown",
+                            "output": {
+                                "count": {
+                                    "$sum": {
+                                        "$numberInt": "1"
+                                    }
+                                },
+                                "artwork": {
+                                    "$push": {
+                                        "title": "$title",
+                                        "year": "$year"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Single Facet Aggregation
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucketAuto/#single-facet-aggregation
+     */
+    case BucketAutoSingleFacetAggregation = <<<'JSON'
+    [
+        {
+            "$bucketAuto": {
+                "groupBy": "$price",
+                "buckets": {
+                    "$numberInt": "4"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/changeStream/#examples
+     */
+    case ChangeStreamExample = <<<'JSON'
+    [
+        {
+            "$changeStream": {}
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/changeStreamSplitLargeEvent/#example
+     */
+    case ChangeStreamSplitLargeEventExample = <<<'JSON'
+    [
+        {
+            "$changeStreamSplitLargeEvent": {}
+        }
+    ]
+    JSON;
+
+    /**
+     * latencyStats Document
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/collStats/#latencystats-document
+     */
+    case CollStatsLatencyStatsDocument = <<<'JSON'
+    [
+        {
+            "$collStats": {
+                "latencyStats": {
+                    "histograms": true
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * storageStats Document
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/collStats/#storagestats-document
+     */
+    case CollStatsStorageStatsDocument = <<<'JSON'
+    [
+        {
+            "$collStats": {
+                "storageStats": {}
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * count Field
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/collStats/#count-field
+     */
+    case CollStatsCountField = <<<'JSON'
+    [
+        {
+            "$collStats": {
+                "count": {}
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * queryExecStats Document
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/collStats/#queryexecstats-document
+     */
+    case CollStatsQueryExecStatsDocument = <<<'JSON'
+    [
+        {
+            "$collStats": {
+                "queryExecStats": {}
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/count/#example
+     */
+    case CountExample = <<<'JSON'
+    [
+        {
+            "$match": {
+                "score": {
+                    "$gt": {
+                        "$numberInt": "80"
+                    }
+                }
+            }
+        },
+        {
+            "$count": "passing_scores"
+        }
+    ]
+    JSON;
+
+    /**
+     * Inactive Sessions
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/currentOp/#inactive-sessions
+     */
+    case CurrentOpInactiveSessions = <<<'JSON'
+    [
+        {
+            "$currentOp": {
+                "allUsers": true,
+                "idleSessions": true
+            }
+        },
+        {
+            "$match": {
+                "active": false,
+                "transaction": {
+                    "$exists": true
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Sampled Queries
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/currentOp/#sampled-queries
+     */
+    case CurrentOpSampledQueries = <<<'JSON'
+    [
+        {
+            "$currentOp": {
+                "allUsers": true,
+                "localOps": true
+            }
+        },
+        {
+            "$match": {
+                "desc": "query analyzer"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Densify Time Series Data
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/densify/#densify-time-series-data
+     */
+    case DensifyDensifyTimeSeriesData = <<<'JSON'
+    [
+        {
+            "$densify": {
+                "field": "timestamp",
+                "range": {
+                    "step": {
+                        "$numberInt": "1"
+                    },
+                    "unit": "hour",
+                    "bounds": [
+                        {
+                            "$date": {
+                                "$numberLong": "1621296000000"
+                            }
+                        },
+                        {
+                            "$date": {
+                                "$numberLong": "1621324800000"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Densifiction with Partitions
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/densify/#densifiction-with-partitions
+     */
+    case DensifyDensifictionWithPartitions = <<<'JSON'
+    [
+        {
+            "$densify": {
+                "field": "altitude",
+                "partitionByFields": [
+                    "variety"
+                ],
+                "range": {
+                    "bounds": "full",
+                    "step": {
+                        "$numberInt": "200"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Test a Pipeline Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/documents/#test-a-pipeline-stage
+     */
+    case DocumentsTestAPipelineStage = <<<'JSON'
+    [
+        {
+            "$documents": [
+                {
+                    "x": {
+                        "$numberInt": "10"
+                    }
+                },
+                {
+                    "x": {
+                        "$numberInt": "2"
+                    }
+                },
+                {
+                    "x": {
+                        "$numberInt": "5"
+                    }
+                }
+            ]
+        },
+        {
+            "$bucketAuto": {
+                "groupBy": "$x",
+                "buckets": {
+                    "$numberInt": "4"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use a $documents Stage in a $lookup Stage
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/documents/#use-a--documents-stage-in-a--lookup-stage
+     */
+    case DocumentsUseADocumentsStageInALookupStage = <<<'JSON'
+    [
+        {
+            "$match": {}
+        },
+        {
+            "$lookup": {
+                "localField": "zip",
+                "foreignField": "zip_id",
+                "as": "city_state",
+                "pipeline": [
+                    {
+                        "$documents": [
+                            {
+                                "zip_id": {
+                                    "$numberInt": "94301"
+                                },
+                                "name": "Palo Alto, CA"
+                            },
+                            {
+                                "zip_id": {
+                                    "$numberInt": "10019"
+                                },
+                                "name": "New York, NY"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/facet/#example
+     */
+    case FacetExample = <<<'JSON'
+    [
+        {
+            "$facet": {
+                "categorizedByTags": [
+                    {
+                        "$unwind": {
+                            "path": "$tags"
+                        }
+                    },
+                    {
+                        "$sortByCount": "$tags"
+                    }
+                ],
+                "categorizedByPrice": [
+                    {
+                        "$match": {
+                            "price": {
+                                "$exists": true
+                            }
+                        }
+                    },
+                    {
+                        "$bucket": {
+                            "groupBy": "$price",
+                            "boundaries": [
+                                {
+                                    "$numberInt": "0"
+                                },
+                                {
+                                    "$numberInt": "150"
+                                },
+                                {
+                                    "$numberInt": "200"
+                                },
+                                {
+                                    "$numberInt": "300"
+                                },
+                                {
+                                    "$numberInt": "400"
+                                }
+                            ],
+                            "default": "Other",
+                            "output": {
+                                "count": {
+                                    "$sum": {
+                                        "$numberInt": "1"
+                                    }
+                                },
+                                "titles": {
+                                    "$push": "$title"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "categorizedByYears(Auto)": [
+                    {
+                        "$bucketAuto": {
+                            "groupBy": "$year",
+                            "buckets": {
+                                "$numberInt": "4"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Fill Missing Field Values with a Constant Value
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/fill/#fill-missing-field-values-with-a-constant-value
+     */
+    case FillFillMissingFieldValuesWithAConstantValue = <<<'JSON'
+    [
+        {
+            "$fill": {
+                "output": {
+                    "bootsSold": {
+                        "value": {
+                            "$numberInt": "0"
+                        }
+                    },
+                    "sandalsSold": {
+                        "value": {
+                            "$numberInt": "0"
+                        }
+                    },
+                    "sneakersSold": {
+                        "value": {
+                            "$numberInt": "0"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Fill Missing Field Values with Linear Interpolation
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/fill/#fill-missing-field-values-with-linear-interpolation
+     */
+    case FillFillMissingFieldValuesWithLinearInterpolation = <<<'JSON'
+    [
+        {
+            "$fill": {
+                "sortBy": {
+                    "time": {
+                        "$numberInt": "1"
+                    }
+                },
+                "output": {
+                    "price": {
+                        "method": "linear"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Fill Missing Field Values Based on the Last Observed Value
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/fill/#fill-missing-field-values-based-on-the-last-observed-value
+     */
+    case FillFillMissingFieldValuesBasedOnTheLastObservedValue = <<<'JSON'
+    [
+        {
+            "$fill": {
+                "sortBy": {
+                    "date": {
+                        "$numberInt": "1"
+                    }
+                },
+                "output": {
+                    "score": {
+                        "method": "locf"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Fill Data for Distinct Partitions
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/fill/#fill-data-for-distinct-partitions
+     */
+    case FillFillDataForDistinctPartitions = <<<'JSON'
+    [
+        {
+            "$fill": {
+                "sortBy": {
+                    "date": {
+                        "$numberInt": "1"
+                    }
+                },
+                "partitionBy": {
+                    "restaurant": "$restaurant"
+                },
+                "output": {
+                    "score": {
+                        "method": "locf"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Indicate if a Field was Populated Using $fill
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/fill/#indicate-if-a-field-was-populated-using--fill
+     */
+    case FillIndicateIfAFieldWasPopulatedUsingFill = <<<'JSON'
+    [
+        {
+            "$set": {
+                "valueExisted": {
+                    "$ifNull": [
+                        {
+                            "$toBool": {
+                                "$toString": "$score"
+                            }
+                        },
+                        false
+                    ]
+                }
+            }
+        },
+        {
+            "$fill": {
+                "sortBy": {
+                    "date": {
+                        "$numberInt": "1"
+                    }
+                },
+                "output": {
+                    "score": {
+                        "method": "locf"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Maximum Distance
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/geoNear/#maximum-distance
+     */
+    case GeoNearMaximumDistance = <<<'JSON'
+    [
+        {
+            "$geoNear": {
+                "near": {
+                    "type": "Point",
+                    "coordinates": [
+                        {
+                            "$numberDouble": "-73.992789999999999395"
+                        },
+                        {
+                            "$numberDouble": "40.719295999999999935"
+                        }
+                    ]
+                },
+                "distanceField": "dist.calculated",
+                "maxDistance": {
+                    "$numberInt": "2"
+                },
+                "query": {
+                    "category": "Parks"
+                },
+                "includeLocs": "dist.location",
+                "spherical": true
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Minimum Distance
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/geoNear/#minimum-distance
+     */
+    case GeoNearMinimumDistance = <<<'JSON'
+    [
+        {
+            "$geoNear": {
+                "near": {
+                    "type": "Point",
+                    "coordinates": [
+                        {
+                            "$numberDouble": "-73.992789999999999395"
+                        },
+                        {
+                            "$numberDouble": "40.719295999999999935"
+                        }
+                    ]
+                },
+                "distanceField": "dist.calculated",
+                "minDistance": {
+                    "$numberInt": "2"
+                },
+                "query": {
+                    "category": "Parks"
+                },
+                "includeLocs": "dist.location",
+                "spherical": true
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * with the let option
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/geoNear/#-geonear-with-the-let-option
+     */
+    case GeoNearWithTheLetOption = <<<'JSON'
+    [
+        {
+            "$geoNear": {
+                "near": "$$pt",
+                "distanceField": "distance",
+                "maxDistance": {
+                    "$numberInt": "2"
+                },
+                "query": {
+                    "category": "Parks"
+                },
+                "includeLocs": "dist.location",
+                "spherical": true
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * with Bound let Option
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/geoNear/#-geonear-with-bound-let-option
+     */
+    case GeoNearWithBoundLetOption = <<<'JSON'
+    [
+        {
+            "$lookup": {
+                "from": "places",
+                "let": {
+                    "pt": "$location"
+                },
+                "pipeline": [
+                    {
+                        "$geoNear": {
+                            "near": "$$pt",
+                            "distanceField": "distance"
+                        }
+                    }
+                ],
+                "as": "joinedField"
+            }
+        },
+        {
+            "$match": {
+                "name": "Sara D. Roosevelt Park"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Specify Which Geospatial Index to Use
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/geoNear/#specify-which-geospatial-index-to-use
+     */
+    case GeoNearSpecifyWhichGeospatialIndexToUse = <<<'JSON'
+    [
+        {
+            "$geoNear": {
+                "near": {
+                    "type": "Point",
+                    "coordinates": [
+                        {
+                            "$numberDouble": "-73.981419999999999959"
+                        },
+                        {
+                            "$numberDouble": "40.717820000000003233"
+                        }
+                    ]
+                },
+                "key": "location",
+                "distanceField": "dist.calculated",
+                "query": {
+                    "category": "Parks"
+                }
+            }
+        },
+        {
+            "$limit": {
+                "$numberInt": "5"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Within a Single Collection
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/graphLookup/#within-a-single-collection
+     */
+    case GraphLookupWithinASingleCollection = <<<'JSON'
+    [
+        {
+            "$graphLookup": {
+                "from": "employees",
+                "startWith": "$reportsTo",
+                "connectFromField": "reportsTo",
+                "connectToField": "name",
+                "as": "reportingHierarchy"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Across Multiple Collections
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/graphLookup/#across-multiple-collections
+     */
+    case GraphLookupAcrossMultipleCollections = <<<'JSON'
+    [
+        {
+            "$graphLookup": {
+                "from": "airports",
+                "startWith": "$nearestAirport",
+                "connectFromField": "connects",
+                "connectToField": "airport",
+                "maxDepth": {
+                    "$numberInt": "2"
+                },
+                "depthField": "numConnections",
+                "as": "destinations"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * With a Query Filter
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/graphLookup/#with-a-query-filter
+     */
+    case GraphLookupWithAQueryFilter = <<<'JSON'
+    [
+        {
+            "$match": {
+                "name": "Tanya Jordan"
+            }
+        },
+        {
+            "$graphLookup": {
+                "from": "people",
+                "startWith": "$friends",
+                "connectFromField": "friends",
+                "connectToField": "name",
+                "as": "golfers",
+                "restrictSearchWithMatch": {
+                    "hobbies": "golf"
+                }
+            }
+        },
+        {
+            "$project": {
+                "name": {
+                    "$numberInt": "1"
+                },
+                "friends": {
+                    "$numberInt": "1"
+                },
+                "connections who play golf": "$golfers.name"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Count the Number of Documents in a Collection
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/#count-the-number-of-documents-in-a-collection
+     */
+    case GroupCountTheNumberOfDocumentsInACollection = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": null,
+                "count": {
+                    "$count": {}
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Retrieve Distinct Values
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/#retrieve-distinct-values
+     */
+    case GroupRetrieveDistinctValues = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": "$item"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Group by Item Having
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/#group-by-item-having
+     */
+    case GroupGroupByItemHaving = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": "$item",
+                "totalSaleAmount": {
+                    "$sum": {
+                        "$multiply": [
+                            "$price",
+                            "$quantity"
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "$match": {
+                "totalSaleAmount": {
+                    "$gte": {
+                        "$numberInt": "100"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Calculate Count Sum and Average
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/#calculate-count--sum--and-average
+     */
+    case GroupCalculateCountSumAndAverage = <<<'JSON'
+    [
+        {
+            "$match": {
+                "date": {
+                    "$gte": {
+                        "$date": {
+                            "$numberLong": "1388534400000"
+                        }
+                    },
+                    "$lt": {
+                        "$date": {
+                            "$numberLong": "1420070400000"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "$group": {
+                "_id": {
+                    "$dateToString": {
+                        "format": "%Y-%m-%d",
+                        "date": "$date"
+                    }
+                },
+                "totalSaleAmount": {
+                    "$sum": {
+                        "$multiply": [
+                            "$price",
+                            "$quantity"
+                        ]
+                    }
+                },
+                "averageQuantity": {
+                    "$avg": "$quantity"
+                },
+                "count": {
+                    "$sum": {
+                        "$numberInt": "1"
+                    }
+                }
+            }
+        },
+        {
+            "$sort": {
+                "totalSaleAmount": {
+                    "$numberInt": "-1"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Group by null
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/#group-by-null
+     */
+    case GroupGroupByNull = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": null,
+                "totalSaleAmount": {
+                    "$sum": {
+                        "$multiply": [
+                            "$price",
+                            "$quantity"
+                        ]
+                    }
+                },
+                "averageQuantity": {
+                    "$avg": "$quantity"
+                },
+                "count": {
+                    "$sum": {
+                        "$numberInt": "1"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Pivot Data
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/#pivot-data
+     */
+    case GroupPivotData = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": "$author",
+                "books": {
+                    "$push": "$title"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Group Documents by author
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/#group-documents-by-author
+     */
+    case GroupGroupDocumentsByAuthor = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": "$author",
+                "books": {
+                    "$push": "$$ROOT"
+                }
+            }
+        },
+        {
+            "$addFields": {
+                "totalCopies": {
+                    "$sum": [
+                        "$books.copies"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/indexStats/#example
+     */
+    case IndexStatsExample = <<<'JSON'
+    [
+        {
+            "$indexStats": {}
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/limit/#example
+     */
+    case LimitExample = <<<'JSON'
+    [
+        {
+            "$limit": {
+                "$numberInt": "5"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * List All Local Sessions
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/listLocalSessions/#list-all-local-sessions
+     */
+    case ListLocalSessionsListAllLocalSessions = <<<'JSON'
+    [
+        {
+            "$listLocalSessions": {
+                "allUsers": true
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * List All Local Sessions for the Specified Users
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/listLocalSessions/#list-all-local-sessions-for-the-specified-users
+     */
+    case ListLocalSessionsListAllLocalSessionsForTheSpecifiedUsers = <<<'JSON'
+    [
+        {
+            "$listLocalSessions": {
+                "users": [
+                    {
+                        "user": "myAppReader",
+                        "db": "test"
+                    }
+                ]
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * List All Local Sessions for the Current User
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/listLocalSessions/#list-all-local-sessions-for-the-current-user
+     */
+    case ListLocalSessionsListAllLocalSessionsForTheCurrentUser = <<<'JSON'
+    [
+        {
+            "$listLocalSessions": {}
+        }
+    ]
+    JSON;
+
+    /**
+     * List Sampled Queries for All Collections
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSampledQueries/#list-sampled-queries-for-all-collections
+     */
+    case ListSampledQueriesListSampledQueriesForAllCollections = <<<'JSON'
+    [
+        {
+            "$listSampledQueries": {}
+        }
+    ]
+    JSON;
+
+    /**
+     * List Sampled Queries for A Specific Collection
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSampledQueries/#list-sampled-queries-for-a-specific-collection
+     */
+    case ListSampledQueriesListSampledQueriesForASpecificCollection = <<<'JSON'
+    [
+        {
+            "$listSampledQueries": {
+                "namespace": "social.post"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Return All Search Indexes
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSearchIndexes/#return-all-search-indexes
+     */
+    case ListSearchIndexesReturnAllSearchIndexes = <<<'JSON'
+    [
+        {
+            "$listSearchIndexes": {}
+        }
+    ]
+    JSON;
+
+    /**
+     * Return a Single Search Index by Name
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSearchIndexes/#return-a-single-search-index-by-name
+     */
+    case ListSearchIndexesReturnASingleSearchIndexByName = <<<'JSON'
+    [
+        {
+            "$listSearchIndexes": {
+                "name": "synonym-mappings"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Return a Single Search Index by id
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSearchIndexes/#return-a-single-search-index-by-id
+     */
+    case ListSearchIndexesReturnASingleSearchIndexById = <<<'JSON'
+    [
+        {
+            "$listSearchIndexes": {
+                "id": "6524096020da840844a4c4a7"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * List All Sessions
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSessions/#list-all-sessions
+     */
+    case ListSessionsListAllSessions = <<<'JSON'
+    [
+        {
+            "$listSessions": {
+                "allUsers": true
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * List All Sessions for the Specified Users
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSessions/#list-all-sessions-for-the-specified-users
+     */
+    case ListSessionsListAllSessionsForTheSpecifiedUsers = <<<'JSON'
+    [
+        {
+            "$listSessions": {
+                "users": [
+                    {
+                        "user": "myAppReader",
+                        "db": "test"
+                    }
+                ]
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * List All Sessions for the Current User
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSessions/#list-all-sessions-for-the-current-user
+     */
+    case ListSessionsListAllSessionsForTheCurrentUser = <<<'JSON'
+    [
+        {
+            "$listSessions": {}
+        }
+    ]
+    JSON;
+
+    /**
+     * Perform a Single Equality Join with $lookup
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/lookup/#perform-a-single-equality-join-with--lookup
+     */
+    case LookupPerformASingleEqualityJoinWithLookup = <<<'JSON'
+    [
+        {
+            "$lookup": {
+                "from": "inventory",
+                "localField": "item",
+                "foreignField": "sku",
+                "as": "inventory_docs"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use $lookup with an Array
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/lookup/#use--lookup-with-an-array
+     */
+    case LookupUseLookupWithAnArray = <<<'JSON'
+    [
+        {
+            "$lookup": {
+                "from": "members",
+                "localField": "enrollmentlist",
+                "foreignField": "name",
+                "as": "enrollee_info"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use $lookup with $mergeObjects
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/lookup/#use--lookup-with--mergeobjects
+     */
+    case LookupUseLookupWithMergeObjects = <<<'JSON'
+    [
+        {
+            "$lookup": {
+                "from": "items",
+                "localField": "item",
+                "foreignField": "item",
+                "as": "fromItems"
+            }
+        },
+        {
+            "$replaceRoot": {
+                "newRoot": {
+                    "$mergeObjects": [
+                        {
+                            "$arrayElemAt": [
+                                "$fromItems",
+                                {
+                                    "$numberInt": "0"
+                                }
+                            ]
+                        },
+                        "$$ROOT"
+                    ]
+                }
+            }
+        },
+        {
+            "$project": {
+                "fromItems": {
+                    "$numberInt": "0"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Perform Multiple Joins and a Correlated Subquery with $lookup
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/lookup/#perform-multiple-joins-and-a-correlated-subquery-with--lookup
+     */
+    case LookupPerformMultipleJoinsAndACorrelatedSubqueryWithLookup = <<<'JSON'
+    [
+        {
+            "$lookup": {
+                "from": "warehouses",
+                "let": {
+                    "order_item": "$item",
+                    "order_qty": "$ordered"
+                },
+                "pipeline": [
+                    {
+                        "$match": {
+                            "$expr": {
+                                "$and": [
+                                    {
+                                        "$eq": [
+                                            "$stock_item",
+                                            "$$order_item"
+                                        ]
+                                    },
+                                    {
+                                        "$gte": [
+                                            "$instock",
+                                            "$$order_qty"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "$project": {
+                            "stock_item": {
+                                "$numberInt": "0"
+                            },
+                            "_id": {
+                                "$numberInt": "0"
+                            }
+                        }
+                    }
+                ],
+                "as": "stockdata"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Perform an Uncorrelated Subquery with $lookup
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/lookup/#perform-an-uncorrelated-subquery-with--lookup
+     */
+    case LookupPerformAnUncorrelatedSubqueryWithLookup = <<<'JSON'
+    [
+        {
+            "$lookup": {
+                "from": "holidays",
+                "pipeline": [
+                    {
+                        "$match": {
+                            "year": {
+                                "$numberInt": "2018"
+                            }
+                        }
+                    },
+                    {
+                        "$project": {
+                            "_id": {
+                                "$numberInt": "0"
+                            },
+                            "date": {
+                                "name": "$name",
+                                "date": "$date"
+                            }
+                        }
+                    },
+                    {
+                        "$replaceRoot": {
+                            "newRoot": "$date"
+                        }
+                    }
+                ],
+                "as": "holidays"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Perform a Concise Correlated Subquery with $lookup
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/lookup/#perform-a-concise-correlated-subquery-with--lookup
+     */
+    case LookupPerformAConciseCorrelatedSubqueryWithLookup = <<<'JSON'
+    [
+        {
+            "$lookup": {
+                "from": "restaurants",
+                "localField": "restaurant_name",
+                "foreignField": "name",
+                "let": {
+                    "orders_drink": "$drink"
+                },
+                "pipeline": [
+                    {
+                        "$match": {
+                            "$expr": {
+                                "$in": [
+                                    "$$orders_drink",
+                                    "$beverages"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "as": "matches"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Equality Match
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/match/#equality-match
+     */
+    case MatchEqualityMatch = <<<'JSON'
+    [
+        {
+            "$match": {
+                "author": "dave"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Perform a Count
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/match/#perform-a-count
+     */
+    case MatchPerformACount = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$or": [
+                    {
+                        "score": {
+                            "$gt": {
+                                "$numberInt": "70"
+                            },
+                            "$lt": {
+                                "$numberInt": "90"
+                            }
+                        }
+                    },
+                    {
+                        "views": {
+                            "$gte": {
+                                "$numberInt": "1000"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "$group": {
+                "_id": null,
+                "count": {
+                    "$sum": {
+                        "$numberInt": "1"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * On-Demand Materialized View Initial Creation
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/merge/#on-demand-materialized-view--initial-creation
+     */
+    case MergeOnDemandMaterializedViewInitialCreation = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": {
+                    "fiscal_year": "$fiscal_year",
+                    "dept": "$dept"
+                },
+                "salaries": {
+                    "$sum": "$salary"
+                }
+            }
+        },
+        {
+            "$merge": {
+                "into": {
+                    "db": "reporting",
+                    "coll": "budgets"
+                },
+                "on": "_id",
+                "whenMatched": "replace",
+                "whenNotMatched": "insert"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * On-Demand Materialized View Update Replace Data
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/merge/#on-demand-materialized-view--update-replace-data
+     */
+    case MergeOnDemandMaterializedViewUpdateReplaceData = <<<'JSON'
+    [
+        {
+            "$match": {
+                "fiscal_year": {
+                    "$gte": {
+                        "$numberInt": "2019"
+                    }
+                }
+            }
+        },
+        {
+            "$group": {
+                "_id": {
+                    "fiscal_year": "$fiscal_year",
+                    "dept": "$dept"
+                },
+                "salaries": {
+                    "$sum": "$salary"
+                }
+            }
+        },
+        {
+            "$merge": {
+                "into": {
+                    "db": "reporting",
+                    "coll": "budgets"
+                },
+                "on": "_id",
+                "whenMatched": "replace",
+                "whenNotMatched": "insert"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Only Insert New Data
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/merge/#only-insert-new-data
+     */
+    case MergeOnlyInsertNewData = <<<'JSON'
+    [
+        {
+            "$match": {
+                "fiscal_year": {
+                    "$numberInt": "2019"
+                }
+            }
+        },
+        {
+            "$group": {
+                "_id": {
+                    "fiscal_year": "$fiscal_year",
+                    "dept": "$dept"
+                },
+                "employees": {
+                    "$push": "$employee"
+                }
+            }
+        },
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "dept": "$_id.dept",
+                "fiscal_year": "$_id.fiscal_year",
+                "employees": {
+                    "$numberInt": "1"
+                }
+            }
+        },
+        {
+            "$merge": {
+                "into": {
+                    "db": "reporting",
+                    "coll": "orgArchive"
+                },
+                "on": [
+                    "dept",
+                    "fiscal_year"
+                ],
+                "whenMatched": "fail"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Merge Results from Multiple Collections
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/merge/#merge-results-from-multiple-collections
+     */
+    case MergeMergeResultsFromMultipleCollections = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": "$quarter",
+                "purchased": {
+                    "$sum": "$qty"
+                }
+            }
+        },
+        {
+            "$merge": {
+                "into": "quarterlyreport",
+                "on": "_id",
+                "whenMatched": "merge",
+                "whenNotMatched": "insert"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use the Pipeline to Customize the Merge
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/merge/#use-the-pipeline-to-customize-the-merge
+     */
+    case MergeUseThePipelineToCustomizeTheMerge = <<<'JSON'
+    [
+        {
+            "$match": {
+                "date": {
+                    "$gte": {
+                        "$date": {
+                            "$numberLong": "1557187200000"
+                        }
+                    },
+                    "$lt": {
+                        "$date": {
+                            "$numberLong": "1557273600000"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "$project": {
+                "_id": {
+                    "$dateToString": {
+                        "format": "%Y-%m",
+                        "date": "$date"
+                    }
+                },
+                "thumbsup": {
+                    "$numberInt": "1"
+                },
+                "thumbsdown": {
+                    "$numberInt": "1"
+                }
+            }
+        },
+        {
+            "$merge": {
+                "into": "monthlytotals",
+                "on": "_id",
+                "whenMatched": [
+                    {
+                        "$addFields": {
+                            "thumbsup": {
+                                "$add": [
+                                    "$thumbsup",
+                                    "$$new.thumbsup"
+                                ]
+                            },
+                            "thumbsdown": {
+                                "$add": [
+                                    "$thumbsdown",
+                                    "$$new.thumbsdown"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "whenNotMatched": "insert"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use Variables to Customize the Merge
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/merge/#use-variables-to-customize-the-merge
+     */
+    case MergeUseVariablesToCustomizeTheMerge = <<<'JSON'
+    [
+        {
+            "$merge": {
+                "into": "cakeSales",
+                "let": {
+                    "year": "2020"
+                },
+                "whenMatched": [
+                    {
+                        "$addFields": {
+                            "salesYear": "$$year"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Output to Same Database
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/out/#output-to-same-database
+     */
+    case OutOutputToSameDatabase = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": "$author",
+                "books": {
+                    "$push": "$title"
+                }
+            }
+        },
+        {
+            "$out": "authors"
+        }
+    ]
+    JSON;
+
+    /**
+     * Output to a Different Database
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/out/#output-to-a-different-database
+     */
+    case OutOutputToADifferentDatabase = <<<'JSON'
+    [
+        {
+            "$group": {
+                "_id": "$author",
+                "books": {
+                    "$push": "$title"
+                }
+            }
+        },
+        {
+            "$out": {
+                "db": "reporting",
+                "coll": "authors"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Return Information for All Entries in the Query Cache
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/planCacheStats/#return-information-for-all-entries-in-the-query-cache
+     */
+    case PlanCacheStatsReturnInformationForAllEntriesInTheQueryCache = <<<'JSON'
+    [
+        {
+            "$planCacheStats": {}
+        }
+    ]
+    JSON;
+
+    /**
+     * Find Cache Entry Details for a Query Hash
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/planCacheStats/#find-cache-entry-details-for-a-query-hash
+     */
+    case PlanCacheStatsFindCacheEntryDetailsForAQueryHash = <<<'JSON'
+    [
+        {
+            "$planCacheStats": {}
+        },
+        {
+            "$match": {
+                "planCacheKey": "B1435201"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Include Specific Fields in Output Documents
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/#include-specific-fields-in-output-documents
+     */
+    case ProjectIncludeSpecificFieldsInOutputDocuments = <<<'JSON'
+    [
+        {
+            "$project": {
+                "title": {
+                    "$numberInt": "1"
+                },
+                "author": {
+                    "$numberInt": "1"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Suppress id Field in the Output Documents
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/#suppress-_id-field-in-the-output-documents
+     */
+    case ProjectSuppressIdFieldInTheOutputDocuments = <<<'JSON'
+    [
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "title": {
+                    "$numberInt": "1"
+                },
+                "author": {
+                    "$numberInt": "1"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Exclude Fields from Output Documents
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/#exclude-fields-from-output-documents
+     */
+    case ProjectExcludeFieldsFromOutputDocuments = <<<'JSON'
+    [
+        {
+            "$project": {
+                "lastModified": {
+                    "$numberInt": "0"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Exclude Fields from Embedded Documents
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/#exclude-fields-from-embedded-documents
+     */
+    case ProjectExcludeFieldsFromEmbeddedDocuments = <<<'JSON'
+    [
+        {
+            "$project": {
+                "author.first": {
+                    "$numberInt": "0"
+                },
+                "lastModified": {
+                    "$numberInt": "0"
+                }
+            }
+        },
+        {
+            "$project": {
+                "author": {
+                    "first": {
+                        "$numberInt": "0"
+                    }
+                },
+                "lastModified": {
+                    "$numberInt": "0"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Conditionally Exclude Fields
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/#conditionally-exclude-fields
+     */
+    case ProjectConditionallyExcludeFields = <<<'JSON'
+    [
+        {
+            "$project": {
+                "title": {
+                    "$numberInt": "1"
+                },
+                "author.first": {
+                    "$numberInt": "1"
+                },
+                "author.last": {
+                    "$numberInt": "1"
+                },
+                "author.middle": {
+                    "$cond": {
+                        "if": {
+                            "$eq": [
+                                "",
+                                "$author.middle"
+                            ]
+                        },
+                        "then": "$$REMOVE",
+                        "else": "$author.middle"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Include Specific Fields from Embedded Documents
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/#include-specific-fields-from-embedded-documents
+     */
+    case ProjectIncludeSpecificFieldsFromEmbeddedDocuments = <<<'JSON'
+    [
+        {
+            "$project": {
+                "stop.title": {
+                    "$numberInt": "1"
+                }
+            }
+        },
+        {
+            "$project": {
+                "stop": {
+                    "title": {
+                        "$numberInt": "1"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Include Computed Fields
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/#include-computed-fields
+     */
+    case ProjectIncludeComputedFields = <<<'JSON'
+    [
+        {
+            "$project": {
+                "title": {
+                    "$numberInt": "1"
+                },
+                "isbn": {
+                    "prefix": {
+                        "$substr": [
+                            "$isbn",
+                            {
+                                "$numberInt": "0"
+                            },
+                            {
+                                "$numberInt": "3"
+                            }
+                        ]
+                    },
+                    "group": {
+                        "$substr": [
+                            "$isbn",
+                            {
+                                "$numberInt": "3"
+                            },
+                            {
+                                "$numberInt": "2"
+                            }
+                        ]
+                    },
+                    "publisher": {
+                        "$substr": [
+                            "$isbn",
+                            {
+                                "$numberInt": "5"
+                            },
+                            {
+                                "$numberInt": "4"
+                            }
+                        ]
+                    },
+                    "title": {
+                        "$substr": [
+                            "$isbn",
+                            {
+                                "$numberInt": "9"
+                            },
+                            {
+                                "$numberInt": "3"
+                            }
+                        ]
+                    },
+                    "checkDigit": {
+                        "$substr": [
+                            "$isbn",
+                            {
+                                "$numberInt": "12"
+                            },
+                            {
+                                "$numberInt": "1"
+                            }
+                        ]
+                    }
+                },
+                "lastName": "$author.last",
+                "copiesSold": "$copies"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Project New Array Fields
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/#project-new-array-fields
+     */
+    case ProjectProjectNewArrayFields = <<<'JSON'
+    [
+        {
+            "$project": {
+                "myArray": [
+                    "$x",
+                    "$y"
+                ]
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Evaluate Access at Every Document Level
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/redact/#evaluate-access-at-every-document-level
+     */
+    case RedactEvaluateAccessAtEveryDocumentLevel = <<<'JSON'
+    [
+        {
+            "$match": {
+                "year": {
+                    "$numberInt": "2014"
+                }
+            }
+        },
+        {
+            "$redact": {
+                "$cond": {
+                    "if": {
+                        "$gt": [
+                            {
+                                "$size": {
+                                    "$setIntersection": [
+                                        "$tags",
+                                        [
+                                            "STLW",
+                                            "G"
+                                        ]
+                                    ]
+                                }
+                            },
+                            {
+                                "$numberInt": "0"
+                            }
+                        ]
+                    },
+                    "then": "$$DESCEND",
+                    "else": "$$PRUNE"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Exclude All Fields at a Given Level
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/redact/#exclude-all-fields-at-a-given-level
+     */
+    case RedactExcludeAllFieldsAtAGivenLevel = <<<'JSON'
+    [
+        {
+            "$match": {
+                "status": "A"
+            }
+        },
+        {
+            "$redact": {
+                "$cond": {
+                    "if": {
+                        "$eq": [
+                            "$level",
+                            {
+                                "$numberInt": "5"
+                            }
+                        ]
+                    },
+                    "then": "$$PRUNE",
+                    "else": "$$DESCEND"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * with an Embedded Document Field
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceRoot/#-replaceroot-with-an-embedded-document-field
+     */
+    case ReplaceRootWithAnEmbeddedDocumentField = <<<'JSON'
+    [
+        {
+            "$replaceRoot": {
+                "newRoot": {
+                    "$mergeObjects": [
+                        {
+                            "dogs": {
+                                "$numberInt": "0"
+                            },
+                            "cats": {
+                                "$numberInt": "0"
+                            },
+                            "birds": {
+                                "$numberInt": "0"
+                            },
+                            "fish": {
+                                "$numberInt": "0"
+                            }
+                        },
+                        "$pets"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * with a Document Nested in an Array
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceRoot/#-replaceroot-with-a-document-nested-in-an-array
+     */
+    case ReplaceRootWithADocumentNestedInAnArray = <<<'JSON'
+    [
+        {
+            "$unwind": {
+                "path": "$grades"
+            }
+        },
+        {
+            "$match": {
+                "grades.grade": {
+                    "$gte": {
+                        "$numberInt": "90"
+                    }
+                }
+            }
+        },
+        {
+            "$replaceRoot": {
+                "newRoot": "$grades"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * with a newly created document
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceRoot/#-replaceroot-with-a-newly-created-document
+     */
+    case ReplaceRootWithANewlyCreatedDocument = <<<'JSON'
+    [
+        {
+            "$replaceRoot": {
+                "newRoot": {
+                    "full_name": {
+                        "$concat": [
+                            "$first_name",
+                            " ",
+                            "$last_name"
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * with a New Document Created from $$ROOT and a Default Document
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceRoot/#-replaceroot-with-a-new-document-created-from---root-and-a-default-document
+     */
+    case ReplaceRootWithANewDocumentCreatedFromROOTAndADefaultDocument = <<<'JSON'
+    [
+        {
+            "$replaceRoot": {
+                "newRoot": {
+                    "$mergeObjects": [
+                        {
+                            "_id": "",
+                            "name": "",
+                            "email": "",
+                            "cell": "",
+                            "home": ""
+                        },
+                        "$$ROOT"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * an Embedded Document Field
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceWith/#-replacewith-an-embedded-document-field
+     */
+    case ReplaceWithAnEmbeddedDocumentField = <<<'JSON'
+    [
+        {
+            "$replaceWith": {
+                "$mergeObjects": [
+                    {
+                        "dogs": {
+                            "$numberInt": "0"
+                        },
+                        "cats": {
+                            "$numberInt": "0"
+                        },
+                        "birds": {
+                            "$numberInt": "0"
+                        },
+                        "fish": {
+                            "$numberInt": "0"
+                        }
+                    },
+                    "$pets"
+                ]
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * a Document Nested in an Array
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceWith/#-replacewith-a-document-nested-in-an-array
+     */
+    case ReplaceWithADocumentNestedInAnArray = <<<'JSON'
+    [
+        {
+            "$unwind": {
+                "path": "$grades"
+            }
+        },
+        {
+            "$match": {
+                "grades.grade": {
+                    "$gte": {
+                        "$numberInt": "90"
+                    }
+                }
+            }
+        },
+        {
+            "$replaceWith": "$grades"
+        }
+    ]
+    JSON;
+
+    /**
+     * a Newly Created Document
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceWith/#-replacewith-a-newly-created-document
+     */
+    case ReplaceWithANewlyCreatedDocument = <<<'JSON'
+    [
+        {
+            "$match": {
+                "status": "C"
+            }
+        },
+        {
+            "$replaceWith": {
+                "_id": "$_id",
+                "item": "$item",
+                "amount": {
+                    "$multiply": [
+                        "$price",
+                        "$quantity"
+                    ]
+                },
+                "status": "Complete",
+                "asofDate": "$$NOW"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * a New Document Created from $$ROOT and a Default Document
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceWith/#-replacewith-a-new-document-created-from---root-and-a-default-document
+     */
+    case ReplaceWithANewDocumentCreatedFromROOTAndADefaultDocument = <<<'JSON'
+    [
+        {
+            "$replaceWith": {
+                "$mergeObjects": [
+                    {
+                        "_id": "",
+                        "name": "",
+                        "email": "",
+                        "cell": "",
+                        "home": ""
+                    },
+                    "$$ROOT"
+                ]
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/#example
+     */
+    case SampleExample = <<<'JSON'
+    [
+        {
+            "$sample": {
+                "size": {
+                    "$numberInt": "3"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Using Two $set Stages
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/set/#using-two--set-stages
+     */
+    case SetUsingTwoSetStages = <<<'JSON'
+    [
+        {
+            "$set": {
+                "totalHomework": {
+                    "$sum": [
+                        "$homework"
+                    ]
+                },
+                "totalQuiz": {
+                    "$sum": [
+                        "$quiz"
+                    ]
+                }
+            }
+        },
+        {
+            "$set": {
+                "totalScore": {
+                    "$add": [
+                        "$totalHomework",
+                        "$totalQuiz",
+                        "$extraCredit"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Adding Fields to an Embedded Document
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/set/#adding-fields-to-an-embedded-document
+     */
+    case SetAddingFieldsToAnEmbeddedDocument = <<<'JSON'
+    [
+        {
+            "$set": {
+                "specs.fuel_type": "unleaded"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Overwriting an existing field
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/set/#overwriting-an-existing-field
+     */
+    case SetOverwritingAnExistingField = <<<'JSON'
+    [
+        {
+            "$set": {
+                "cats": {
+                    "$numberInt": "20"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Add Element to an Array
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/set/#add-element-to-an-array
+     */
+    case SetAddElementToAnArray = <<<'JSON'
+    [
+        {
+            "$match": {
+                "_id": {
+                    "$numberInt": "1"
+                }
+            }
+        },
+        {
+            "$set": {
+                "homework": {
+                    "$concatArrays": [
+                        "$homework",
+                        [
+                            {
+                                "$numberInt": "7"
+                            }
+                        ]
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Creating a New Field with Existing Fields
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/set/#creating-a-new-field-with-existing-fields
+     */
+    case SetCreatingANewFieldWithExistingFields = <<<'JSON'
+    [
+        {
+            "$set": {
+                "quizAverage": {
+                    "$avg": [
+                        "$quiz"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use Documents Window to Obtain Cumulative Quantity for Each State
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setWindowFields/#use-documents-window-to-obtain-cumulative-quantity-for-each-state
+     */
+    case SetWindowFieldsUseDocumentsWindowToObtainCumulativeQuantityForEachState = <<<'JSON'
+    [
+        {
+            "$setWindowFields": {
+                "partitionBy": "$state",
+                "sortBy": {
+                    "orderDate": {
+                        "$numberInt": "1"
+                    }
+                },
+                "output": {
+                    "cumulativeQuantityForState": {
+                        "$sum": "$quantity",
+                        "window": {
+                            "documents": [
+                                "unbounded",
+                                "current"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use Documents Window to Obtain Cumulative Quantity for Each Year
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setWindowFields/#use-documents-window-to-obtain-cumulative-quantity-for-each-year
+     */
+    case SetWindowFieldsUseDocumentsWindowToObtainCumulativeQuantityForEachYear = <<<'JSON'
+    [
+        {
+            "$setWindowFields": {
+                "partitionBy": {
+                    "$year": {
+                        "date": "$orderDate"
+                    }
+                },
+                "sortBy": {
+                    "orderDate": {
+                        "$numberInt": "1"
+                    }
+                },
+                "output": {
+                    "cumulativeQuantityForYear": {
+                        "$sum": "$quantity",
+                        "window": {
+                            "documents": [
+                                "unbounded",
+                                "current"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use Documents Window to Obtain Moving Average Quantity for Each Year
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setWindowFields/#use-documents-window-to-obtain-moving-average-quantity-for-each-year
+     */
+    case SetWindowFieldsUseDocumentsWindowToObtainMovingAverageQuantityForEachYear = <<<'JSON'
+    [
+        {
+            "$setWindowFields": {
+                "partitionBy": {
+                    "$year": {
+                        "date": "$orderDate"
+                    }
+                },
+                "sortBy": {
+                    "orderDate": {
+                        "$numberInt": "1"
+                    }
+                },
+                "output": {
+                    "averageQuantity": {
+                        "$avg": "$quantity",
+                        "window": {
+                            "documents": [
+                                {
+                                    "$numberInt": "-1"
+                                },
+                                {
+                                    "$numberInt": "0"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use Documents Window to Obtain Cumulative and Maximum Quantity for Each Year
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setWindowFields/#use-documents-window-to-obtain-cumulative-and-maximum-quantity-for-each-year
+     */
+    case SetWindowFieldsUseDocumentsWindowToObtainCumulativeAndMaximumQuantityForEachYear = <<<'JSON'
+    [
+        {
+            "$setWindowFields": {
+                "partitionBy": {
+                    "$year": {
+                        "date": "$orderDate"
+                    }
+                },
+                "sortBy": {
+                    "orderDate": {
+                        "$numberInt": "1"
+                    }
+                },
+                "output": {
+                    "cumulativeQuantityForYear": {
+                        "$sum": "$quantity",
+                        "window": {
+                            "documents": [
+                                "unbounded",
+                                "current"
+                            ]
+                        }
+                    },
+                    "maximumQuantityForYear": {
+                        "$max": "$quantity",
+                        "window": {
+                            "documents": [
+                                "unbounded",
+                                "unbounded"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Range Window Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setWindowFields/#range-window-example
+     */
+    case SetWindowFieldsRangeWindowExample = <<<'JSON'
+    [
+        {
+            "$setWindowFields": {
+                "partitionBy": "$state",
+                "sortBy": {
+                    "price": {
+                        "$numberInt": "1"
+                    }
+                },
+                "output": {
+                    "quantityFromSimilarOrders": {
+                        "$sum": "$quantity",
+                        "window": {
+                            "range": [
+                                {
+                                    "$numberInt": "-10"
+                                },
+                                {
+                                    "$numberInt": "10"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use a Time Range Window with a Positive Upper Bound
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setWindowFields/#use-a-time-range-window-with-a-positive-upper-bound
+     */
+    case SetWindowFieldsUseATimeRangeWindowWithAPositiveUpperBound = <<<'JSON'
+    [
+        {
+            "$setWindowFields": {
+                "partitionBy": "$state",
+                "sortBy": {
+                    "orderDate": {
+                        "$numberInt": "1"
+                    }
+                },
+                "output": {
+                    "recentOrders": {
+                        "$push": "$orderDate",
+                        "window": {
+                            "range": [
+                                "unbounded",
+                                {
+                                    "$numberInt": "10"
+                                }
+                            ],
+                            "unit": "month"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Use a Time Range Window with a Negative Upper Bound
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setWindowFields/#use-a-time-range-window-with-a-negative-upper-bound
+     */
+    case SetWindowFieldsUseATimeRangeWindowWithANegativeUpperBound = <<<'JSON'
+    [
+        {
+            "$setWindowFields": {
+                "partitionBy": "$state",
+                "sortBy": {
+                    "orderDate": {
+                        "$numberInt": "1"
+                    }
+                },
+                "output": {
+                    "recentOrders": {
+                        "$push": "$orderDate",
+                        "window": {
+                            "range": [
+                                "unbounded",
+                                {
+                                    "$numberInt": "-10"
+                                }
+                            ],
+                            "unit": "month"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/shardedDataDistribution/#examples
+     */
+    case ShardedDataDistributionExample = <<<'JSON'
+    [
+        {
+            "$shardedDataDistribution": {}
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/skip/#example
+     */
+    case SkipExample = <<<'JSON'
+    [
+        {
+            "$skip": {
+                "$numberInt": "5"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Ascending Descending Sort
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sort/#ascending-descending-sort
+     */
+    case SortAscendingDescendingSort = <<<'JSON'
+    [
+        {
+            "$sort": {
+                "age": {
+                    "$numberInt": "-1"
+                },
+                "posts": {
+                    "$numberInt": "1"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Text Score Metadata Sort
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sort/#text-score-metadata-sort
+     */
+    case SortTextScoreMetadataSort = <<<'JSON'
+    [
+        {
+            "$match": {
+                "$text": {
+                    "$search": "operating"
+                }
+            }
+        },
+        {
+            "$sort": {
+                "score": {
+                    "$meta": "textScore"
+                },
+                "posts": {
+                    "$numberInt": "-1"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sortByCount/#example
+     */
+    case SortByCountExample = <<<'JSON'
+    [
+        {
+            "$unwind": {
+                "path": "$tags"
+            }
+        },
+        {
+            "$sortByCount": "$tags"
+        }
+    ]
+    JSON;
+
+    /**
+     * Report 1 All Sales by Year and Stores and Items
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/unionWith/#report-1--all-sales-by-year-and-stores-and-items
+     */
+    case UnionWithReport1AllSalesByYearAndStoresAndItems = <<<'JSON'
+    [
+        {
+            "$set": {
+                "_id": "2017"
+            }
+        },
+        {
+            "$unionWith": {
+                "coll": "sales_2018",
+                "pipeline": [
+                    {
+                        "$set": {
+                            "_id": "2018"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "$unionWith": {
+                "coll": "sales_2019",
+                "pipeline": [
+                    {
+                        "$set": {
+                            "_id": "2019"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "$unionWith": {
+                "coll": "sales_2020",
+                "pipeline": [
+                    {
+                        "$set": {
+                            "_id": "2020"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "$sort": {
+                "_id": {
+                    "$numberInt": "1"
+                },
+                "store": {
+                    "$numberInt": "1"
+                },
+                "item": {
+                    "$numberInt": "1"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Report 2 Aggregated Sales by Items
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/unionWith/#report-2--aggregated-sales-by-items
+     */
+    case UnionWithReport2AggregatedSalesByItems = <<<'JSON'
+    [
+        {
+            "$unionWith": {
+                "coll": "sales_2018"
+            }
+        },
+        {
+            "$unionWith": {
+                "coll": "sales_2019"
+            }
+        },
+        {
+            "$unionWith": {
+                "coll": "sales_2020"
+            }
+        },
+        {
+            "$group": {
+                "_id": "$item",
+                "total": {
+                    "$sum": "$quantity"
+                }
+            }
+        },
+        {
+            "$sort": {
+                "total": {
+                    "$numberInt": "-1"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Remove a Single Field
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/unset/#remove-a-single-field
+     */
+    case UnsetRemoveASingleField = <<<'JSON'
+    [
+        {
+            "$unset": [
+                "copies"
+            ]
+        }
+    ]
+    JSON;
+
+    /**
+     * Remove Top-Level Fields
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/unset/#remove-top-level-fields
+     */
+    case UnsetRemoveTopLevelFields = <<<'JSON'
+    [
+        {
+            "$unset": [
+                "isbn",
+                "copies"
+            ]
+        }
+    ]
+    JSON;
+
+    /**
+     * Remove Embedded Fields
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/unset/#remove-embedded-fields
+     */
+    case UnsetRemoveEmbeddedFields = <<<'JSON'
+    [
+        {
+            "$unset": [
+                "isbn",
+                "author.first",
+                "copies.warehouse"
+            ]
+        }
+    ]
+    JSON;
+
+    /**
+     * Unwind Array
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/unwind/#unwind-array
+     */
+    case UnwindUnwindArray = <<<'JSON'
+    [
+        {
+            "$unwind": {
+                "path": "$sizes"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * preserveNullAndEmptyArrays
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/unwind/#preservenullandemptyarrays
+     */
+    case UnwindPreserveNullAndEmptyArrays = <<<'JSON'
+    [
+        {
+            "$unwind": {
+                "path": "$sizes",
+                "preserveNullAndEmptyArrays": true
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * includeArrayIndex
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/unwind/#includearrayindex
+     */
+    case UnwindIncludeArrayIndex = <<<'JSON'
+    [
+        {
+            "$unwind": {
+                "path": "$sizes",
+                "includeArrayIndex": "arrayIndex"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Group by Unwound Values
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/unwind/#group-by-unwound-values
+     */
+    case UnwindGroupByUnwoundValues = <<<'JSON'
+    [
+        {
+            "$unwind": {
+                "path": "$sizes",
+                "preserveNullAndEmptyArrays": true
+            }
+        },
+        {
+            "$group": {
+                "_id": "$sizes",
+                "averagePrice": {
+                    "$avg": "$price"
+                }
+            }
+        },
+        {
+            "$sort": {
+                "averagePrice": {
+                    "$numberInt": "-1"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Unwind Embedded Arrays
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/unwind/#unwind-embedded-arrays
+     */
+    case UnwindUnwindEmbeddedArrays = <<<'JSON'
+    [
+        {
+            "$unwind": {
+                "path": "$items"
+            }
+        },
+        {
+            "$unwind": {
+                "path": "$items.tags"
+            }
+        },
+        {
+            "$group": {
+                "_id": "$items.tags",
+                "totalSalesAmount": {
+                    "$sum": {
+                        "$multiply": [
+                            "$items.price",
+                            "$items.quantity"
+                        ]
+                    }
+                }
             }
         }
     ]

--- a/tests/Builder/Stage/PlanCacheStatsStageTest.php
+++ b/tests/Builder/Stage/PlanCacheStatsStageTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $planCacheStats stage
+ */
+class PlanCacheStatsStageTest extends PipelineTestCase
+{
+    public function testFindCacheEntryDetailsForAQueryHash(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::planCacheStats(),
+            Stage::match(
+                planCacheKey: 'B1435201',
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::PlanCacheStatsFindCacheEntryDetailsForAQueryHash, $pipeline);
+    }
+
+    public function testReturnInformationForAllEntriesInTheQueryCache(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::planCacheStats(),
+        );
+
+        $this->assertSamePipeline(Pipelines::PlanCacheStatsReturnInformationForAllEntriesInTheQueryCache, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/ProjectStageTest.php
+++ b/tests/Builder/Stage/ProjectStageTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $project stage
+ */
+class ProjectStageTest extends PipelineTestCase
+{
+    public function testConditionallyExcludeFields(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                // Array unpacking is necessary for name that are not valid argument names,
+                // in PHP, they must be defined before named arguments.
+                ...[
+                    'author.first' => 1,
+                    'author.last' => 1,
+                    'author.middle' => Expression::cond(
+                        if: Expression::eq(
+                            '',
+                            Expression::stringFieldPath('author.middle'),
+                        ),
+                        then: Expression::variable('REMOVE'),
+                        else: Expression::stringFieldPath('author.middle'),
+                    ),
+                ],
+                title: 1,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ProjectConditionallyExcludeFields, $pipeline);
+    }
+
+    public function testExcludeFieldsFromEmbeddedDocuments(): void
+    {
+        $pipeline = new Pipeline(
+            // Both stages are equivalents
+            Stage::project(
+                ...['author.first' => 0],
+                ...['lastModified' => 0],
+            ),
+            Stage::project(
+                author: object(first: 0),
+                lastModified: 0,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ProjectExcludeFieldsFromEmbeddedDocuments, $pipeline);
+    }
+
+    public function testExcludeFieldsFromOutputDocuments(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                lastModified: 0,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ProjectExcludeFieldsFromOutputDocuments, $pipeline);
+    }
+
+    public function testIncludeComputedFields(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                title: 1,
+                isbn: object(
+                    prefix: Expression::substr(Expression::stringFieldPath('isbn'), 0, 3),
+                    group: Expression::substr(Expression::stringFieldPath('isbn'), 3, 2),
+                    publisher: Expression::substr(Expression::stringFieldPath('isbn'), 5, 4),
+                    title: Expression::substr(Expression::stringFieldPath('isbn'), 9, 3),
+                    checkDigit: Expression::substr(Expression::stringFieldPath('isbn'), 12, 1),
+                ),
+                lastName: Expression::stringFieldPath('author.last'),
+                copiesSold: Expression::intFieldPath('copies'),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ProjectIncludeComputedFields, $pipeline);
+    }
+
+    public function testIncludeSpecificFieldsFromEmbeddedDocuments(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                ...['stop.title' => 1],
+            ),
+            Stage::project(
+                stop: object(title: 1),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ProjectIncludeSpecificFieldsFromEmbeddedDocuments, $pipeline);
+    }
+
+    public function testIncludeSpecificFieldsInOutputDocuments(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                title: 1,
+                author: 1,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ProjectIncludeSpecificFieldsInOutputDocuments, $pipeline);
+    }
+
+    public function testProjectNewArrayFields(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                myArray: [Expression::fieldPath('x'), Expression::fieldPath('y')],
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ProjectProjectNewArrayFields, $pipeline);
+    }
+
+    public function testSuppressIdFieldInTheOutputDocuments(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                _id: 0,
+                title: 1,
+                author: 1,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ProjectSuppressIdFieldInTheOutputDocuments, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/ProjectStageTest.php
+++ b/tests/Builder/Stage/ProjectStageTest.php
@@ -75,11 +75,31 @@ class ProjectStageTest extends PipelineTestCase
             Stage::project(
                 title: 1,
                 isbn: object(
-                    prefix: Expression::substr(Expression::stringFieldPath('isbn'), 0, 3),
-                    group: Expression::substr(Expression::stringFieldPath('isbn'), 3, 2),
-                    publisher: Expression::substr(Expression::stringFieldPath('isbn'), 5, 4),
-                    title: Expression::substr(Expression::stringFieldPath('isbn'), 9, 3),
-                    checkDigit: Expression::substr(Expression::stringFieldPath('isbn'), 12, 1),
+                    prefix: Expression::substr(
+                        Expression::stringFieldPath('isbn'),
+                        0,
+                        3,
+                    ),
+                    group: Expression::substr(
+                        Expression::stringFieldPath('isbn'),
+                        3,
+                        2,
+                    ),
+                    publisher: Expression::substr(
+                        Expression::stringFieldPath('isbn'),
+                        5,
+                        4,
+                    ),
+                    title: Expression::substr(
+                        Expression::stringFieldPath('isbn'),
+                        9,
+                        3,
+                    ),
+                    checkDigit: Expression::substr(
+                        Expression::stringFieldPath('isbn'),
+                        12,
+                        1,
+                    ),
                 ),
                 lastName: Expression::stringFieldPath('author.last'),
                 copiesSold: Expression::intFieldPath('copies'),
@@ -119,7 +139,10 @@ class ProjectStageTest extends PipelineTestCase
     {
         $pipeline = new Pipeline(
             Stage::project(
-                myArray: [Expression::fieldPath('x'), Expression::fieldPath('y')],
+                myArray: [
+                    Expression::fieldPath('x'),
+                    Expression::fieldPath('y'),
+                ],
             ),
         );
 

--- a/tests/Builder/Stage/RedactStageTest.php
+++ b/tests/Builder/Stage/RedactStageTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $redact stage
+ */
+class RedactStageTest extends PipelineTestCase
+{
+    public function testEvaluateAccessAtEveryDocumentLevel(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                year: 2014,
+            ),
+            Stage::redact(
+                Expression::cond(
+                    if: Expression::gt(
+                        Expression::size(
+                            Expression::setIntersection(
+                                Expression::arrayFieldPath('tags'),
+                                ['STLW', 'G'],
+                            ),
+                        ),
+                        0,
+                    ),
+                    then: Expression::variable('DESCEND'),
+                    else: Expression::variable('PRUNE'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::RedactEvaluateAccessAtEveryDocumentLevel, $pipeline);
+    }
+
+    public function testExcludeAllFieldsAtAGivenLevel(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                status: 'A',
+            ),
+            Stage::redact(
+                Expression::cond(
+                    if: Expression::eq(
+                        Expression::intFieldPath('level'),
+                        5,
+                    ),
+                    then: Expression::variable('PRUNE'),
+                    else: Expression::variable('DESCEND'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::RedactExcludeAllFieldsAtAGivenLevel, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/ReplaceRootStageTest.php
+++ b/tests/Builder/Stage/ReplaceRootStageTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $replaceRoot stage
+ */
+class ReplaceRootStageTest extends PipelineTestCase
+{
+    public function testWithADocumentNestedInAnArray(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::unwind(Expression::arrayFieldPath('grades')),
+            Stage::match(
+                ...['grades.grade' => Query::gte(90)],
+            ),
+            Stage::replaceRoot(Expression::objectFieldPath('grades')),
+        );
+
+        $this->assertSamePipeline(Pipelines::ReplaceRootWithADocumentNestedInAnArray, $pipeline);
+    }
+
+    public function testWithANewDocumentCreatedFromROOTAndADefaultDocument(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::replaceRoot(
+                Expression::mergeObjects(
+                    object(_id: '', name: '', email: '', cell: '', home: ''),
+                    Expression::variable('ROOT'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ReplaceRootWithANewDocumentCreatedFromROOTAndADefaultDocument, $pipeline);
+    }
+
+    public function testWithANewlyCreatedDocument(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::replaceRoot(
+                object(
+                    full_name: Expression::concat(
+                        Expression::stringFieldPath('first_name'),
+                        ' ',
+                        Expression::stringFieldPath('last_name'),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ReplaceRootWithANewlyCreatedDocument, $pipeline);
+    }
+
+    public function testWithAnEmbeddedDocumentField(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::replaceRoot(
+                Expression::mergeObjects(
+                    object(dogs: 0, cats: 0, birds: 0, fish: 0),
+                    Expression::objectFieldPath('pets'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ReplaceRootWithAnEmbeddedDocumentField, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/ReplaceWithStageTest.php
+++ b/tests/Builder/Stage/ReplaceWithStageTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $replaceWith stage
+ */
+class ReplaceWithStageTest extends PipelineTestCase
+{
+    public function testADocumentNestedInAnArray(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::unwind(Expression::arrayFieldPath('grades')),
+            Stage::match(
+                ...['grades.grade' => Query::gte(90)],
+            ),
+            Stage::replaceWith(Expression::objectFieldPath('grades')),
+        );
+
+        $this->assertSamePipeline(Pipelines::ReplaceWithADocumentNestedInAnArray, $pipeline);
+    }
+
+    public function testANewDocumentCreatedFromROOTAndADefaultDocument(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::replaceWith(
+                Expression::mergeObjects(
+                    object(_id: '', name: '', email: '', cell: '', home: ''),
+                    Expression::variable('ROOT'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ReplaceWithANewDocumentCreatedFromROOTAndADefaultDocument, $pipeline);
+    }
+
+    public function testANewlyCreatedDocument(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                status: 'C',
+            ),
+            Stage::replaceWith(
+                object(
+                    _id: Expression::objectFieldPath('_id'),
+                    item: Expression::fieldPath('item'),
+                    amount: Expression::multiply(
+                        Expression::numberFieldPath('price'),
+                        Expression::numberFieldPath('quantity'),
+                    ),
+                    status: 'Complete',
+                    asofDate: Expression::variable('NOW'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ReplaceWithANewlyCreatedDocument, $pipeline);
+    }
+
+    public function testAnEmbeddedDocumentField(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::replaceWith(
+                Expression::mergeObjects(
+                    object(dogs: 0, cats: 0, birds: 0, fish: 0),
+                    Expression::objectFieldPath('pets'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ReplaceWithAnEmbeddedDocumentField, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/SampleStageTest.php
+++ b/tests/Builder/Stage/SampleStageTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $sample stage
+ */
+class SampleStageTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::sample(3),
+        );
+
+        $this->assertSamePipeline(Pipelines::SampleExample, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/SetStageTest.php
+++ b/tests/Builder/Stage/SetStageTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $set stage
+ */
+class SetStageTest extends PipelineTestCase
+{
+    public function testAddElementToAnArray(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                _id: 1,
+            ),
+            Stage::set(
+                homework: Expression::concatArrays(
+                    Expression::arrayFieldPath('homework'),
+                    [7],
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetAddElementToAnArray, $pipeline);
+    }
+
+    public function testAddingFieldsToAnEmbeddedDocument(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::set(
+                ...['specs.fuel_type' => 'unleaded'],
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetAddingFieldsToAnEmbeddedDocument, $pipeline);
+    }
+
+    public function testCreatingANewFieldWithExistingFields(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::set(
+                quizAverage: Expression::avg(
+                    Expression::numberFieldPath('quiz'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetCreatingANewFieldWithExistingFields, $pipeline);
+    }
+
+    public function testOverwritingAnExistingField(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::set(cats: 20),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetOverwritingAnExistingField, $pipeline);
+    }
+
+    public function testUsingTwoSetStages(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::set(
+                totalHomework: Expression::sum(
+                    Expression::arrayFieldPath('homework'),
+                ),
+                totalQuiz: Expression::sum(
+                    Expression::arrayFieldPath('quiz'),
+                ),
+            ),
+            Stage::set(
+                totalScore: Expression::add(
+                    Expression::numberFieldPath('totalHomework'),
+                    Expression::numberFieldPath('totalQuiz'),
+                    Expression::numberFieldPath('extraCredit'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetUsingTwoSetStages, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/SetWindowFieldsStageTest.php
+++ b/tests/Builder/Stage/SetWindowFieldsStageTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $setWindowFields stage
+ */
+class SetWindowFieldsStageTest extends PipelineTestCase
+{
+    public function testRangeWindowExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::setWindowFields(
+                partitionBy: Expression::stringFieldPath('state'),
+                sortBy: object(price: 1),
+                output: object(
+                    quantityFromSimilarOrders: Accumulator::outputWindow(
+                        Accumulator::sum(
+                            Expression::numberFieldPath('quantity'),
+                        ),
+                        range: [-10, 10],
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetWindowFieldsRangeWindowExample, $pipeline);
+    }
+
+    public function testUseATimeRangeWindowWithANegativeUpperBound(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::setWindowFields(
+                partitionBy: Expression::stringFieldPath('state'),
+                sortBy: object(orderDate: 1),
+                output: object(
+                    recentOrders: Accumulator::outputWindow(
+                        Accumulator::push(
+                            Expression::dateFieldPath('orderDate'),
+                        ),
+                        range: ['unbounded', -10],
+                        unit: 'month',
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetWindowFieldsUseATimeRangeWindowWithANegativeUpperBound, $pipeline);
+    }
+
+    public function testUseATimeRangeWindowWithAPositiveUpperBound(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::setWindowFields(
+                partitionBy: Expression::stringFieldPath('state'),
+                sortBy: object(orderDate: 1),
+                output: object(
+                    recentOrders: Accumulator::outputWindow(
+                        Accumulator::push(
+                            Expression::dateFieldPath('orderDate'),
+                        ),
+                        range: ['unbounded', 10],
+                        unit: 'month',
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetWindowFieldsUseATimeRangeWindowWithAPositiveUpperBound, $pipeline);
+    }
+
+    public function testUseDocumentsWindowToObtainCumulativeAndMaximumQuantityForEachYear(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::setWindowFields(
+                partitionBy: Expression::year(
+                    Expression::dateFieldPath('orderDate'),
+                ),
+                sortBy: object(orderDate: 1),
+                output: object(
+                    cumulativeQuantityForYear: Accumulator::outputWindow(
+                        Accumulator::sum(
+                            Expression::numberFieldPath('quantity'),
+                        ),
+                        documents: ['unbounded', 'current'],
+                    ),
+                    maximumQuantityForYear: Accumulator::outputWindow(
+                        Accumulator::max(
+                            Expression::numberFieldPath('quantity'),
+                        ),
+                        documents: ['unbounded', 'unbounded'],
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetWindowFieldsUseDocumentsWindowToObtainCumulativeAndMaximumQuantityForEachYear, $pipeline);
+    }
+
+    public function testUseDocumentsWindowToObtainCumulativeQuantityForEachState(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::setWindowFields(
+                partitionBy: Expression::stringFieldPath('state'),
+                sortBy: object(orderDate: 1),
+                output: object(
+                    cumulativeQuantityForState: Accumulator::outputWindow(
+                        Accumulator::sum(
+                            Expression::numberFieldPath('quantity'),
+                        ),
+                        documents: ['unbounded', 'current'],
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetWindowFieldsUseDocumentsWindowToObtainCumulativeQuantityForEachState, $pipeline);
+    }
+
+    public function testUseDocumentsWindowToObtainCumulativeQuantityForEachYear(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::setWindowFields(
+                partitionBy: Expression::year(
+                    Expression::dateFieldPath('orderDate'),
+                ),
+                sortBy: object(orderDate: 1),
+                output: object(
+                    cumulativeQuantityForYear: Accumulator::outputWindow(
+                        Accumulator::sum(
+                            Expression::numberFieldPath('quantity'),
+                        ),
+                        documents: ['unbounded', 'current'],
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetWindowFieldsUseDocumentsWindowToObtainCumulativeQuantityForEachYear, $pipeline);
+    }
+
+    public function testUseDocumentsWindowToObtainMovingAverageQuantityForEachYear(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::setWindowFields(
+                partitionBy: Expression::year(
+                    Expression::dateFieldPath('orderDate'),
+                ),
+                sortBy: object(orderDate: 1),
+                output: object(
+                    averageQuantity: Accumulator::outputWindow(
+                        Accumulator::avg(
+                            Expression::numberFieldPath('quantity'),
+                        ),
+                        documents: [-1, 0],
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SetWindowFieldsUseDocumentsWindowToObtainMovingAverageQuantityForEachYear, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/ShardedDataDistributionStageTest.php
+++ b/tests/Builder/Stage/ShardedDataDistributionStageTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $shardedDataDistribution stage
+ */
+class ShardedDataDistributionStageTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::shardedDataDistribution(),
+        );
+
+        $this->assertSamePipeline(Pipelines::ShardedDataDistributionExample, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/SkipStageTest.php
+++ b/tests/Builder/Stage/SkipStageTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $skip stage
+ */
+class SkipStageTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::skip(5),
+        );
+
+        $this->assertSamePipeline(Pipelines::SkipExample, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/SortByCountStageTest.php
+++ b/tests/Builder/Stage/SortByCountStageTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $sortByCount stage
+ */
+class SortByCountStageTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::unwind(
+                Expression::arrayFieldPath('tags'),
+            ),
+            Stage::sortByCount(
+                Expression::arrayFieldPath('tags'),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SortByCountExample, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/SortStageTest.php
+++ b/tests/Builder/Stage/SortStageTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $sort stage
+ */
+class SortStageTest extends PipelineTestCase
+{
+    public function testAscendingDescendingSort(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::sort(
+                object(
+                    age: -1,
+                    posts: 1,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SortAscendingDescendingSort, $pipeline);
+    }
+
+    public function testTextScoreMetadataSort(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::text('operating'),
+            ),
+            Stage::sort(
+                object(
+                    score: ['$meta' => 'textScore'],
+                    posts: -1,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SortTextScoreMetadataSort, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/UnionWithStageTest.php
+++ b/tests/Builder/Stage/UnionWithStageTest.php
@@ -10,10 +10,7 @@ use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
-use function array_map;
-use function array_merge;
 use function MongoDB\object;
-use function range;
 
 /**
  * Test $unionWith stage
@@ -22,33 +19,42 @@ class UnionWithStageTest extends PipelineTestCase
 {
     public function testReport1AllSalesByYearAndStoresAndItems(): void
     {
-        $pipeline = new Pipeline(...array_merge(
-            [
-                Stage::set(
-                    _id: '2017',
-                ),
-            ],
-            array_map(
-                fn ($year) => Stage::unionWith(
-                    coll: 'sales_' . $year,
-                    pipeline: new Pipeline(
-                        Stage::set(
-                            _id: (string) $year,
-                        ),
-                    ),
-                ),
-                range(2018, 2020),
+        $pipeline = new Pipeline(
+            Stage::set(
+                _id: '2017',
             ),
-            [
-                Stage::sort(
-                    object(
-                        _id: 1,
-                        store: 1,
-                        item: 1,
+            Stage::unionWith(
+                coll: 'sales_2018',
+                pipeline: new Pipeline(
+                    Stage::set(
+                        _id: '2018',
                     ),
                 ),
-            ],
-        ));
+            ),
+            Stage::unionWith(
+                coll: 'sales_2019',
+                pipeline: new Pipeline(
+                    Stage::set(
+                        _id: '2019',
+                    ),
+                ),
+            ),
+            Stage::unionWith(
+                coll: 'sales_2020',
+                pipeline: new Pipeline(
+                    Stage::set(
+                        _id: '2020',
+                    ),
+                ),
+            ),
+            Stage::sort(
+                object(
+                    _id: 1,
+                    store: 1,
+                    item: 1,
+                ),
+            ),
+        );
 
         $this->assertSamePipeline(Pipelines::UnionWithReport1AllSalesByYearAndStoresAndItems, $pipeline);
     }

--- a/tests/Builder/Stage/UnionWithStageTest.php
+++ b/tests/Builder/Stage/UnionWithStageTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function array_map;
+use function array_merge;
+use function MongoDB\object;
+use function range;
+
+/**
+ * Test $unionWith stage
+ */
+class UnionWithStageTest extends PipelineTestCase
+{
+    public function testReport1AllSalesByYearAndStoresAndItems(): void
+    {
+        $pipeline = new Pipeline(...array_merge(
+            [
+                Stage::set(
+                    _id: '2017',
+                ),
+            ],
+            array_map(
+                fn ($year) => Stage::unionWith(
+                    coll: 'sales_' . $year,
+                    pipeline: new Pipeline(
+                        Stage::set(
+                            _id: (string) $year,
+                        ),
+                    ),
+                ),
+                range(2018, 2020),
+            ),
+            [
+                Stage::sort(
+                    object(
+                        _id: 1,
+                        store: 1,
+                        item: 1,
+                    ),
+                ),
+            ],
+        ));
+
+        $this->assertSamePipeline(Pipelines::UnionWithReport1AllSalesByYearAndStoresAndItems, $pipeline);
+    }
+
+    public function testReport2AggregatedSalesByItems(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::unionWith('sales_2018'),
+            Stage::unionWith('sales_2019'),
+            Stage::unionWith('sales_2020'),
+            Stage::group(
+                _id: Expression::stringFieldPath('item'),
+                total: Accumulator::sum(
+                    Expression::numberFieldPath('quantity'),
+                ),
+            ),
+            Stage::sort(
+                object(
+                    total: -1,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::UnionWithReport2AggregatedSalesByItems, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/UnsetStageTest.php
+++ b/tests/Builder/Stage/UnsetStageTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $unset stage
+ */
+class UnsetStageTest extends PipelineTestCase
+{
+    public function testRemoveASingleField(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::unset('copies'),
+        );
+
+        $this->assertSamePipeline(Pipelines::UnsetRemoveASingleField, $pipeline);
+    }
+
+    public function testRemoveEmbeddedFields(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::unset(
+                'isbn',
+                'author.first',
+                'copies.warehouse',
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::UnsetRemoveEmbeddedFields, $pipeline);
+    }
+
+    public function testRemoveTopLevelFields(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::unset(
+                'isbn',
+                'copies',
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::UnsetRemoveTopLevelFields, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/UnwindStageTest.php
+++ b/tests/Builder/Stage/UnwindStageTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $unwind stage
+ */
+class UnwindStageTest extends PipelineTestCase
+{
+    public function testGroupByUnwoundValues(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::unwind(
+                path: Expression::arrayFieldPath('sizes'),
+                preserveNullAndEmptyArrays: true,
+            ),
+            Stage::group(
+                _id: Expression::fieldPath('sizes'),
+                averagePrice: Accumulator::avg(
+                    Expression::numberFieldPath('price'),
+                ),
+            ),
+            Stage::sort(
+                object(
+                    averagePrice: -1,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::UnwindGroupByUnwoundValues, $pipeline);
+    }
+
+    public function testIncludeArrayIndex(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::unwind(
+                path: Expression::arrayFieldPath('sizes'),
+                includeArrayIndex: 'arrayIndex',
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::UnwindIncludeArrayIndex, $pipeline);
+    }
+
+    public function testPreserveNullAndEmptyArrays(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::unwind(
+                path: Expression::arrayFieldPath('sizes'),
+                preserveNullAndEmptyArrays: true,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::UnwindPreserveNullAndEmptyArrays, $pipeline);
+    }
+
+    public function testUnwindArray(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::unwind(Expression::arrayFieldPath('sizes')),
+        );
+
+        $this->assertSamePipeline(Pipelines::UnwindUnwindArray, $pipeline);
+    }
+
+    public function testUnwindEmbeddedArrays(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::unwind(Expression::arrayFieldPath('items')),
+            Stage::unwind(Expression::arrayFieldPath('items.tags')),
+            Stage::group(
+                _id: Expression::fieldPath('items.tags'),
+                totalSalesAmount: Accumulator::sum(
+                    Expression::multiply(
+                        Expression::numberFieldPath('items.price'),
+                        Expression::numberFieldPath('items.quantity'),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::UnwindUnwindEmbeddedArrays, $pipeline);
+    }
+}


### PR DESCRIPTION
Fix [PHPLIB-1374](https://jira.mongodb.org/browse/PHPLIB-1374)

https://www.mongodb.com/docs/manual/reference/operator/aggregation-pipeline/

- ~`$addFields`~ already done
- `$bucket`
- `$bucketAuto`
- `$changeStream`
- `$changeStreamSplitLargeEvent`
- `$collStats`
- `$count`
- `$densify`
- `$documents`
- `$facet`
- `$fill`
- `$geoNear`
- `$graphLookup`
- `$group`
- `$indexStats`
- `$limit`
- `$listSampledQueries`
- `$listSearchIndexes`
- `$listSessions`
- `$lookup`
- `$match`
- `$merge`
- `$out`
- `$planCacheStats`
- `$project`
- `$redact`
- `$replaceRoot`
- `$replaceWith`
- `$sample`
- ~`$search`~ (no example)
- ~`$searchMeta`~ (no example)
- `$set`
- `$setWindowFields`
- `$skip`
- `$sort`
- `$sortByCount`
- `$unionWith`
- `$unset`
- `$unwind`