### PR TITLE
PHPLIB-1384: Use default value in Query::exists()

### DIFF
--- a/generator/config/query/exists.yaml
+++ b/generator/config/query/exists.yaml
@@ -11,6 +11,7 @@ arguments:
         name: exists
         type:
             - bool
+        default: true
 tests:
     -
         name: 'Exists and Not Equal To'
@@ -29,3 +30,10 @@ tests:
                 $match:
                     qty:
                         $exists: true
+    -
+        name: 'Missing Field'
+        pipeline:
+            -
+                $match:
+                    qty:
+                        $exists: false

--- a/src/Builder/Query/ExistsOperator.php
+++ b/src/Builder/Query/ExistsOperator.php
@@ -27,7 +27,7 @@ class ExistsOperator implements FieldQueryInterface, OperatorInterface
     /**
      * @param bool $exists
      */
-    public function __construct(bool $exists)
+    public function __construct(bool $exists = true)
     {
         $this->exists = $exists;
     }

--- a/src/Builder/Query/FactoryTrait.php
+++ b/src/Builder/Query/FactoryTrait.php
@@ -175,7 +175,7 @@ trait FactoryTrait
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/exists/
      * @param bool $exists
      */
-    public static function exists(bool $exists): ExistsOperator
+    public static function exists(bool $exists = true): ExistsOperator
     {
         return new ExistsOperator($exists);
     }

--- a/tests/Builder/Query/AndOperatorTest.php
+++ b/tests/Builder/Query/AndOperatorTest.php
@@ -23,7 +23,7 @@ class AndOperatorTest extends PipelineTestCase
                         price: Query::ne(1.99),
                     ),
                     Query::query(
-                        price: Query::exists(true),
+                        price: Query::exists(),
                     ),
                 ),
             ),

--- a/tests/Builder/Query/ExistsOperatorTest.php
+++ b/tests/Builder/Query/ExistsOperatorTest.php
@@ -19,7 +19,7 @@ class ExistsOperatorTest extends PipelineTestCase
         $pipeline = new Pipeline(
             Stage::match(
                 qty: [
-                    Query::exists(true),
+                    Query::exists(),
                     Query::nin([5, 15]),
                 ],
             ),
@@ -28,13 +28,22 @@ class ExistsOperatorTest extends PipelineTestCase
         $this->assertSamePipeline(Pipelines::ExistsExistsAndNotEqualTo, $pipeline);
     }
 
+    public function testMissingField(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                qty: Query::exists(false),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ExistsMissingField, $pipeline);
+    }
+
     public function testNullValues(): void
     {
         $pipeline = new Pipeline(
             Stage::match(
-                qty: [
-                    Query::exists(true),
-                ],
+                qty: Query::exists(),
             ),
         );
 

--- a/tests/Builder/Query/Pipelines.php
+++ b/tests/Builder/Query/Pipelines.php
@@ -696,6 +696,19 @@ enum Pipelines: string
     ]
     JSON;
 
+    /** Missing Field */
+    case ExistsMissingField = <<<'JSON'
+    [
+        {
+            "$match": {
+                "qty": {
+                    "$exists": false
+                }
+            }
+        }
+    ]
+    JSON;
+
     /**
      * Compare Two Fields from A Single Document
      *

--- a/tests/Builder/Stage/CurrentOpStageTest.php
+++ b/tests/Builder/Stage/CurrentOpStageTest.php
@@ -23,7 +23,7 @@ class CurrentOpStageTest extends PipelineTestCase
             ),
             Stage::match(
                 active: false,
-                transaction: Query::exists(true),
+                transaction: Query::exists(),
             ),
         );
 

--- a/tests/Builder/Stage/FacetStageTest.php
+++ b/tests/Builder/Stage/FacetStageTest.php
@@ -40,7 +40,7 @@ class FacetStageTest extends PipelineTestCase
                 ),
                 categorizedByPrice: new Pipeline(
                     Stage::match(
-                        price: Query::exists(true),
+                        price: Query::exists(),
                     ),
                     Stage::bucket(
                         groupBy: Expression::numberFieldPath('price'),


### PR DESCRIPTION
PHPLIB-1384

I decided to add another test to explicitly test using `exists` with a different value.