### PR TITLE
PHPLIB-1380: Add tests for $search and $searchMeta stages

### DIFF
--- a/generator/config/stage/search.yaml
+++ b/generator/config/stage/search.yaml
@@ -12,3 +12,30 @@ arguments:
         name: search
         type:
             - object
+
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#aggregation-variable'
+        pipeline:
+            -
+                $search:
+                    near:
+                        path: 'released'
+                        origin: !bson_utcdatetime '2011-09-01T00:00:00.000+00:00'
+                        pivot: 7776000000
+            -
+                $project:
+                    _id: 0
+                    title: 1
+                    released: 1
+            -
+                $limit: 5
+            -
+                $facet:
+                    docs: []
+                    meta:
+                        -
+                            $replaceWith: '$$SEARCH_META'
+                        -
+                            $limit: 1

--- a/generator/config/stage/searchMeta.yaml
+++ b/generator/config/stage/searchMeta.yaml
@@ -12,3 +12,17 @@ arguments:
         name: meta
         type:
             - object
+
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#example'
+        pipeline:
+            -
+                $searchMeta:
+                    range:
+                        path: 'year'
+                        gte: 1998
+                        lt: 1999
+                    count:
+                        type: 'total'

--- a/tests/Builder/Stage/Pipelines.php
+++ b/tests/Builder/Stage/Pipelines.php
@@ -2555,6 +2555,90 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#aggregation-variable
+     */
+    case SearchExample = <<<'JSON'
+    [
+        {
+            "$search": {
+                "near": {
+                    "path": "released",
+                    "origin": {
+                        "$date": {
+                            "$numberLong": "1314835200000"
+                        }
+                    },
+                    "pivot": {
+                        "$numberLong": "7776000000"
+                    }
+                }
+            }
+        },
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "title": {
+                    "$numberInt": "1"
+                },
+                "released": {
+                    "$numberInt": "1"
+                }
+            }
+        },
+        {
+            "$limit": {
+                "$numberInt": "5"
+            }
+        },
+        {
+            "$facet": {
+                "docs": [],
+                "meta": [
+                    {
+                        "$replaceWith": "$$SEARCH_META"
+                    },
+                    {
+                        "$limit": {
+                            "$numberInt": "1"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#example
+     */
+    case SearchMetaExample = <<<'JSON'
+    [
+        {
+            "$searchMeta": {
+                "range": {
+                    "path": "year",
+                    "gte": {
+                        "$numberInt": "1998"
+                    },
+                    "lt": {
+                        "$numberInt": "1999"
+                    }
+                },
+                "count": {
+                    "type": "total"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Using Two $set Stages
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/set/#using-two--set-stages

--- a/tests/Builder/Stage/SearchMetaStageTest.php
+++ b/tests/Builder/Stage/SearchMetaStageTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $searchMeta stage
+ */
+class SearchMetaStageTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::searchMeta(object(
+                range: object(
+                    path: 'year',
+                    gte: 1998,
+                    lt: 1999,
+                ),
+                count: object(type: 'total'),
+            )),
+        );
+
+        $this->assertSamePipeline(Pipelines::SearchMetaExample, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/SearchStageTest.php
+++ b/tests/Builder/Stage/SearchStageTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use DateTime;
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $search stage
+ */
+class SearchStageTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::search(object(
+                near: object(
+                    path: 'released',
+                    origin: new UTCDateTime(new DateTime('2011-09-01T00:00:00.000+00:00')),
+                    pivot: 7776000000,
+                ),
+            )),
+            Stage::project(_id: 0, title: 1, released: 1),
+            Stage::limit(5),
+            Stage::facet(
+                docs: [],
+                meta: new Pipeline(
+                    Stage::replaceWith(Expression::variable('SEARCH_META')),
+                    Stage::limit(1),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SearchExample, $pipeline);
+    }
+}


### PR DESCRIPTION
PHPLIB-1380

Added tests for these two stages from the documentation, which is in a different place than that for other stages.

For now, this uses `object(...)` to define the contents of the search stage. I've created PHPLIB-1388 to track creation of dedicated builders for search operators, and this will likely involve having a separate encoder, as the `$search` stage will only take a list of operators.