### PR TITLE
PHPLIB-1273: Improve $switch syntax

### DIFF
--- a/generator/config/expression/case.yaml
+++ b/generator/config/expression/case.yaml
@@ -2,7 +2,7 @@
 name: $case
 link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/switch/'
 type:
-    - resolvesToAny
+    - switchBranch
 encode: flat_object
 description: |
     Represents a single case in a $switch expression

--- a/generator/config/expression/case.yaml
+++ b/generator/config/expression/case.yaml
@@ -1,0 +1,21 @@
+# $schema: ../schema.json
+name: $case
+link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/switch/'
+type:
+    - resolvesToAny
+encode: flat_object
+description: |
+    Represents a single case in a $switch expression
+arguments:
+    -
+        name: case
+        type:
+            - resolvesToBool
+        description: |
+            Can be any valid expression that resolves to a boolean. If the result is not a boolean, it is coerced to a boolean value. More information about how MongoDB evaluates expressions as either true or false can be found here.
+    -
+        name: then
+        type:
+            - expression
+        description: |
+            Can be any valid expression.

--- a/generator/config/expression/switch.yaml
+++ b/generator/config/expression/switch.yaml
@@ -10,7 +10,7 @@ arguments:
     -
         name: branches
         type:
-            - array # of object{case:resolvesToBool, then:expression}
+            - array # of CaseOperator
         description: |
             An array of control branch documents. Each branch is a document with the following fields:
             - case Can be any valid expression that resolves to a boolean. If the result is not a boolean, it is coerced to a boolean value. More information about how MongoDB evaluates expressions as either true or false can be found here.

--- a/generator/config/expressions.php
+++ b/generator/config/expressions.php
@@ -113,6 +113,10 @@ return $expressions + [
         'returnType' => Type\GeometryInterface::class,
         'acceptedTypes' => [Type\GeometryInterface::class, ...$bsonTypes['object']],
     ],
+    'switchBranch' => [
+        'returnType' => Type\SwitchBranchInterface::class,
+        'acceptedTypes' => [Type\SwitchBranchInterface::class, ...$bsonTypes['object']],
+    ],
 
     // @todo add enum values
     'Granularity' => [

--- a/generator/config/schema.json
+++ b/generator/config/schema.json
@@ -58,7 +58,7 @@
                     "type": "string",
                     "enum": [
                         "array",
-                        "object",
+                        "flat_object",
                         "dollar_object",
                         "single",
                         "group"

--- a/generator/config/schema.json
+++ b/generator/config/schema.json
@@ -29,6 +29,7 @@
                             "filter",
                             "window",
                             "geometry",
+                            "switchBranch",
                             "resolvesToAny",
                             "resolvesToNumber",
                             "resolvesToDouble",

--- a/generator/config/schema.json
+++ b/generator/config/schema.json
@@ -58,6 +58,7 @@
                     "type": "string",
                     "enum": [
                         "array",
+                        "object",
                         "flat_object",
                         "dollar_object",
                         "single",

--- a/generator/src/Definition/OperatorDefinition.php
+++ b/generator/src/Definition/OperatorDefinition.php
@@ -39,6 +39,7 @@ final class OperatorDefinition
             'single' => Encode::Single,
             'array' => Encode::Array,
             'object' => Encode::Object,
+            'flat_object' => Encode::FlatObject,
             'dollar_object' => Encode::DollarObject,
             'group' => Encode::Group,
             default => throw new UnexpectedValueException(sprintf('Unexpected "encode" value for operator "%s". Got "%s"', $name, $encode)),

--- a/src/Builder/Encoder/OperatorEncoder.php
+++ b/src/Builder/Encoder/OperatorEncoder.php
@@ -46,10 +46,8 @@ class OperatorEncoder extends AbstractExpressionEncoder
                 return $this->encodeAsArray($value);
 
             case Encode::Object:
-                return $this->encodeAsObject($value);
-
             case Encode::FlatObject:
-                return $this->encodeAsObject($value, true);
+                return $this->encodeAsObject($value);
 
             case Encode::DollarObject:
                 return $this->encodeAsDollarObject($value);
@@ -98,7 +96,7 @@ class OperatorEncoder extends AbstractExpressionEncoder
         return $this->wrap($value, $result);
     }
 
-    private function encodeAsObject(OperatorInterface $value, bool $flat = false): stdClass
+    private function encodeAsObject(OperatorInterface $value): stdClass
     {
         $result = new stdClass();
         foreach (get_object_vars($value) as $key => $val) {
@@ -110,7 +108,7 @@ class OperatorEncoder extends AbstractExpressionEncoder
             $result->{$key} = $this->recursiveEncode($val);
         }
 
-        return $flat
+        return $value::ENCODE === Encode::FlatObject
             ? $result
             : $this->wrap($value, $result);
     }

--- a/src/Builder/Encoder/OperatorEncoder.php
+++ b/src/Builder/Encoder/OperatorEncoder.php
@@ -48,6 +48,9 @@ class OperatorEncoder extends AbstractExpressionEncoder
             case Encode::Object:
                 return $this->encodeAsObject($value);
 
+            case Encode::FlatObject:
+                return $this->encodeAsObject($value, true);
+
             case Encode::DollarObject:
                 return $this->encodeAsDollarObject($value);
 
@@ -95,7 +98,7 @@ class OperatorEncoder extends AbstractExpressionEncoder
         return $this->wrap($value, $result);
     }
 
-    private function encodeAsObject(OperatorInterface $value): stdClass
+    private function encodeAsObject(OperatorInterface $value, bool $flat = false): stdClass
     {
         $result = new stdClass();
         foreach (get_object_vars($value) as $key => $val) {
@@ -107,7 +110,9 @@ class OperatorEncoder extends AbstractExpressionEncoder
             $result->{$key} = $this->recursiveEncode($val);
         }
 
-        return $this->wrap($value, $result);
+        return $flat
+            ? $result
+            : $this->wrap($value, $result);
     }
 
     private function encodeAsDollarObject(OperatorInterface $value): stdClass

--- a/src/Builder/Expression/CaseOperator.php
+++ b/src/Builder/Expression/CaseOperator.php
@@ -12,6 +12,7 @@ use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
 use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\SwitchBranchInterface;
 use stdClass;
 
 /**
@@ -19,7 +20,7 @@ use stdClass;
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/switch/
  */
-class CaseOperator implements ResolvesToAny, OperatorInterface
+class CaseOperator implements SwitchBranchInterface, OperatorInterface
 {
     public const ENCODE = Encode::FlatObject;
 

--- a/src/Builder/Expression/CaseOperator.php
+++ b/src/Builder/Expression/CaseOperator.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * THIS FILE IS AUTO-GENERATED. ANY CHANGES WILL BE LOST!
+ */
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Expression;
+
+use MongoDB\BSON\Type;
+use MongoDB\Builder\Type\Encode;
+use MongoDB\Builder\Type\ExpressionInterface;
+use MongoDB\Builder\Type\OperatorInterface;
+use stdClass;
+
+/**
+ * Represents a single case in a $switch expression
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/switch/
+ */
+class CaseOperator implements ResolvesToAny, OperatorInterface
+{
+    public const ENCODE = Encode::FlatObject;
+
+    /** @var ResolvesToBool|bool $case Can be any valid expression that resolves to a boolean. If the result is not a boolean, it is coerced to a boolean value. More information about how MongoDB evaluates expressions as either true or false can be found here. */
+    public readonly ResolvesToBool|bool $case;
+
+    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $then Can be any valid expression. */
+    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $then;
+
+    /**
+     * @param ResolvesToBool|bool $case Can be any valid expression that resolves to a boolean. If the result is not a boolean, it is coerced to a boolean value. More information about how MongoDB evaluates expressions as either true or false can be found here.
+     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $then Can be any valid expression.
+     */
+    public function __construct(
+        ResolvesToBool|bool $case,
+        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $then,
+    ) {
+        $this->case = $case;
+        $this->then = $then;
+    }
+
+    public function getOperator(): string
+    {
+        return '$case';
+    }
+}

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -307,6 +307,21 @@ trait FactoryTrait
     }
 
     /**
+     * Represents a single case in a $switch expression
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/switch/
+     * @param ResolvesToBool|bool $case Can be any valid expression that resolves to a boolean. If the result is not a boolean, it is coerced to a boolean value. More information about how MongoDB evaluates expressions as either true or false can be found here.
+     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $then Can be any valid expression.
+     */
+    public static function case(
+        ResolvesToBool|bool $case,
+        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $then,
+    ): CaseOperator
+    {
+        return new CaseOperator($case, $then);
+    }
+
+    /**
      * Returns the smallest integer greater than or equal to the specified number.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/ceil/

--- a/src/Builder/Type/Encode.php
+++ b/src/Builder/Type/Encode.php
@@ -24,6 +24,11 @@ enum Encode
     case Object;
 
     /**
+     * Same as Object, but only parameters are returned. The operator name will not be used.
+     */
+    case FlatObject;
+
+    /**
      * Parameters are encoded as an object with keys matching the parameter names prefixed with a dollar sign ($)
      */
     case DollarObject;

--- a/src/Builder/Type/SwitchBranchInterface.php
+++ b/src/Builder/Type/SwitchBranchInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Type;
+
+/**
+ * Interface for branches in $switch operators
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/switch/
+ */
+interface SwitchBranchInterface
+{
+}

--- a/tests/Builder/Expression/ConvertOperatorTest.php
+++ b/tests/Builder/Expression/ConvertOperatorTest.php
@@ -10,8 +10,6 @@ use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
-use function MongoDB\object;
-
 /**
  * Test $convert expression
  */
@@ -43,7 +41,7 @@ class ConvertOperatorTest extends PipelineTestCase
             Stage::project(
                 totalPrice: Expression::switch(
                     branches: [
-                        object(
+                        Expression::case(
                             case: Expression::eq(
                                 Expression::type(
                                     Expression::fieldPath('convertedPrice'),
@@ -52,7 +50,7 @@ class ConvertOperatorTest extends PipelineTestCase
                             ),
                             then: 'NaN',
                         ),
-                        object(
+                        Expression::case(
                             case: Expression::eq(
                                 Expression::type(
                                     Expression::fieldPath('convertedQty'),

--- a/tests/Builder/Expression/IsNumberOperatorTest.php
+++ b/tests/Builder/Expression/IsNumberOperatorTest.php
@@ -10,8 +10,6 @@ use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
-use function MongoDB\object;
-
 /**
  * Test $isNumber expression
  */
@@ -28,35 +26,35 @@ class IsNumberOperatorTest extends PipelineTestCase
                     then: Expression::fieldPath('grade'),
                     else: Expression::switch(
                         branches: [
-                            object(
+                            Expression::case(
                                 case: Expression::eq(
                                     Expression::fieldPath('grade'),
                                     'A',
                                 ),
                                 then: 4,
                             ),
-                            object(
+                            Expression::case(
                                 case: Expression::eq(
                                     Expression::fieldPath('grade'),
                                     'B',
                                 ),
                                 then: 3,
                             ),
-                            object(
+                            Expression::case(
                                 case: Expression::eq(
                                     Expression::fieldPath('grade'),
                                     'C',
                                 ),
                                 then: 2,
                             ),
-                            object(
+                            Expression::case(
                                 case: Expression::eq(
                                     Expression::fieldPath('grade'),
                                     'D',
                                 ),
                                 then: 1,
                             ),
-                            object(
+                            Expression::case(
                                 case: Expression::eq(
                                     Expression::fieldPath('grade'),
                                     'F',

--- a/tests/Builder/Expression/SwitchOperatorTest.php
+++ b/tests/Builder/Expression/SwitchOperatorTest.php
@@ -9,8 +9,6 @@ use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
-use function MongoDB\object;
-
 /**
  * Test $switch expression
  */
@@ -23,7 +21,7 @@ class SwitchOperatorTest extends PipelineTestCase
                 name: 1,
                 summary: Expression::switch(
                     branches: [
-                        object(
+                        Expression::case(
                             case: Expression::gte(
                                 Expression::avg(
                                     Expression::intFieldPath('scores'),
@@ -32,7 +30,7 @@ class SwitchOperatorTest extends PipelineTestCase
                             ),
                             then: 'Doing great!',
                         ),
-                        object(
+                        Expression::case(
                             case:Expression::and(
                                 Expression::gte(
                                     Expression::avg(
@@ -49,7 +47,7 @@ class SwitchOperatorTest extends PipelineTestCase
                             ),
                             then: 'Doing pretty well.',
                         ),
-                        object(
+                        Expression::case(
                             case: Expression::lt(
                                 Expression::avg(
                                     Expression::intFieldPath('scores'),

--- a/tests/Builder/Expression/ToBoolOperatorTest.php
+++ b/tests/Builder/Expression/ToBoolOperatorTest.php
@@ -9,8 +9,6 @@ use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
-use function MongoDB\object;
-
 /**
  * Test $toBool expression
  */
@@ -22,14 +20,14 @@ class ToBoolOperatorTest extends PipelineTestCase
             Stage::addFields(
                 convertedShippedFlag: Expression::switch(
                     branches: [
-                        object(
+                        Expression::case(
                             case: Expression::eq(
                                 Expression::fieldPath('shipped'),
                                 'false',
                             ),
                             then: false,
                         ),
-                        object(
+                        Expression::case(
                             case: Expression::eq(
                                 Expression::fieldPath('shipped'),
                                 '',


### PR DESCRIPTION
PHPLIB-1273

Instead of using `object`, there is now a dedicated `case` operator. In order to accommodate the different encoding for `case`, I added a `flat_object` encoding mechanism that doesn't wrap the parameter object in another object containing the operator name. Alternatively, we could create a separate encoder for `case`.