### PR TITLE
PHPLIB-1388 Fix `$search` and `$searchMeta` operators

### DIFF
--- a/generator/config/stage/search.yaml
+++ b/generator/config/stage/search.yaml
@@ -3,12 +3,187 @@ name: $search
 link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/search/'
 type:
     - stage
-encode: single
+encode: object
 description: |
     Performs a full-text search of the field or fields in an Atlas collection.
     NOTE: $search is only available for MongoDB Atlas clusters, and is not available for self-managed deployments.
 arguments:
     -
-        name: search
+        name: index
+        type:
+            - string
+        optional: true
+    -
+        name: highlight
         type:
             - object
+        optional: true
+    -
+        name: concurrent
+        type:
+            - bool
+        optional: true
+    -
+        name: count
+        type:
+            - object
+        optional: true
+    -
+        name: searchAfter
+        type:
+            - string
+        optional: true
+    -
+        name: searchBefore
+        type:
+            - string
+        optional: true
+    -
+        name: scoreDetails
+        type:
+            - bool
+        optional: true
+    -
+        name: sort
+        type:
+            - object # SortSpec
+        optional: true
+    -
+        name: returnStoredSource
+        type:
+            - bool
+        optional: true
+    -
+        name: tracking
+        type:
+            - object
+        optional: true
+    -
+        name: operatorOrCollection
+        type:
+            - object
+        variadic: object
+tests:
+    -
+        name: 'Basic Example'
+        link: 'https://www.mongodb.com/docs/atlas/atlas-search/highlighting/#basic-example'
+        pipeline:
+            -
+                $search:
+                    text:
+                        path: 'description'
+                        query:
+                            - 'variety'
+                            - 'bunch'
+                    highlight:
+                        path: 'description'
+            -
+                $project:
+                    description: 1
+                    _id: 0
+                    highlights:
+                        $meta: 'searchHighlights'
+    -
+        name: 'Advanced Example'
+        link: 'https://www.mongodb.com/docs/atlas/atlas-search/highlighting/#advanced-example'
+        pipeline:
+            -
+                $search:
+                    text:
+                        path: 'description'
+                        query:
+                            - 'variety'
+                            - 'bunch'
+                    highlight:
+                        path: 'description'
+                        maxNumPassages: 1
+                        maxCharsToExamine: 40
+            -
+                $project:
+                    description: 1
+                    _id: 0
+                    highlights:
+                        $meta: 'searchHighlights'
+    -
+        name: 'Multi-Field Example'
+        link: 'https://www.mongodb.com/docs/atlas/atlas-search/highlighting/#multi-field-example'
+        pipeline:
+            -
+                $search:
+                    text:
+                        path: 'description'
+                        query: 'varieties'
+                    highlight:
+                        path:
+                            - 'description'
+                            - 'summary'
+            -
+                $project:
+                    description: 1
+                    summary: 1
+                    _id: 0
+                    highlights:
+                        $meta: 'searchHighlights'
+    -
+        name: 'Wildcard Example'
+        link: 'https://www.mongodb.com/docs/atlas/atlas-search/highlighting/#wildcard-example'
+        pipeline:
+            -
+                $search:
+                    text:
+                        path:
+                            wildcard: 'des*'
+                        query:
+                            - 'variety'
+                    highlight:
+                        path:
+                            wildcard: 'des*'
+            -
+                $project:
+                    description: 1
+                    _id: 0
+                    highlights:
+                        $meta: 'searchHighlights'
+    -
+        name: 'Autocomplete Example'
+        link: 'https://www.mongodb.com/docs/atlas/atlas-search/highlighting/#autocomplete-example'
+        pipeline:
+            -
+                $search:
+                    autocomplete:
+                        path: 'description'
+                        query:
+                            - 'var'
+                    highlight:
+                        path: 'description'
+            -
+                $project:
+                    description: 1
+                    _id: 0
+                    highlights:
+                        $meta: 'searchHighlights'
+    -
+        name: 'Compound Example'
+        link: 'https://www.mongodb.com/docs/atlas/atlas-search/highlighting/#compound-example'
+        pipeline:
+            -
+                $search:
+                    compound:
+                        should:
+                            -
+                                text:
+                                    path: 'category'
+                                    query: 'organic'
+                            -
+                                text:
+                                    path: 'description'
+                                    query: 'variety'
+                    highlight:
+                        path: 'description'
+            -
+                $project:
+                    description: 1
+                    category: 1
+                    _id: 0
+                    highlights:
+                        $meta: 'searchHighlights'

--- a/src/Builder/Stage/FactoryTrait.php
+++ b/src/Builder/Stage/FactoryTrait.php
@@ -545,11 +545,33 @@ trait FactoryTrait
      * NOTE: $search is only available for MongoDB Atlas clusters, and is not available for self-managed deployments.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/search/
-     * @param Document|Serializable|array|stdClass $search
+     * @param Document|Serializable|array|stdClass ...$operatorOrCollection
+     * @param Optional|string $index
+     * @param Optional|Document|Serializable|array|stdClass $highlight
+     * @param Optional|bool $concurrent
+     * @param Optional|Document|Serializable|array|stdClass $count
+     * @param Optional|string $searchAfter
+     * @param Optional|string $searchBefore
+     * @param Optional|bool $scoreDetails
+     * @param Optional|Document|Serializable|array|stdClass $sort
+     * @param Optional|bool $returnStoredSource
+     * @param Optional|Document|Serializable|array|stdClass $tracking
      */
-    public static function search(Document|Serializable|stdClass|array $search): SearchStage
+    public static function search(
+        Document|Serializable|stdClass|array $operatorOrCollection,
+        Optional|string $index = Optional::Undefined,
+        Optional|Document|Serializable|stdClass|array $highlight = Optional::Undefined,
+        Optional|bool $concurrent = Optional::Undefined,
+        Optional|Document|Serializable|stdClass|array $count = Optional::Undefined,
+        Optional|string $searchAfter = Optional::Undefined,
+        Optional|string $searchBefore = Optional::Undefined,
+        Optional|bool $scoreDetails = Optional::Undefined,
+        Optional|Document|Serializable|stdClass|array $sort = Optional::Undefined,
+        Optional|bool $returnStoredSource = Optional::Undefined,
+        Optional|Document|Serializable|stdClass|array ...$tracking,
+    ): SearchStage
     {
-        return new SearchStage($search);
+        return new SearchStage(...$operatorOrCollection, $index, $highlight, $concurrent, $count, $searchAfter, $searchBefore, $scoreDetails, $sort, $returnStoredSource, $tracking);
     }
 
     /**

--- a/src/Builder/Stage/SearchStage.php
+++ b/src/Builder/Stage/SearchStage.php
@@ -12,8 +12,12 @@ use MongoDB\BSON\Document;
 use MongoDB\BSON\Serializable;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\Optional;
 use MongoDB\Builder\Type\StageInterface;
+use MongoDB\Exception\InvalidArgumentException;
 use stdClass;
+
+use function is_string;
 
 /**
  * Performs a full-text search of the field or fields in an Atlas collection.
@@ -23,17 +27,89 @@ use stdClass;
  */
 class SearchStage implements StageInterface, OperatorInterface
 {
-    public const ENCODE = Encode::Single;
+    public const ENCODE = Encode::Object;
 
-    /** @var Document|Serializable|array|stdClass $search */
-    public readonly Document|Serializable|stdClass|array $search;
+    /** @var stdClass<Document|Serializable|array|stdClass> $operatorOrCollection */
+    public readonly stdClass $operatorOrCollection;
+
+    /** @var Optional|string $index */
+    public readonly Optional|string $index;
+
+    /** @var Optional|Document|Serializable|array|stdClass $highlight */
+    public readonly Optional|Document|Serializable|stdClass|array $highlight;
+
+    /** @var Optional|bool $concurrent */
+    public readonly Optional|bool $concurrent;
+
+    /** @var Optional|Document|Serializable|array|stdClass $count */
+    public readonly Optional|Document|Serializable|stdClass|array $count;
+
+    /** @var Optional|string $searchAfter */
+    public readonly Optional|string $searchAfter;
+
+    /** @var Optional|string $searchBefore */
+    public readonly Optional|string $searchBefore;
+
+    /** @var Optional|bool $scoreDetails */
+    public readonly Optional|bool $scoreDetails;
+
+    /** @var Optional|Document|Serializable|array|stdClass $sort */
+    public readonly Optional|Document|Serializable|stdClass|array $sort;
+
+    /** @var Optional|bool $returnStoredSource */
+    public readonly Optional|bool $returnStoredSource;
+
+    /** @var Optional|Document|Serializable|array|stdClass $tracking */
+    public readonly Optional|Document|Serializable|stdClass|array $tracking;
 
     /**
-     * @param Document|Serializable|array|stdClass $search
+     * @param Document|Serializable|array|stdClass ...$operatorOrCollection
+     * @param Optional|string $index
+     * @param Optional|Document|Serializable|array|stdClass $highlight
+     * @param Optional|bool $concurrent
+     * @param Optional|Document|Serializable|array|stdClass $count
+     * @param Optional|string $searchAfter
+     * @param Optional|string $searchBefore
+     * @param Optional|bool $scoreDetails
+     * @param Optional|Document|Serializable|array|stdClass $sort
+     * @param Optional|bool $returnStoredSource
+     * @param Optional|Document|Serializable|array|stdClass $tracking
      */
-    public function __construct(Document|Serializable|stdClass|array $search)
-    {
-        $this->search = $search;
+    public function __construct(
+        Document|Serializable|stdClass|array $operatorOrCollection,
+        Optional|string $index = Optional::Undefined,
+        Optional|Document|Serializable|stdClass|array $highlight = Optional::Undefined,
+        Optional|bool $concurrent = Optional::Undefined,
+        Optional|Document|Serializable|stdClass|array $count = Optional::Undefined,
+        Optional|string $searchAfter = Optional::Undefined,
+        Optional|string $searchBefore = Optional::Undefined,
+        Optional|bool $scoreDetails = Optional::Undefined,
+        Optional|Document|Serializable|stdClass|array $sort = Optional::Undefined,
+        Optional|bool $returnStoredSource = Optional::Undefined,
+        Optional|Document|Serializable|stdClass|array ...$tracking,
+    ) {
+        if (\count($operatorOrCollection) < 1) {
+            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $operatorOrCollection, got %d.', 1, \count($operatorOrCollection)));
+        }
+
+        foreach($operatorOrCollection as $key => $value) {
+            if (! is_string($key)) {
+                throw new InvalidArgumentException('Expected $operatorOrCollection arguments to be a map (object), named arguments (<name>:<value>) or array unpacking ...[\'<name>\' => <value>] must be used');
+            }
+        }
+
+        $operatorOrCollection = (object) $operatorOrCollection;
+        $this->operatorOrCollection = $operatorOrCollection;
+        $this->index = $index;
+        $this->highlight = $highlight;
+        $this->concurrent = $concurrent;
+        $this->count = $count;
+        $this->searchAfter = $searchAfter;
+        $this->searchBefore = $searchBefore;
+        $this->scoreDetails = $scoreDetails;
+        $this->sort = $sort;
+        $this->returnStoredSource = $returnStoredSource;
+        $this->tracking = $tracking;
     }
 
     public function getOperator(): string

--- a/tests/Builder/Stage/Pipelines.php
+++ b/tests/Builder/Stage/Pipelines.php
@@ -55,4 +55,249 @@ enum Pipelines: string
         }
     ]
     JSON;
+
+    /**
+     * Basic Example
+     *
+     * @see https://www.mongodb.com/docs/atlas/atlas-search/highlighting/#basic-example
+     */
+    case SearchBasicExample = <<<'JSON'
+    [
+        {
+            "$search": {
+                "text": {
+                    "path": "description",
+                    "query": [
+                        "variety",
+                        "bunch"
+                    ]
+                },
+                "highlight": {
+                    "path": "description"
+                }
+            }
+        },
+        {
+            "$project": {
+                "description": {
+                    "$numberInt": "1"
+                },
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "highlights": {
+                    "$meta": "searchHighlights"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Advanced Example
+     *
+     * @see https://www.mongodb.com/docs/atlas/atlas-search/highlighting/#advanced-example
+     */
+    case SearchAdvancedExample = <<<'JSON'
+    [
+        {
+            "$search": {
+                "text": {
+                    "path": "description",
+                    "query": [
+                        "variety",
+                        "bunch"
+                    ]
+                },
+                "highlight": {
+                    "path": "description",
+                    "maxNumPassages": {
+                        "$numberInt": "1"
+                    },
+                    "maxCharsToExamine": {
+                        "$numberInt": "40"
+                    }
+                }
+            }
+        },
+        {
+            "$project": {
+                "description": {
+                    "$numberInt": "1"
+                },
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "highlights": {
+                    "$meta": "searchHighlights"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Multi-Field Example
+     *
+     * @see https://www.mongodb.com/docs/atlas/atlas-search/highlighting/#multi-field-example
+     */
+    case SearchMultiFieldExample = <<<'JSON'
+    [
+        {
+            "$search": {
+                "text": {
+                    "path": "description",
+                    "query": "varieties"
+                },
+                "highlight": {
+                    "path": [
+                        "description",
+                        "summary"
+                    ]
+                }
+            }
+        },
+        {
+            "$project": {
+                "description": {
+                    "$numberInt": "1"
+                },
+                "summary": {
+                    "$numberInt": "1"
+                },
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "highlights": {
+                    "$meta": "searchHighlights"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Wildcard Example
+     *
+     * @see https://www.mongodb.com/docs/atlas/atlas-search/highlighting/#wildcard-example
+     */
+    case SearchWildcardExample = <<<'JSON'
+    [
+        {
+            "$search": {
+                "text": {
+                    "path": {
+                        "wildcard": "des*"
+                    },
+                    "query": [
+                        "variety"
+                    ]
+                },
+                "highlight": {
+                    "path": {
+                        "wildcard": "des*"
+                    }
+                }
+            }
+        },
+        {
+            "$project": {
+                "description": {
+                    "$numberInt": "1"
+                },
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "highlights": {
+                    "$meta": "searchHighlights"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Autocomplete Example
+     *
+     * @see https://www.mongodb.com/docs/atlas/atlas-search/highlighting/#autocomplete-example
+     */
+    case SearchAutocompleteExample = <<<'JSON'
+    [
+        {
+            "$search": {
+                "autocomplete": {
+                    "path": "description",
+                    "query": [
+                        "var"
+                    ]
+                },
+                "highlight": {
+                    "path": "description"
+                }
+            }
+        },
+        {
+            "$project": {
+                "description": {
+                    "$numberInt": "1"
+                },
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "highlights": {
+                    "$meta": "searchHighlights"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Compound Example
+     *
+     * @see https://www.mongodb.com/docs/atlas/atlas-search/highlighting/#compound-example
+     */
+    case SearchCompoundExample = <<<'JSON'
+    [
+        {
+            "$search": {
+                "compound": {
+                    "should": [
+                        {
+                            "text": {
+                                "path": "category",
+                                "query": "organic"
+                            }
+                        },
+                        {
+                            "text": {
+                                "path": "description",
+                                "query": "variety"
+                            }
+                        }
+                    ]
+                },
+                "highlight": {
+                    "path": "description"
+                }
+            }
+        },
+        {
+            "$project": {
+                "description": {
+                    "$numberInt": "1"
+                },
+                "category": {
+                    "$numberInt": "1"
+                },
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "highlights": {
+                    "$meta": "searchHighlights"
+                }
+            }
+        }
+    ]
+    JSON;
 }

--- a/tests/Builder/Stage/SearchStageTest.php
+++ b/tests/Builder/Stage/SearchStageTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $search stage
+ */
+class SearchStageTest extends PipelineTestCase
+{
+    public function testAdvancedExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::search(
+            )
+        );
+
+        $this->assertSamePipeline(Pipelines::SearchAdvancedExample, $pipeline);
+    }
+
+    public function testAutocompleteExample(): void
+    {
+        $pipeline = new Pipeline();
+
+        $this->assertSamePipeline(Pipelines::SearchAutocompleteExample, $pipeline);
+    }
+
+    public function testBasicExample(): void
+    {
+        $pipeline = new Pipeline();
+
+        $this->assertSamePipeline(Pipelines::SearchBasicExample, $pipeline);
+    }
+
+    public function testCompoundExample(): void
+    {
+        $pipeline = new Pipeline();
+
+        $this->assertSamePipeline(Pipelines::SearchCompoundExample, $pipeline);
+    }
+
+    public function testMultiFieldExample(): void
+    {
+        $pipeline = new Pipeline();
+
+        $this->assertSamePipeline(Pipelines::SearchMultiFieldExample, $pipeline);
+    }
+
+    public function testWildcardExample(): void
+    {
+        $pipeline = new Pipeline();
+
+        $this->assertSamePipeline(Pipelines::SearchWildcardExample, $pipeline);
+    }
+}


### PR DESCRIPTION
Fix [PHPLIB-1388](https://jira.mongodb.org/browse/PHPLIB-1388)

The syntax of this operator is scary.
https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/