### PR TITLE
PHPLIB-1381 PHPLIB-1269 Add enum for Sort and TimeUnit

### DIFF
--- a/generator/config/accumulator/derivative.yaml
+++ b/generator/config/accumulator/derivative.yaml
@@ -16,7 +16,7 @@ arguments:
     -
         name: unit
         type:
-            - string
+            - timeUnit
         optional: true
         description: |
             A string that specifies the time unit. Use one of these strings: "week", "day","hour", "minute", "second", "millisecond".

--- a/generator/config/accumulator/integral.yaml
+++ b/generator/config/accumulator/integral.yaml
@@ -16,7 +16,7 @@ arguments:
     -
         name: unit
         type:
-            - resolvesToString
+            - timeUnit
         optional: true
         description: |
             A string that specifies the time unit. Use one of these strings: "week", "day","hour", "minute", "second", "millisecond".

--- a/generator/config/expression/dateAdd.yaml
+++ b/generator/config/expression/dateAdd.yaml
@@ -18,7 +18,7 @@ arguments:
     -
         name: unit
         type:
-            - resolvesToString
+            - timeUnit
         description: |
             The unit used to measure the amount of time added to the startDate.
     -

--- a/generator/config/expression/dateDiff.yaml
+++ b/generator/config/expression/dateDiff.yaml
@@ -26,7 +26,7 @@ arguments:
     -
         name: unit
         type:
-            - resolvesToString
+            - timeUnit
         description: |
             The time measurement unit between the startDate and endDate
     -

--- a/generator/config/expression/dateSubtract.yaml
+++ b/generator/config/expression/dateSubtract.yaml
@@ -18,7 +18,7 @@ arguments:
     -
         name: unit
         type:
-            - resolvesToString
+            - timeUnit
         description: |
             The unit used to measure the amount of time added to the startDate.
     -

--- a/generator/config/expression/dateTrunc.yaml
+++ b/generator/config/expression/dateTrunc.yaml
@@ -18,7 +18,7 @@ arguments:
     -
         name: unit
         type:
-            - resolvesToString
+            - timeUnit
         description: |
             The unit of time, specified as an expression that must resolve to one of these strings: year, quarter, week, month, day, hour, minute, second.
             Together, binSize and unit specify the time period used in the $dateTrunc calculation.

--- a/generator/config/expression/sortArray.yaml
+++ b/generator/config/expression/sortArray.yaml
@@ -20,6 +20,7 @@ arguments:
         type:
             - object # SortSpec
             - int
+            - sortSpec
         description: |
             The document specifies a sort ordering.
 tests:

--- a/generator/config/expressions.php
+++ b/generator/config/expressions.php
@@ -121,6 +121,10 @@ return $expressions + [
         'returnType' => Type\TimeUnit::class,
         'acceptedTypes' => [Type\TimeUnit::class, ResolvesToString::class, ...$bsonTypes['string']],
     ],
+    'sortSpec' => [
+        'returnType' => Type\Sort::class,
+        'acceptedTypes' => [Type\Sort::class],
+    ],
 
     // @todo add enum values
     'Granularity' => [

--- a/generator/config/expressions.php
+++ b/generator/config/expressions.php
@@ -117,6 +117,10 @@ return $expressions + [
         'returnType' => Type\SwitchBranchInterface::class,
         'acceptedTypes' => [Type\SwitchBranchInterface::class, ...$bsonTypes['object']],
     ],
+    'timeUnit' => [
+        'returnType' => Type\TimeUnit::class,
+        'acceptedTypes' => [Type\TimeUnit::class, ResolvesToString::class, ...$bsonTypes['string']],
+    ],
 
     // @todo add enum values
     'Granularity' => [

--- a/generator/config/query/text.yaml
+++ b/generator/config/query/text.yaml
@@ -102,6 +102,8 @@ tests:
                     $text:
                         $search: 'CAFÉ'
                         $diacriticSensitive: true
+            -
+                $project:
                     score:
                         $meta: 'textScore'
             -

--- a/generator/config/schema.json
+++ b/generator/config/schema.json
@@ -116,6 +116,7 @@
                             "geometry",
                             "fieldPath",
                             "timeUnit",
+                            "sortSpec",
                             "any",
                             "resolvesToNumber", "numberFieldPath", "number",
                             "resolvesToDouble", "doubleFieldPath", "double",

--- a/generator/config/schema.json
+++ b/generator/config/schema.json
@@ -115,6 +115,7 @@
                             "expression",
                             "geometry",
                             "fieldPath",
+                            "timeUnit",
                             "any",
                             "resolvesToNumber", "numberFieldPath", "number",
                             "resolvesToDouble", "doubleFieldPath", "double",

--- a/generator/config/stage/sort.yaml
+++ b/generator/config/stage/sort.yaml
@@ -10,7 +10,8 @@ arguments:
     -
         name: sort
         type:
-            - object # SortSpec
+            - expression
+        variadic: object
 tests:
     -
         name: 'Ascending Descending Sort'

--- a/generator/config/stage/sort.yaml
+++ b/generator/config/stage/sort.yaml
@@ -11,6 +11,7 @@ arguments:
         name: sort
         type:
             - expression
+            - sortSpec
         variadic: object
 tests:
     -

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.20.0@3f284e96c9d9be6fe6b15c79416e1d1903dcfef4">
+<files psalm-version="5.21.1@8c473e2437be8b6a8fd8f630f0f11a16b114c494">
   <file src="src/Builder/Encoder/AbstractExpressionEncoder.php">
     <MixedAssignment>
       <code>$val</code>
@@ -108,6 +108,14 @@
   <file src="src/Builder/Stage/SetStage.php">
     <PropertyTypeCoercion>
       <code>$field</code>
+    </PropertyTypeCoercion>
+    <TooManyTemplateParams>
+      <code>stdClass</code>
+    </TooManyTemplateParams>
+  </file>
+  <file src="src/Builder/Stage/SortStage.php">
+    <PropertyTypeCoercion>
+      <code>$sort</code>
     </PropertyTypeCoercion>
     <TooManyTemplateParams>
       <code>stdClass</code>

--- a/src/Builder/Accumulator.php
+++ b/src/Builder/Accumulator.php
@@ -8,6 +8,7 @@ use MongoDB\BSON\Document;
 use MongoDB\BSON\Serializable;
 use MongoDB\Builder\Type\Optional;
 use MongoDB\Builder\Type\OutputWindow;
+use MongoDB\Builder\Type\TimeUnit;
 use MongoDB\Builder\Type\WindowInterface;
 use stdClass;
 
@@ -31,7 +32,7 @@ final class Accumulator
         Document|Serializable|WindowInterface|stdClass|array $operator,
         Optional|array $documents = Optional::Undefined,
         Optional|array $range = Optional::Undefined,
-        Optional|string $unit = Optional::Undefined,
+        Optional|TimeUnit|string $unit = Optional::Undefined,
     ): OutputWindow {
         return new OutputWindow($operator, $documents, $range, $unit);
     }

--- a/src/Builder/Accumulator/DerivativeAccumulator.php
+++ b/src/Builder/Accumulator/DerivativeAccumulator.php
@@ -13,9 +13,11 @@ use MongoDB\BSON\Int64;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Builder\Expression\ResolvesToDate;
 use MongoDB\Builder\Expression\ResolvesToNumber;
+use MongoDB\Builder\Expression\ResolvesToString;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
 use MongoDB\Builder\Type\Optional;
+use MongoDB\Builder\Type\TimeUnit;
 use MongoDB\Builder\Type\WindowInterface;
 
 /**
@@ -32,19 +34,19 @@ class DerivativeAccumulator implements WindowInterface, OperatorInterface
     public readonly Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int $input;
 
     /**
-     * @var Optional|string $unit A string that specifies the time unit. Use one of these strings: "week", "day","hour", "minute", "second", "millisecond".
+     * @var Optional|ResolvesToString|TimeUnit|string $unit A string that specifies the time unit. Use one of these strings: "week", "day","hour", "minute", "second", "millisecond".
      * If the sortBy field is not a date, you must omit a unit. If you specify a unit, you must specify a date in the sortBy field.
      */
-    public readonly Optional|string $unit;
+    public readonly Optional|ResolvesToString|TimeUnit|string $unit;
 
     /**
      * @param Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int $input
-     * @param Optional|string $unit A string that specifies the time unit. Use one of these strings: "week", "day","hour", "minute", "second", "millisecond".
+     * @param Optional|ResolvesToString|TimeUnit|string $unit A string that specifies the time unit. Use one of these strings: "week", "day","hour", "minute", "second", "millisecond".
      * If the sortBy field is not a date, you must omit a unit. If you specify a unit, you must specify a date in the sortBy field.
      */
     public function __construct(
         Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int $input,
-        Optional|string $unit = Optional::Undefined,
+        Optional|ResolvesToString|TimeUnit|string $unit = Optional::Undefined,
     ) {
         $this->input = $input;
         $this->unit = $unit;

--- a/src/Builder/Accumulator/FactoryTrait.php
+++ b/src/Builder/Accumulator/FactoryTrait.php
@@ -24,6 +24,7 @@ use MongoDB\Builder\Expression\ResolvesToObject;
 use MongoDB\Builder\Expression\ResolvesToString;
 use MongoDB\Builder\Type\ExpressionInterface;
 use MongoDB\Builder\Type\Optional;
+use MongoDB\Builder\Type\TimeUnit;
 use MongoDB\Model\BSONArray;
 use stdClass;
 
@@ -180,12 +181,12 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/derivative/
      * @param Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int $input
-     * @param Optional|string $unit A string that specifies the time unit. Use one of these strings: "week", "day","hour", "minute", "second", "millisecond".
+     * @param Optional|ResolvesToString|TimeUnit|string $unit A string that specifies the time unit. Use one of these strings: "week", "day","hour", "minute", "second", "millisecond".
      * If the sortBy field is not a date, you must omit a unit. If you specify a unit, you must specify a date in the sortBy field.
      */
     public static function derivative(
         Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int $input,
-        Optional|string $unit = Optional::Undefined,
+        Optional|ResolvesToString|TimeUnit|string $unit = Optional::Undefined,
     ): DerivativeAccumulator
     {
         return new DerivativeAccumulator($input, $unit);
@@ -260,12 +261,12 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/integral/
      * @param Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int $input
-     * @param Optional|ResolvesToString|string $unit A string that specifies the time unit. Use one of these strings: "week", "day","hour", "minute", "second", "millisecond".
+     * @param Optional|ResolvesToString|TimeUnit|string $unit A string that specifies the time unit. Use one of these strings: "week", "day","hour", "minute", "second", "millisecond".
      * If the sortBy field is not a date, you must omit a unit. If you specify a unit, you must specify a date in the sortBy field.
      */
     public static function integral(
         Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int $input,
-        Optional|ResolvesToString|string $unit = Optional::Undefined,
+        Optional|ResolvesToString|TimeUnit|string $unit = Optional::Undefined,
     ): IntegralAccumulator
     {
         return new IntegralAccumulator($input, $unit);

--- a/src/Builder/Accumulator/IntegralAccumulator.php
+++ b/src/Builder/Accumulator/IntegralAccumulator.php
@@ -17,6 +17,7 @@ use MongoDB\Builder\Expression\ResolvesToString;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
 use MongoDB\Builder\Type\Optional;
+use MongoDB\Builder\Type\TimeUnit;
 use MongoDB\Builder\Type\WindowInterface;
 
 /**
@@ -33,19 +34,19 @@ class IntegralAccumulator implements WindowInterface, OperatorInterface
     public readonly Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int $input;
 
     /**
-     * @var Optional|ResolvesToString|string $unit A string that specifies the time unit. Use one of these strings: "week", "day","hour", "minute", "second", "millisecond".
+     * @var Optional|ResolvesToString|TimeUnit|string $unit A string that specifies the time unit. Use one of these strings: "week", "day","hour", "minute", "second", "millisecond".
      * If the sortBy field is not a date, you must omit a unit. If you specify a unit, you must specify a date in the sortBy field.
      */
-    public readonly Optional|ResolvesToString|string $unit;
+    public readonly Optional|ResolvesToString|TimeUnit|string $unit;
 
     /**
      * @param Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int $input
-     * @param Optional|ResolvesToString|string $unit A string that specifies the time unit. Use one of these strings: "week", "day","hour", "minute", "second", "millisecond".
+     * @param Optional|ResolvesToString|TimeUnit|string $unit A string that specifies the time unit. Use one of these strings: "week", "day","hour", "minute", "second", "millisecond".
      * If the sortBy field is not a date, you must omit a unit. If you specify a unit, you must specify a date in the sortBy field.
      */
     public function __construct(
         Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int $input,
-        Optional|ResolvesToString|string $unit = Optional::Undefined,
+        Optional|ResolvesToString|TimeUnit|string $unit = Optional::Undefined,
     ) {
         $this->input = $input;
         $this->unit = $unit;

--- a/src/Builder/BuilderEncoder.php
+++ b/src/Builder/BuilderEncoder.php
@@ -15,7 +15,7 @@ use MongoDB\Builder\Encoder\QueryEncoder;
 use MongoDB\Builder\Encoder\VariableEncoder;
 use MongoDB\Builder\Expression\Variable;
 use MongoDB\Builder\Type\CombinedFieldQuery;
-use MongoDB\Builder\Type\Dictionnary;
+use MongoDB\Builder\Type\DictionaryInterface;
 use MongoDB\Builder\Type\ExpressionInterface;
 use MongoDB\Builder\Type\FieldPathInterface;
 use MongoDB\Builder\Type\OperatorInterface;
@@ -31,17 +31,17 @@ use stdClass;
 use function array_key_exists;
 use function is_object;
 
-/** @template-implements Encoder<stdClass|array|string, Pipeline|StageInterface|ExpressionInterface|QueryInterface> */
+/** @template-implements Encoder<stdClass|array|string|int, Pipeline|StageInterface|ExpressionInterface|QueryInterface> */
 class BuilderEncoder implements Encoder
 {
-    /** @template-use EncodeIfSupported<stdClass|array|string, Pipeline|StageInterface|ExpressionInterface|QueryInterface> */
+    /** @template-use EncodeIfSupported<stdClass|array|string|int, Pipeline|StageInterface|ExpressionInterface|QueryInterface> */
     use EncodeIfSupported;
 
     /** @var array<class-string, class-string<ExpressionEncoder>> */
     private array $defaultEncoders = [
         Pipeline::class => PipelineEncoder::class,
         Variable::class => VariableEncoder::class,
-        Dictionnary::class => DictionaryEncoder::class,
+        DictionaryInterface::class => DictionaryEncoder::class,
         FieldPathInterface::class => FieldPathEncoder::class,
         CombinedFieldQuery::class => CombinedFieldQueryEncoder::class,
         QueryObject::class => QueryEncoder::class,

--- a/src/Builder/BuilderEncoder.php
+++ b/src/Builder/BuilderEncoder.php
@@ -67,7 +67,7 @@ class BuilderEncoder implements Encoder
         return (bool) $this->getEncoderFor($value)?->canEncode($value);
     }
 
-    public function encode(mixed $value): stdClass|array|string
+    public function encode(mixed $value): stdClass|array|string|int
     {
         $encoder = $this->getEncoderFor($value);
 

--- a/src/Builder/BuilderEncoder.php
+++ b/src/Builder/BuilderEncoder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MongoDB\Builder;
 
 use MongoDB\Builder\Encoder\CombinedFieldQueryEncoder;
+use MongoDB\Builder\Encoder\DictionaryEncoder;
 use MongoDB\Builder\Encoder\ExpressionEncoder;
 use MongoDB\Builder\Encoder\FieldPathEncoder;
 use MongoDB\Builder\Encoder\OperatorEncoder;
@@ -14,6 +15,7 @@ use MongoDB\Builder\Encoder\QueryEncoder;
 use MongoDB\Builder\Encoder\VariableEncoder;
 use MongoDB\Builder\Expression\Variable;
 use MongoDB\Builder\Type\CombinedFieldQuery;
+use MongoDB\Builder\Type\Dictionnary;
 use MongoDB\Builder\Type\ExpressionInterface;
 use MongoDB\Builder\Type\FieldPathInterface;
 use MongoDB\Builder\Type\OperatorInterface;
@@ -39,6 +41,7 @@ class BuilderEncoder implements Encoder
     private array $defaultEncoders = [
         Pipeline::class => PipelineEncoder::class,
         Variable::class => VariableEncoder::class,
+        Dictionnary::class => DictionaryEncoder::class,
         FieldPathInterface::class => FieldPathEncoder::class,
         CombinedFieldQuery::class => CombinedFieldQueryEncoder::class,
         QueryObject::class => QueryEncoder::class,

--- a/src/Builder/Encoder/AbstractExpressionEncoder.php
+++ b/src/Builder/Encoder/AbstractExpressionEncoder.php
@@ -11,7 +11,7 @@ use function get_object_vars;
 use function is_array;
 
 /**
- * @template BSONType of stdClass|array|string
+ * @template BSONType of stdClass|array|string|int
  * @template NativeType
  * @template-implements ExpressionEncoder<BSONType, NativeType>
  */

--- a/src/Builder/Encoder/DictionaryEncoder.php
+++ b/src/Builder/Encoder/DictionaryEncoder.php
@@ -4,20 +4,20 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Encoder;
 
-use MongoDB\Builder\Type\Dictionnary;
+use MongoDB\Builder\Type\DictionaryInterface;
 use MongoDB\Codec\EncodeIfSupported;
 use MongoDB\Exception\UnsupportedValueException;
 use stdClass;
 
-/** @template-extends AbstractExpressionEncoder<string, Dictionnary> */
+/** @template-extends AbstractExpressionEncoder<string|int|array|stdClass, DictionaryInterface> */
 class DictionaryEncoder extends AbstractExpressionEncoder
 {
-    /** @template-use EncodeIfSupported<string, Dictionnary> */
+    /** @template-use EncodeIfSupported<string|int|array|stdClass, DictionaryInterface> */
     use EncodeIfSupported;
 
     public function canEncode(mixed $value): bool
     {
-        return $value instanceof Dictionnary;
+        return $value instanceof DictionaryInterface;
     }
 
     public function encode(mixed $value): string|int|array|stdClass

--- a/src/Builder/Encoder/DictionaryEncoder.php
+++ b/src/Builder/Encoder/DictionaryEncoder.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Encoder;
+
+use MongoDB\Builder\Type\Dictionnary;
+use MongoDB\Codec\EncodeIfSupported;
+use MongoDB\Exception\UnsupportedValueException;
+use stdClass;
+
+/** @template-extends AbstractExpressionEncoder<string, Dictionnary> */
+class DictionaryEncoder extends AbstractExpressionEncoder
+{
+    /** @template-use EncodeIfSupported<string, Dictionnary> */
+    use EncodeIfSupported;
+
+    public function canEncode(mixed $value): bool
+    {
+        return $value instanceof Dictionnary;
+    }
+
+    public function encode(mixed $value): string|int|array|stdClass
+    {
+        if (! $this->canEncode($value)) {
+            throw UnsupportedValueException::invalidEncodableValue($value);
+        }
+
+        return $value->getValue();
+    }
+}

--- a/src/Builder/Encoder/ExpressionEncoder.php
+++ b/src/Builder/Encoder/ExpressionEncoder.php
@@ -9,7 +9,7 @@ use MongoDB\Codec\Encoder;
 use stdClass;
 
 /**
- * @template BSONType of stdClass|array|string
+ * @template BSONType of stdClass|array|string|int
  * @template NativeType
  * @template-extends Encoder<BSONType, NativeType>
  */

--- a/src/Builder/Expression/DateAddOperator.php
+++ b/src/Builder/Expression/DateAddOperator.php
@@ -15,6 +15,7 @@ use MongoDB\BSON\UTCDateTime;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
 use MongoDB\Builder\Type\Optional;
+use MongoDB\Builder\Type\TimeUnit;
 
 /**
  * Adds a number of time units to a date object.
@@ -28,8 +29,8 @@ class DateAddOperator implements ResolvesToDate, OperatorInterface
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $startDate The beginning date, in UTC, for the addition operation. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $startDate;
 
-    /** @var ResolvesToString|string $unit The unit used to measure the amount of time added to the startDate. */
-    public readonly ResolvesToString|string $unit;
+    /** @var ResolvesToString|TimeUnit|string $unit The unit used to measure the amount of time added to the startDate. */
+    public readonly ResolvesToString|TimeUnit|string $unit;
 
     /** @var Int64|ResolvesToInt|ResolvesToLong|int $amount */
     public readonly Int64|ResolvesToInt|ResolvesToLong|int $amount;
@@ -39,13 +40,13 @@ class DateAddOperator implements ResolvesToDate, OperatorInterface
 
     /**
      * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $startDate The beginning date, in UTC, for the addition operation. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
-     * @param ResolvesToString|string $unit The unit used to measure the amount of time added to the startDate.
+     * @param ResolvesToString|TimeUnit|string $unit The unit used to measure the amount of time added to the startDate.
      * @param Int64|ResolvesToInt|ResolvesToLong|int $amount
      * @param Optional|ResolvesToString|string $timezone The timezone to carry out the operation. $timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public function __construct(
         ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $startDate,
-        ResolvesToString|string $unit,
+        ResolvesToString|TimeUnit|string $unit,
         Int64|ResolvesToInt|ResolvesToLong|int $amount,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ) {

--- a/src/Builder/Expression/DateDiffOperator.php
+++ b/src/Builder/Expression/DateDiffOperator.php
@@ -14,6 +14,7 @@ use MongoDB\BSON\UTCDateTime;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
 use MongoDB\Builder\Type\Optional;
+use MongoDB\Builder\Type\TimeUnit;
 
 /**
  * Returns the difference between two dates.
@@ -30,8 +31,8 @@ class DateDiffOperator implements ResolvesToInt, OperatorInterface
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $endDate The end of the time period. The endDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $endDate;
 
-    /** @var ResolvesToString|string $unit The time measurement unit between the startDate and endDate */
-    public readonly ResolvesToString|string $unit;
+    /** @var ResolvesToString|TimeUnit|string $unit The time measurement unit between the startDate and endDate */
+    public readonly ResolvesToString|TimeUnit|string $unit;
 
     /** @var Optional|ResolvesToString|string $timezone The timezone to carry out the operation. $timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC. */
     public readonly Optional|ResolvesToString|string $timezone;
@@ -42,14 +43,14 @@ class DateDiffOperator implements ResolvesToInt, OperatorInterface
     /**
      * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $startDate The start of the time period. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $endDate The end of the time period. The endDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
-     * @param ResolvesToString|string $unit The time measurement unit between the startDate and endDate
+     * @param ResolvesToString|TimeUnit|string $unit The time measurement unit between the startDate and endDate
      * @param Optional|ResolvesToString|string $timezone The timezone to carry out the operation. $timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      * @param Optional|ResolvesToString|string $startOfWeek Used when the unit is equal to week. Defaults to Sunday. The startOfWeek parameter is an expression that resolves to a case insensitive string
      */
     public function __construct(
         ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $startDate,
         ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $endDate,
-        ResolvesToString|string $unit,
+        ResolvesToString|TimeUnit|string $unit,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
         Optional|ResolvesToString|string $startOfWeek = Optional::Undefined,
     ) {

--- a/src/Builder/Expression/DateSubtractOperator.php
+++ b/src/Builder/Expression/DateSubtractOperator.php
@@ -15,6 +15,7 @@ use MongoDB\BSON\UTCDateTime;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
 use MongoDB\Builder\Type\Optional;
+use MongoDB\Builder\Type\TimeUnit;
 
 /**
  * Subtracts a number of time units from a date object.
@@ -28,8 +29,8 @@ class DateSubtractOperator implements ResolvesToDate, OperatorInterface
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $startDate The beginning date, in UTC, for the addition operation. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $startDate;
 
-    /** @var ResolvesToString|string $unit The unit used to measure the amount of time added to the startDate. */
-    public readonly ResolvesToString|string $unit;
+    /** @var ResolvesToString|TimeUnit|string $unit The unit used to measure the amount of time added to the startDate. */
+    public readonly ResolvesToString|TimeUnit|string $unit;
 
     /** @var Int64|ResolvesToInt|ResolvesToLong|int $amount */
     public readonly Int64|ResolvesToInt|ResolvesToLong|int $amount;
@@ -39,13 +40,13 @@ class DateSubtractOperator implements ResolvesToDate, OperatorInterface
 
     /**
      * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $startDate The beginning date, in UTC, for the addition operation. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
-     * @param ResolvesToString|string $unit The unit used to measure the amount of time added to the startDate.
+     * @param ResolvesToString|TimeUnit|string $unit The unit used to measure the amount of time added to the startDate.
      * @param Int64|ResolvesToInt|ResolvesToLong|int $amount
      * @param Optional|ResolvesToString|string $timezone The timezone to carry out the operation. $timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public function __construct(
         ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $startDate,
-        ResolvesToString|string $unit,
+        ResolvesToString|TimeUnit|string $unit,
         Int64|ResolvesToInt|ResolvesToLong|int $amount,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ) {

--- a/src/Builder/Expression/DateTruncOperator.php
+++ b/src/Builder/Expression/DateTruncOperator.php
@@ -16,6 +16,7 @@ use MongoDB\BSON\UTCDateTime;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
 use MongoDB\Builder\Type\Optional;
+use MongoDB\Builder\Type\TimeUnit;
 
 /**
  * Truncates a date.
@@ -30,10 +31,10 @@ class DateTruncOperator implements ResolvesToDate, OperatorInterface
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $date;
 
     /**
-     * @var ResolvesToString|string $unit The unit of time, specified as an expression that must resolve to one of these strings: year, quarter, week, month, day, hour, minute, second.
+     * @var ResolvesToString|TimeUnit|string $unit The unit of time, specified as an expression that must resolve to one of these strings: year, quarter, week, month, day, hour, minute, second.
      * Together, binSize and unit specify the time period used in the $dateTrunc calculation.
      */
-    public readonly ResolvesToString|string $unit;
+    public readonly ResolvesToString|TimeUnit|string $unit;
 
     /**
      * @var Optional|Decimal128|Int64|ResolvesToNumber|float|int $binSize The numeric time value, specified as an expression that must resolve to a positive non-zero number. Defaults to 1.
@@ -52,7 +53,7 @@ class DateTruncOperator implements ResolvesToDate, OperatorInterface
 
     /**
      * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to truncate, specified in UTC. The date can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
-     * @param ResolvesToString|string $unit The unit of time, specified as an expression that must resolve to one of these strings: year, quarter, week, month, day, hour, minute, second.
+     * @param ResolvesToString|TimeUnit|string $unit The unit of time, specified as an expression that must resolve to one of these strings: year, quarter, week, month, day, hour, minute, second.
      * Together, binSize and unit specify the time period used in the $dateTrunc calculation.
      * @param Optional|Decimal128|Int64|ResolvesToNumber|float|int $binSize The numeric time value, specified as an expression that must resolve to a positive non-zero number. Defaults to 1.
      * Together, binSize and unit specify the time period used in the $dateTrunc calculation.
@@ -62,7 +63,7 @@ class DateTruncOperator implements ResolvesToDate, OperatorInterface
      */
     public function __construct(
         ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $date,
-        ResolvesToString|string $unit,
+        ResolvesToString|TimeUnit|string $unit,
         Optional|Decimal128|Int64|ResolvesToNumber|float|int $binSize = Optional::Undefined,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
         Optional|string $startOfWeek = Optional::Undefined,

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -22,6 +22,7 @@ use MongoDB\BSON\Type;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Builder\Type\ExpressionInterface;
 use MongoDB\Builder\Type\Optional;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Builder\Type\TimeUnit;
 use MongoDB\Model\BSONArray;
 use stdClass;
@@ -1816,11 +1817,11 @@ trait FactoryTrait
      * @param BSONArray|PackedArray|ResolvesToArray|array $input The array to be sorted.
      * The result is null if the expression: is missing, evaluates to null, or evaluates to undefined
      * If the expression evaluates to any other non-array value, the document returns an error.
-     * @param Document|Serializable|array|int|stdClass $sortBy The document specifies a sort ordering.
+     * @param Document|Serializable|Sort|array|int|stdClass $sortBy The document specifies a sort ordering.
      */
     public static function sortArray(
         PackedArray|ResolvesToArray|BSONArray|array $input,
-        Document|Serializable|stdClass|array|int $sortBy,
+        Document|Serializable|Sort|stdClass|array|int $sortBy,
     ): SortArrayOperator
     {
         return new SortArrayOperator($input, $sortBy);

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -22,6 +22,7 @@ use MongoDB\BSON\Type;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Builder\Type\ExpressionInterface;
 use MongoDB\Builder\Type\Optional;
+use MongoDB\Builder\Type\TimeUnit;
 use MongoDB\Model\BSONArray;
 use stdClass;
 
@@ -439,13 +440,13 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateAdd/
      * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $startDate The beginning date, in UTC, for the addition operation. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
-     * @param ResolvesToString|string $unit The unit used to measure the amount of time added to the startDate.
+     * @param ResolvesToString|TimeUnit|string $unit The unit used to measure the amount of time added to the startDate.
      * @param Int64|ResolvesToInt|ResolvesToLong|int $amount
      * @param Optional|ResolvesToString|string $timezone The timezone to carry out the operation. $timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public static function dateAdd(
         ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $startDate,
-        ResolvesToString|string $unit,
+        ResolvesToString|TimeUnit|string $unit,
         Int64|ResolvesToInt|ResolvesToLong|int $amount,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ): DateAddOperator
@@ -459,14 +460,14 @@ trait FactoryTrait
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateDiff/
      * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $startDate The start of the time period. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $endDate The end of the time period. The endDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
-     * @param ResolvesToString|string $unit The time measurement unit between the startDate and endDate
+     * @param ResolvesToString|TimeUnit|string $unit The time measurement unit between the startDate and endDate
      * @param Optional|ResolvesToString|string $timezone The timezone to carry out the operation. $timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      * @param Optional|ResolvesToString|string $startOfWeek Used when the unit is equal to week. Defaults to Sunday. The startOfWeek parameter is an expression that resolves to a case insensitive string
      */
     public static function dateDiff(
         ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $startDate,
         ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $endDate,
-        ResolvesToString|string $unit,
+        ResolvesToString|TimeUnit|string $unit,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
         Optional|ResolvesToString|string $startOfWeek = Optional::Undefined,
     ): DateDiffOperator
@@ -536,13 +537,13 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateSubtract/
      * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $startDate The beginning date, in UTC, for the addition operation. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
-     * @param ResolvesToString|string $unit The unit used to measure the amount of time added to the startDate.
+     * @param ResolvesToString|TimeUnit|string $unit The unit used to measure the amount of time added to the startDate.
      * @param Int64|ResolvesToInt|ResolvesToLong|int $amount
      * @param Optional|ResolvesToString|string $timezone The timezone to carry out the operation. $timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public static function dateSubtract(
         ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $startDate,
-        ResolvesToString|string $unit,
+        ResolvesToString|TimeUnit|string $unit,
         Int64|ResolvesToInt|ResolvesToLong|int $amount,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ): DateSubtractOperator
@@ -593,7 +594,7 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateTrunc/
      * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to truncate, specified in UTC. The date can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
-     * @param ResolvesToString|string $unit The unit of time, specified as an expression that must resolve to one of these strings: year, quarter, week, month, day, hour, minute, second.
+     * @param ResolvesToString|TimeUnit|string $unit The unit of time, specified as an expression that must resolve to one of these strings: year, quarter, week, month, day, hour, minute, second.
      * Together, binSize and unit specify the time period used in the $dateTrunc calculation.
      * @param Optional|Decimal128|Int64|ResolvesToNumber|float|int $binSize The numeric time value, specified as an expression that must resolve to a positive non-zero number. Defaults to 1.
      * Together, binSize and unit specify the time period used in the $dateTrunc calculation.
@@ -603,7 +604,7 @@ trait FactoryTrait
      */
     public static function dateTrunc(
         ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $date,
-        ResolvesToString|string $unit,
+        ResolvesToString|TimeUnit|string $unit,
         Optional|Decimal128|Int64|ResolvesToNumber|float|int $binSize = Optional::Undefined,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
         Optional|string $startOfWeek = Optional::Undefined,

--- a/src/Builder/Expression/SortArrayOperator.php
+++ b/src/Builder/Expression/SortArrayOperator.php
@@ -13,6 +13,7 @@ use MongoDB\BSON\PackedArray;
 use MongoDB\BSON\Serializable;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\BSONArray;
 use stdClass;
@@ -36,18 +37,18 @@ class SortArrayOperator implements ResolvesToArray, OperatorInterface
      */
     public readonly PackedArray|ResolvesToArray|BSONArray|array $input;
 
-    /** @var Document|Serializable|array|int|stdClass $sortBy The document specifies a sort ordering. */
-    public readonly Document|Serializable|stdClass|array|int $sortBy;
+    /** @var Document|Serializable|Sort|array|int|stdClass $sortBy The document specifies a sort ordering. */
+    public readonly Document|Serializable|Sort|stdClass|array|int $sortBy;
 
     /**
      * @param BSONArray|PackedArray|ResolvesToArray|array $input The array to be sorted.
      * The result is null if the expression: is missing, evaluates to null, or evaluates to undefined
      * If the expression evaluates to any other non-array value, the document returns an error.
-     * @param Document|Serializable|array|int|stdClass $sortBy The document specifies a sort ordering.
+     * @param Document|Serializable|Sort|array|int|stdClass $sortBy The document specifies a sort ordering.
      */
     public function __construct(
         PackedArray|ResolvesToArray|BSONArray|array $input,
-        Document|Serializable|stdClass|array|int $sortBy,
+        Document|Serializable|Sort|stdClass|array|int $sortBy,
     ) {
         if (is_array($input) && ! array_is_list($input)) {
             throw new InvalidArgumentException('Expected $input argument to be a list, got an associative array.');

--- a/src/Builder/Stage/FactoryTrait.php
+++ b/src/Builder/Stage/FactoryTrait.php
@@ -633,11 +633,13 @@ trait FactoryTrait
      * Reorders the document stream by a specified sort key. Only the order changes; the documents remain unmodified. For each input document, outputs one document.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sort/
-     * @param Document|Serializable|array|stdClass $sort
+     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$sort
      */
-    public static function sort(Document|Serializable|stdClass|array $sort): SortStage
+    public static function sort(
+        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$sort,
+    ): SortStage
     {
-        return new SortStage($sort);
+        return new SortStage(...$sort);
     }
 
     /**

--- a/src/Builder/Stage/FactoryTrait.php
+++ b/src/Builder/Stage/FactoryTrait.php
@@ -24,6 +24,7 @@ use MongoDB\Builder\Type\AccumulatorInterface;
 use MongoDB\Builder\Type\ExpressionInterface;
 use MongoDB\Builder\Type\Optional;
 use MongoDB\Builder\Type\QueryInterface;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Model\BSONArray;
 use stdClass;
 
@@ -633,10 +634,10 @@ trait FactoryTrait
      * Reorders the document stream by a specified sort key. Only the order changes; the documents remain unmodified. For each input document, outputs one document.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sort/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$sort
+     * @param ExpressionInterface|Sort|Type|array|bool|float|int|null|stdClass|string ...$sort
      */
     public static function sort(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$sort,
+        Type|ExpressionInterface|Sort|stdClass|array|bool|float|int|null|string ...$sort,
     ): SortStage
     {
         return new SortStage(...$sort);

--- a/src/Builder/Stage/SortStage.php
+++ b/src/Builder/Stage/SortStage.php
@@ -8,12 +8,15 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Stage;
 
-use MongoDB\BSON\Document;
-use MongoDB\BSON\Serializable;
+use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
+use MongoDB\Builder\Type\ExpressionInterface;
 use MongoDB\Builder\Type\OperatorInterface;
 use MongoDB\Builder\Type\StageInterface;
+use MongoDB\Exception\InvalidArgumentException;
 use stdClass;
+
+use function is_string;
 
 /**
  * Reorders the document stream by a specified sort key. Only the order changes; the documents remain unmodified. For each input document, outputs one document.
@@ -24,14 +27,25 @@ class SortStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 
-    /** @var Document|Serializable|array|stdClass $sort */
-    public readonly Document|Serializable|stdClass|array $sort;
+    /** @var stdClass<ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $sort */
+    public readonly stdClass $sort;
 
     /**
-     * @param Document|Serializable|array|stdClass $sort
+     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$sort
      */
-    public function __construct(Document|Serializable|stdClass|array $sort)
+    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$sort)
     {
+        if (\count($sort) < 1) {
+            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $sort, got %d.', 1, \count($sort)));
+        }
+
+        foreach($sort as $key => $value) {
+            if (! is_string($key)) {
+                throw new InvalidArgumentException('Expected $sort arguments to be a map (object), named arguments (<name>:<value>) or array unpacking ...[\'<name>\' => <value>] must be used');
+            }
+        }
+
+        $sort = (object) $sort;
         $this->sort = $sort;
     }
 

--- a/src/Builder/Stage/SortStage.php
+++ b/src/Builder/Stage/SortStage.php
@@ -12,6 +12,7 @@ use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
 use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Builder\Type\StageInterface;
 use MongoDB\Exception\InvalidArgumentException;
 use stdClass;
@@ -27,13 +28,13 @@ class SortStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 
-    /** @var stdClass<ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $sort */
+    /** @var stdClass<ExpressionInterface|Sort|Type|array|bool|float|int|null|stdClass|string> $sort */
     public readonly stdClass $sort;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$sort
+     * @param ExpressionInterface|Sort|Type|array|bool|float|int|null|stdClass|string ...$sort
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$sort)
+    public function __construct(Type|ExpressionInterface|Sort|stdClass|array|bool|float|int|null|string ...$sort)
     {
         if (\count($sort) < 1) {
             throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $sort, got %d.', 1, \count($sort)));

--- a/src/Builder/Type/DictionaryInterface.php
+++ b/src/Builder/Type/DictionaryInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Type;
 
-interface Dictionnary
+interface DictionaryInterface
 {
     public function getValue(): string|int|array;
 }

--- a/src/Builder/Type/Dictionnary.php
+++ b/src/Builder/Type/Dictionnary.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Type;
 
-use stdClass;
-
 interface Dictionnary
 {
-    public function getValue(): string|int|array|stdClass;
+    public function getValue(): string|int|array;
 }

--- a/src/Builder/Type/Dictionnary.php
+++ b/src/Builder/Type/Dictionnary.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Type;
+
+use stdClass;
+
+interface Dictionnary
+{
+    public function getValue(): string|int|array|stdClass;
+}

--- a/src/Builder/Type/OutputWindow.php
+++ b/src/Builder/Type/OutputWindow.php
@@ -46,7 +46,7 @@ class OutputWindow implements WindowInterface
         Document|Serializable|WindowInterface|stdClass|array $operator,
         Optional|array $documents = Optional::Undefined,
         Optional|array $range = Optional::Undefined,
-        Optional|string $unit = Optional::Undefined,
+        Optional|TimeUnit|string $unit = Optional::Undefined,
     ) {
         $this->operator = $operator;
 

--- a/src/Builder/Type/Sort.php
+++ b/src/Builder/Type/Sort.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Type;
+
+enum Sort implements Dictionnary
+{
+    case Asc;
+    case Desc;
+    case TextScore;
+    case SearchScoreAsc;
+    case SearchScoreDesc;
+
+    public function getValue(): int|array
+    {
+        return match ($this) {
+            self::Asc => 1,
+            self::Desc => -1,
+            self::TextScore => ['$meta' => 'textScore'],
+            self::SearchScoreAsc => ['$meta' => 'searchScore', 'order' => 1],
+            self::SearchScoreDesc => ['$meta' => 'searchScore', 'order' => -1],
+        };
+    }
+}

--- a/src/Builder/Type/Sort.php
+++ b/src/Builder/Type/Sort.php
@@ -14,8 +14,6 @@ enum Sort implements DictionaryInterface
     case Asc;
     case Desc;
     case TextScore;
-    case SearchScoreAsc;
-    case SearchScoreDesc;
 
     public function getValue(): int|array
     {
@@ -23,8 +21,6 @@ enum Sort implements DictionaryInterface
             self::Asc => 1,
             self::Desc => -1,
             self::TextScore => ['$meta' => 'textScore'],
-            self::SearchScoreAsc => ['$meta' => 'searchScore', 'order' => 1],
-            self::SearchScoreDesc => ['$meta' => 'searchScore', 'order' => -1],
         };
     }
 }

--- a/src/Builder/Type/Sort.php
+++ b/src/Builder/Type/Sort.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Type;
 
-enum Sort implements Dictionnary
+/**
+ * Sort order can be used with $sort stage and sortBy properties
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sort/
+ */
+enum Sort implements DictionaryInterface
 {
     case Asc;
     case Desc;

--- a/src/Builder/Type/TimeUnit.php
+++ b/src/Builder/Type/TimeUnit.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Type;
+
+enum TimeUnit: string implements Dictionnary
+{
+    case Year = 'year';
+    case Quarter = 'quarter';
+    case Week = 'week';
+    case Month = 'month';
+    case Day = 'day';
+    case Hour = 'hour';
+    case Minute = 'minute';
+    case Second = 'second';
+    case Millisecond = 'millisecond';
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Builder/Type/TimeUnit.php
+++ b/src/Builder/Type/TimeUnit.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Type;
 
-enum TimeUnit: string implements Dictionnary
+/**
+ * Values for "unit" property of stages like $derivative and $integral, and operators like $dateAdd and $dateDiff
+ */
+enum TimeUnit: string implements DictionaryInterface
 {
     case Year = 'year';
     case Quarter = 'quarter';

--- a/tests/Builder/Accumulator/AddToSetAccumulatorTest.php
+++ b/tests/Builder/Accumulator/AddToSetAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -38,7 +39,7 @@ class AddToSetAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::fieldPath('state'),
                 sortBy: object(
-                    orderDate: 1,
+                    orderDate: Sort::Asc,
                 ),
                 output: object(
                     cakeTypesForState: Accumulator::outputWindow(

--- a/tests/Builder/Accumulator/AvgAccumulatorTest.php
+++ b/tests/Builder/Accumulator/AvgAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -43,7 +44,7 @@ class AvgAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::fieldPath('state'),
                 sortBy: object(
-                    orderDate: 1,
+                    orderDate: Sort::Asc,
                 ),
                 output: object(
                     averageQuantityForState: Accumulator::outputWindow(

--- a/tests/Builder/Accumulator/BottomAccumulatorTest.php
+++ b/tests/Builder/Accumulator/BottomAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -31,7 +32,7 @@ class BottomAccumulatorTest extends PipelineTestCase
                         Expression::fieldPath('score'),
                     ],
                     sortBy: object(
-                        score: -1,
+                        score: Sort::Desc,
                     ),
                 ),
             ),
@@ -51,7 +52,7 @@ class BottomAccumulatorTest extends PipelineTestCase
                         Expression::fieldPath('score'),
                     ],
                     sortBy: object(
-                        score: -1,
+                        score: Sort::Desc,
                     ),
                 ),
             ),

--- a/tests/Builder/Accumulator/BottomNAccumulatorTest.php
+++ b/tests/Builder/Accumulator/BottomNAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -35,7 +36,7 @@ class BottomNAccumulatorTest extends PipelineTestCase
                         else: 3,
                     ),
                     sortBy: object(
-                        score: -1,
+                        score: Sort::Desc,
                     ),
                 ),
             ),
@@ -58,7 +59,7 @@ class BottomNAccumulatorTest extends PipelineTestCase
                         Expression::fieldPath('score'),
                     ],
                     sortBy: object(
-                        score: -1,
+                        score: Sort::Desc,
                     ),
                     n: 3,
                 ),
@@ -79,7 +80,7 @@ class BottomNAccumulatorTest extends PipelineTestCase
                         Expression::fieldPath('score'),
                     ],
                     sortBy: object(
-                        score: -1,
+                        score: Sort::Desc,
                     ),
                     n: 3,
                 ),

--- a/tests/Builder/Accumulator/CountAccumulatorTest.php
+++ b/tests/Builder/Accumulator/CountAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -35,7 +36,7 @@ class CountAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::fieldPath('state'),
                 sortBy: object(
-                    orderDate: 1,
+                    orderDate: Sort::Asc,
                 ),
                 output: object(
                     countNumberOfDocumentsForState: Accumulator::outputWindow(

--- a/tests/Builder/Accumulator/CovariancePopAccumulatorTest.php
+++ b/tests/Builder/Accumulator/CovariancePopAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -23,7 +24,7 @@ class CovariancePopAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::stringFieldPath('state'),
                 sortBy: object(
-                    orderDate: 1,
+                    orderDate: Sort::Asc,
                 ),
                 output: object(
                     covariancePopForState: Accumulator::outputWindow(

--- a/tests/Builder/Accumulator/CovarianceSampAccumulatorTest.php
+++ b/tests/Builder/Accumulator/CovarianceSampAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -23,7 +24,7 @@ class CovarianceSampAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::stringFieldPath('state'),
                 sortBy: object(
-                    orderDate: 1,
+                    orderDate: Sort::Asc,
                 ),
                 output: object(
                     covarianceSampForState: Accumulator::outputWindow(

--- a/tests/Builder/Accumulator/DenseRankAccumulatorTest.php
+++ b/tests/Builder/Accumulator/DenseRankAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -23,7 +24,7 @@ class DenseRankAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::stringFieldPath('state'),
                 sortBy: object(
-                    orderDate: 1,
+                    orderDate: Sort::Asc,
                 ),
                 output: object(
                     denseRankOrderDateForState: Accumulator::outputWindow(
@@ -42,7 +43,7 @@ class DenseRankAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::stringFieldPath('state'),
                 sortBy: object(
-                    quantity: -1,
+                    quantity: Sort::Desc,
                 ),
                 output: object(
                     // The outputWindow is optional when no window property is set.

--- a/tests/Builder/Accumulator/DerivativeAccumulatorTest.php
+++ b/tests/Builder/Accumulator/DerivativeAccumulatorTest.php
@@ -9,6 +9,7 @@ use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Query;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Builder\Type\TimeUnit;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
@@ -25,7 +26,7 @@ class DerivativeAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::stringFieldPath('truckID'),
                 sortBy: object(
-                    timeStamp: 1,
+                    timeStamp: Sort::Asc,
                 ),
                 output: object(
                     truckAverageSpeed: Accumulator::outputWindow(

--- a/tests/Builder/Accumulator/DerivativeAccumulatorTest.php
+++ b/tests/Builder/Accumulator/DerivativeAccumulatorTest.php
@@ -9,6 +9,7 @@ use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Query;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\TimeUnit;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -30,10 +31,10 @@ class DerivativeAccumulatorTest extends PipelineTestCase
                     truckAverageSpeed: Accumulator::outputWindow(
                         Accumulator::derivative(
                             input: Expression::numberFieldPath('miles'),
-                            unit: 'hour',
+                            unit: TimeUnit::Hour,
                         ),
                         range: [-30, 0],
-                        unit: 'second',
+                        unit: TimeUnit::Second,
                     ),
                 ),
             ),

--- a/tests/Builder/Accumulator/DocumentNumberAccumulatorTest.php
+++ b/tests/Builder/Accumulator/DocumentNumberAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -23,7 +24,7 @@ class DocumentNumberAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::stringFieldPath('state'),
                 sortBy: object(
-                    quantity: -1,
+                    quantity: Sort::Desc,
                 ),
                 output: object(
                     documentNumberForState: Accumulator::documentNumber(),

--- a/tests/Builder/Accumulator/ExpMovingAvgAccumulatorTest.php
+++ b/tests/Builder/Accumulator/ExpMovingAvgAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -23,7 +24,7 @@ class ExpMovingAvgAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::stringFieldPath('stock'),
                 sortBy: object(
-                    date: 1,
+                    date: Sort::Asc,
                 ),
                 output: object(
                     expMovingAvgForStock: Accumulator::expMovingAvg(
@@ -43,7 +44,7 @@ class ExpMovingAvgAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::stringFieldPath('stock'),
                 sortBy: object(
-                    date: 1,
+                    date: Sort::Asc,
                 ),
                 output: object(
                     expMovingAvgForStock: Accumulator::expMovingAvg(

--- a/tests/Builder/Accumulator/FirstAccumulatorTest.php
+++ b/tests/Builder/Accumulator/FirstAccumulatorTest.php
@@ -20,10 +20,10 @@ class FirstAccumulatorTest extends PipelineTestCase
     public function testUseInGroupStage(): void
     {
         $pipeline = new Pipeline(
-            Stage::sort(object(
+            Stage::sort(
                 item: 1,
                 date: 1,
-            )),
+            ),
             Stage::group(
                 _id: Expression::fieldPath('item'),
                 firstSale: Accumulator::first(Expression::dateFieldPath('date')),

--- a/tests/Builder/Accumulator/FirstAccumulatorTest.php
+++ b/tests/Builder/Accumulator/FirstAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -21,8 +22,8 @@ class FirstAccumulatorTest extends PipelineTestCase
     {
         $pipeline = new Pipeline(
             Stage::sort(
-                item: 1,
-                date: 1,
+                item: Sort::Asc,
+                date: Sort::Asc,
             ),
             Stage::group(
                 _id: Expression::fieldPath('item'),
@@ -39,7 +40,7 @@ class FirstAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::fieldPath('state'),
                 sortBy: object(
-                    orderDate: 1,
+                    orderDate: Sort::Asc,
                 ),
                 output: object(
                     firstOrderTypeForState: Accumulator::outputWindow(

--- a/tests/Builder/Accumulator/FirstNAccumulatorTest.php
+++ b/tests/Builder/Accumulator/FirstNAccumulatorTest.php
@@ -106,9 +106,7 @@ class FirstNAccumulatorTest extends PipelineTestCase
     {
         $pipeline = new Pipeline(
             Stage::sort(
-                object(
-                    score: -1,
-                ),
+                score: -1,
             ),
             Stage::group(
                 _id: Expression::fieldPath('gameId'),

--- a/tests/Builder/Accumulator/FirstNAccumulatorTest.php
+++ b/tests/Builder/Accumulator/FirstNAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -106,7 +107,7 @@ class FirstNAccumulatorTest extends PipelineTestCase
     {
         $pipeline = new Pipeline(
             Stage::sort(
-                score: -1,
+                score: Sort::Desc,
             ),
             Stage::group(
                 _id: Expression::fieldPath('gameId'),

--- a/tests/Builder/Accumulator/IntegralAccumulatorTest.php
+++ b/tests/Builder/Accumulator/IntegralAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Builder\Type\TimeUnit;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
@@ -24,7 +25,7 @@ class IntegralAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::stringFieldPath('powerMeterID'),
                 sortBy: object(
-                    timeStamp: 1,
+                    timeStamp: Sort::Asc,
                 ),
                 output: object(
                     powerMeterKilowattHours: Accumulator::outputWindow(

--- a/tests/Builder/Accumulator/IntegralAccumulatorTest.php
+++ b/tests/Builder/Accumulator/IntegralAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\TimeUnit;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -29,10 +30,10 @@ class IntegralAccumulatorTest extends PipelineTestCase
                     powerMeterKilowattHours: Accumulator::outputWindow(
                         Accumulator::integral(
                             input: Expression::numberFieldPath('kilowatts'),
-                            unit: 'hour',
+                            unit: TimeUnit::Hour,
                         ),
                         range: ['unbounded', 'current'],
-                        unit: 'hour',
+                        unit: TimeUnit::Hour,
                     ),
                 ),
             ),

--- a/tests/Builder/Accumulator/LastAccumulatorTest.php
+++ b/tests/Builder/Accumulator/LastAccumulatorTest.php
@@ -20,10 +20,10 @@ class LastAccumulatorTest extends PipelineTestCase
     public function testUseInGroupStage(): void
     {
         $pipeline = new Pipeline(
-            Stage::sort(object(
+            Stage::sort(
                 item: 1,
                 date: 1,
-            )),
+            ),
             Stage::group(
                 _id: '$item',
                 lastSalesDate: Accumulator::last(Expression::dateFieldPath('date')),

--- a/tests/Builder/Accumulator/LastAccumulatorTest.php
+++ b/tests/Builder/Accumulator/LastAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -21,8 +22,8 @@ class LastAccumulatorTest extends PipelineTestCase
     {
         $pipeline = new Pipeline(
             Stage::sort(
-                item: 1,
-                date: 1,
+                item: Sort::Asc,
+                date: Sort::Asc,
             ),
             Stage::group(
                 _id: '$item',
@@ -39,7 +40,7 @@ class LastAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::fieldPath('state'),
                 sortBy: object(
-                    orderDate: 1,
+                    orderDate: Sort::Asc,
                 ),
                 output: object(
                     lastOrderTypeForState: Accumulator::outputWindow(

--- a/tests/Builder/Accumulator/LastNAccumulatorTest.php
+++ b/tests/Builder/Accumulator/LastNAccumulatorTest.php
@@ -10,8 +10,6 @@ use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
-use function MongoDB\object;
-
 /**
  * Test $lastN accumulator
  */
@@ -81,9 +79,9 @@ class LastNAccumulatorTest extends PipelineTestCase
     public function testUsingSortWithLastN(): void
     {
         $pipeline = new Pipeline(
-            Stage::sort(object(
+            Stage::sort(
                 score: -1,
-            )),
+            ),
             Stage::group(
                 _id: Expression::fieldPath('gameId'),
                 playerId: Accumulator::lastN(

--- a/tests/Builder/Accumulator/LastNAccumulatorTest.php
+++ b/tests/Builder/Accumulator/LastNAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 /**
@@ -80,7 +81,7 @@ class LastNAccumulatorTest extends PipelineTestCase
     {
         $pipeline = new Pipeline(
             Stage::sort(
-                score: -1,
+                score: Sort::Desc,
             ),
             Stage::group(
                 _id: Expression::fieldPath('gameId'),

--- a/tests/Builder/Accumulator/LinearFillAccumulatorTest.php
+++ b/tests/Builder/Accumulator/LinearFillAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -22,7 +23,7 @@ class LinearFillAccumulatorTest extends PipelineTestCase
         $pipeline = new Pipeline(
             Stage::setWindowFields(
                 sortBy: object(
-                    time: 1,
+                    time: Sort::Asc,
                 ),
                 output: object(
                     price: Accumulator::linearFill(
@@ -40,7 +41,7 @@ class LinearFillAccumulatorTest extends PipelineTestCase
         $pipeline = new Pipeline(
             Stage::setWindowFields(
                 sortBy: object(
-                    time: 1,
+                    time: Sort::Asc,
                 ),
                 output: object(
                     linearFillPrice: Accumulator::linearFill(

--- a/tests/Builder/Accumulator/LocfAccumulatorTest.php
+++ b/tests/Builder/Accumulator/LocfAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -22,7 +23,7 @@ class LocfAccumulatorTest extends PipelineTestCase
         $pipeline = new Pipeline(
             Stage::setWindowFields(
                 sortBy: object(
-                    time: 1,
+                    time: Sort::Asc,
                 ),
                 output: object(
                     price: Accumulator::locf(

--- a/tests/Builder/Accumulator/MaxAccumulatorTest.php
+++ b/tests/Builder/Accumulator/MaxAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -43,7 +44,7 @@ class MaxAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::fieldPath('state'),
                 sortBy: object(
-                    orderDate: 1,
+                    orderDate: Sort::Asc,
                 ),
                 output: object(
                     maximumQuantityForState: Accumulator::outputWindow(

--- a/tests/Builder/Accumulator/MedianAccumulatorTest.php
+++ b/tests/Builder/Accumulator/MedianAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -37,7 +38,7 @@ class MedianAccumulatorTest extends PipelineTestCase
         $pipeline = new Pipeline(
             Stage::setWindowFields(
                 sortBy: object(
-                    test01: 1,
+                    test01: Sort::Asc,
                 ),
                 output: object(
                     test01_median: Accumulator::outputWindow(

--- a/tests/Builder/Accumulator/MinAccumulatorTest.php
+++ b/tests/Builder/Accumulator/MinAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -37,7 +38,7 @@ class MinAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::fieldPath('state'),
                 sortBy: object(
-                    orderDate: 1,
+                    orderDate: Sort::Asc,
                 ),
                 output: object(
                     minimumQuantityForState: Accumulator::outputWindow(

--- a/tests/Builder/Accumulator/PercentileAccumulatorTest.php
+++ b/tests/Builder/Accumulator/PercentileAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -69,7 +70,7 @@ class PercentileAccumulatorTest extends PipelineTestCase
         $pipeline = new Pipeline(
             Stage::setWindowFields(
                 sortBy: object(
-                    test01: 1,
+                    test01: Sort::Asc,
                 ),
                 output: object(
                     test01_95percentile: Accumulator::outputWindow(

--- a/tests/Builder/Accumulator/PushAccumulatorTest.php
+++ b/tests/Builder/Accumulator/PushAccumulatorTest.php
@@ -21,10 +21,8 @@ class PushAccumulatorTest extends PipelineTestCase
     {
         $pipeline = new Pipeline(
             Stage::sort(
-                object(
-                    date: 1,
-                    item: 1,
-                ),
+                date: 1,
+                item: 1,
             ),
             Stage::group(
                 _id: object(

--- a/tests/Builder/Accumulator/PushAccumulatorTest.php
+++ b/tests/Builder/Accumulator/PushAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -21,8 +22,8 @@ class PushAccumulatorTest extends PipelineTestCase
     {
         $pipeline = new Pipeline(
             Stage::sort(
-                date: 1,
-                item: 1,
+                date: Sort::Asc,
+                item: Sort::Asc,
             ),
             Stage::group(
                 _id: object(
@@ -51,7 +52,7 @@ class PushAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::fieldPath('state'),
                 sortBy: object(
-                    orderDate: 1,
+                    orderDate: Sort::Asc,
                 ),
                 output: object(
                     quantitiesForState: Accumulator::outputWindow(

--- a/tests/Builder/Accumulator/RankAccumulatorTest.php
+++ b/tests/Builder/Accumulator/RankAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -23,7 +24,7 @@ class RankAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::stringFieldPath('state'),
                 sortBy: object(
-                    orderDate: 1,
+                    orderDate:Sort::Asc,
                 ),
                 output: object(
                     rankOrderDateForState: Accumulator::rank(),
@@ -40,7 +41,7 @@ class RankAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::stringFieldPath('state'),
                 sortBy: object(
-                    quantity: -1,
+                    quantity: Sort::Desc,
                 ),
                 output: object(
                     rankQuantityForState: Accumulator::rank(),

--- a/tests/Builder/Accumulator/ShiftAccumulatorTest.php
+++ b/tests/Builder/Accumulator/ShiftAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -23,7 +24,7 @@ class ShiftAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::stringFieldPath('state'),
                 sortBy: object(
-                    quantity: -1,
+                    quantity: Sort::Desc,
                 ),
                 output: object(
                     shiftQuantityForState: Accumulator::shift(
@@ -44,7 +45,7 @@ class ShiftAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::stringFieldPath('state'),
                 sortBy: object(
-                    quantity: -1,
+                    quantity: Sort::Desc,
                 ),
                 output: object(
                     shiftQuantityForState: Accumulator::shift(

--- a/tests/Builder/Accumulator/StdDevPopAccumulatorTest.php
+++ b/tests/Builder/Accumulator/StdDevPopAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -37,7 +38,7 @@ class StdDevPopAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::fieldPath('state'),
                 sortBy: object(
-                    orderDate: 1,
+                    orderDate: Sort::Asc,
                 ),
                 output: object(
                     stdDevPopQuantityForState: Accumulator::outputWindow(

--- a/tests/Builder/Accumulator/StdDevSampAccumulatorTest.php
+++ b/tests/Builder/Accumulator/StdDevSampAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -38,7 +39,7 @@ class StdDevSampAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::fieldPath('state'),
                 sortBy: object(
-                    orderDate: 1,
+                    orderDate: Sort::Asc,
                 ),
                 output: object(
                     stdDevSampQuantityForState: Accumulator::outputWindow(

--- a/tests/Builder/Accumulator/SumAccumulatorTest.php
+++ b/tests/Builder/Accumulator/SumAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -48,7 +49,7 @@ class SumAccumulatorTest extends PipelineTestCase
             Stage::setWindowFields(
                 partitionBy: Expression::fieldPath('state'),
                 sortBy: object(
-                    orderDate: 1,
+                    orderDate: Sort::Asc,
                 ),
                 output: object(
                     sumQuantityForState: Accumulator::outputWindow(

--- a/tests/Builder/Accumulator/TopAccumulatorTest.php
+++ b/tests/Builder/Accumulator/TopAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -31,7 +32,7 @@ class TopAccumulatorTest extends PipelineTestCase
                         Expression::fieldPath('score'),
                     ],
                     sortBy: object(
-                        score: -1,
+                        score: Sort::Desc,
                     ),
                 ),
             ),
@@ -51,7 +52,7 @@ class TopAccumulatorTest extends PipelineTestCase
                         Expression::fieldPath('score'),
                     ],
                     sortBy: object(
-                        score: -1,
+                        score: Sort::Desc,
                     ),
                 ),
             ),

--- a/tests/Builder/Accumulator/TopNAccumulatorTest.php
+++ b/tests/Builder/Accumulator/TopNAccumulatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -35,7 +36,7 @@ class TopNAccumulatorTest extends PipelineTestCase
                         else: 3,
                     ),
                     sortBy: object(
-                        score: -1,
+                        score: Sort::Desc,
                     ),
                 ),
             ),
@@ -58,7 +59,7 @@ class TopNAccumulatorTest extends PipelineTestCase
                         Expression::fieldPath('score'),
                     ],
                     sortBy: object(
-                        score: -1,
+                        score: Sort::Desc,
                     ),
                     n: 3,
                 ),
@@ -79,7 +80,7 @@ class TopNAccumulatorTest extends PipelineTestCase
                         Expression::fieldPath('score'),
                     ],
                     sortBy: object(
-                        score: -1,
+                        score: Sort::Desc,
                     ),
                     n: 3,
                 ),

--- a/tests/Builder/BuilderEncoderTest.php
+++ b/tests/Builder/BuilderEncoderTest.php
@@ -98,7 +98,7 @@ class BuilderEncoderTest extends TestCase
     public function testSort(): void
     {
         $pipeline = new Pipeline(
-            Stage::sort(object(age: -1, posts: 1)),
+            Stage::sort(age: -1, posts: 1),
         );
 
         $expected = [

--- a/tests/Builder/BuilderEncoderTest.php
+++ b/tests/Builder/BuilderEncoderTest.php
@@ -12,6 +12,7 @@ use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Query;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Builder\Variable;
 use PHPUnit\Framework\TestCase;
 
@@ -98,7 +99,10 @@ class BuilderEncoderTest extends TestCase
     public function testSort(): void
     {
         $pipeline = new Pipeline(
-            Stage::sort(age: -1, posts: 1),
+            Stage::sort(
+                age: Sort::Desc,
+                posts: Sort::Asc,
+            ),
         );
 
         $expected = [
@@ -228,7 +232,7 @@ class BuilderEncoderTest extends TestCase
         $pipeline = new Pipeline(
             Stage::setWindowFields(
                 partitionBy: Expression::year(Expression::dateFieldPath('orderDate')),
-                sortBy: object(orderDate: 1),
+                sortBy: object(orderDate: Sort::Asc),
                 output: object(
                     cumulativeQuantityForYear: Accumulator::outputWindow(
                         Accumulator::sum(Expression::intFieldPath('quantity')),

--- a/tests/Builder/Expression/BsonSizeOperatorTest.php
+++ b/tests/Builder/Expression/BsonSizeOperatorTest.php
@@ -10,8 +10,6 @@ use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
-use function MongoDB\object;
-
 /**
  * Test $bsonSize expression
  */
@@ -43,7 +41,7 @@ class BsonSizeOperatorTest extends PipelineTestCase
                 ),
             ),
             Stage::sort(
-                object(task_object_size: -1),
+                task_object_size: -1,
             ),
             Stage::limit(1),
         );

--- a/tests/Builder/Expression/BsonSizeOperatorTest.php
+++ b/tests/Builder/Expression/BsonSizeOperatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 /**
@@ -41,7 +42,7 @@ class BsonSizeOperatorTest extends PipelineTestCase
                 ),
             ),
             Stage::sort(
-                task_object_size: -1,
+                task_object_size: Sort::Desc,
             ),
             Stage::limit(1),
         );

--- a/tests/Builder/Expression/DateAddOperatorTest.php
+++ b/tests/Builder/Expression/DateAddOperatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Query;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\TimeUnit;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 /**
@@ -21,7 +22,7 @@ class DateAddOperatorTest extends PipelineTestCase
             Stage::project(
                 expectedDeliveryDate: Expression::dateAdd(
                     startDate: Expression::dateFieldPath('purchaseDate'),
-                    unit: 'day',
+                    unit: TimeUnit::Day,
                     amount: 3,
                 ),
             ),
@@ -45,7 +46,7 @@ class DateAddOperatorTest extends PipelineTestCase
                     format: '%Y-%m-%d %H:%M',
                     date: Expression::dateAdd(
                         startDate: Expression::dateFieldPath('login'),
-                        unit: 'day',
+                        unit: TimeUnit::Day,
                         amount: 1,
                         timezone: Expression::stringFieldPath('location'),
                     ),
@@ -54,7 +55,7 @@ class DateAddOperatorTest extends PipelineTestCase
                     format: '%Y-%m-%d %H:%M',
                     date: Expression::dateAdd(
                         startDate: Expression::dateFieldPath('login'),
-                        unit: 'hour',
+                        unit: TimeUnit::Hour,
                         amount: 24,
                         timezone: Expression::stringFieldPath('location'),
                     ),
@@ -68,7 +69,7 @@ class DateAddOperatorTest extends PipelineTestCase
                     format: '%Y-%m-%d %H:%M',
                     date: Expression::dateAdd(
                         startDate: Expression::dateFieldPath('login'),
-                        unit: 'day',
+                        unit: TimeUnit::Day,
                         amount: 1,
                         timezone: Expression::stringFieldPath('location'),
                     ),
@@ -78,7 +79,7 @@ class DateAddOperatorTest extends PipelineTestCase
                     format: '%Y-%m-%d %H:%M',
                     date: Expression::dateAdd(
                         startDate: Expression::dateFieldPath('login'),
-                        unit: 'hour',
+                        unit: TimeUnit::Hour,
                         amount: 24,
                         timezone: Expression::stringFieldPath('location'),
                     ),
@@ -99,7 +100,7 @@ class DateAddOperatorTest extends PipelineTestCase
                         Expression::dateFieldPath('deliveryDate'),
                         Expression::dateAdd(
                             startDate: Expression::dateFieldPath('purchaseDate'),
-                            unit: 'day',
+                            unit: TimeUnit::Day,
                             amount: 5,
                         ),
                     ),

--- a/tests/Builder/Expression/DateDiffOperatorTest.php
+++ b/tests/Builder/Expression/DateDiffOperatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\TimeUnit;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 /**
@@ -24,7 +25,7 @@ class DateDiffOperatorTest extends PipelineTestCase
                     Expression::dateDiff(
                         startDate: Expression::dateFieldPath('purchased'),
                         endDate: Expression::dateFieldPath('delivered'),
-                        unit: 'day',
+                        unit: TimeUnit::Day,
                     ),
                 ),
             ),
@@ -49,17 +50,17 @@ class DateDiffOperatorTest extends PipelineTestCase
                 years: Expression::dateDiff(
                     startDate: Expression::dateFieldPath('start'),
                     endDate: Expression::dateFieldPath('end'),
-                    unit: 'year',
+                    unit: TimeUnit::Year,
                 ),
                 months: Expression::dateDiff(
                     startDate: Expression::dateFieldPath('start'),
                     endDate: Expression::dateFieldPath('end'),
-                    unit: 'month',
+                    unit: TimeUnit::Month,
                 ),
                 days: Expression::dateDiff(
                     startDate: Expression::dateFieldPath('start'),
                     endDate: Expression::dateFieldPath('end'),
-                    unit: 'day',
+                    unit: TimeUnit::Day,
                 ),
                 _id: 0,
             ),
@@ -75,18 +76,18 @@ class DateDiffOperatorTest extends PipelineTestCase
                 wks_default: Expression::dateDiff(
                     startDate: Expression::dateFieldPath('start'),
                     endDate: Expression::dateFieldPath('end'),
-                    unit: 'week',
+                    unit: TimeUnit::Week,
                 ),
                 wks_monday: Expression::dateDiff(
                     startDate: Expression::dateFieldPath('start'),
                     endDate: Expression::dateFieldPath('end'),
-                    unit: 'week',
+                    unit: TimeUnit::Week,
                     startOfWeek: 'Monday',
                 ),
                 wks_friday: Expression::dateDiff(
                     startDate: Expression::dateFieldPath('start'),
                     endDate: Expression::dateFieldPath('end'),
-                    unit: 'week',
+                    unit: TimeUnit::Week,
                     startOfWeek: 'fri',
                 ),
                 _id: 0,

--- a/tests/Builder/Expression/DateSubtractOperatorTest.php
+++ b/tests/Builder/Expression/DateSubtractOperatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Query;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\TimeUnit;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 /**
@@ -29,7 +30,7 @@ class DateSubtractOperatorTest extends PipelineTestCase
                     format: '%Y-%m-%d %H:%M',
                     date: Expression::dateSubtract(
                         startDate: Expression::dateFieldPath('login'),
-                        unit: 'day',
+                        unit: TimeUnit::Day,
                         amount: 1,
                         timezone: Expression::stringFieldPath('location'),
                     ),
@@ -38,7 +39,7 @@ class DateSubtractOperatorTest extends PipelineTestCase
                     format: '%Y-%m-%d %H:%M',
                     date: Expression::dateSubtract(
                         startDate: Expression::dateFieldPath('login'),
-                        unit: 'hour',
+                        unit: TimeUnit::Hour,
                         amount: 24,
                         timezone: Expression::stringFieldPath('location'),
                     ),
@@ -52,7 +53,7 @@ class DateSubtractOperatorTest extends PipelineTestCase
                     format: '%Y-%m-%d %H:%M',
                     date: Expression::dateSubtract(
                         startDate: Expression::dateFieldPath('login'),
-                        unit: 'day',
+                        unit: TimeUnit::Day,
                         amount: 1,
                         timezone: Expression::stringFieldPath('location'),
                     ),
@@ -62,7 +63,7 @@ class DateSubtractOperatorTest extends PipelineTestCase
                     format: '%Y-%m-%d %H:%M',
                     date: Expression::dateSubtract(
                         startDate: Expression::dateFieldPath('login'),
-                        unit: 'hour',
+                        unit: TimeUnit::Hour,
                         amount: 24,
                         timezone: Expression::stringFieldPath('location'),
                     ),
@@ -83,7 +84,7 @@ class DateSubtractOperatorTest extends PipelineTestCase
                         Expression::dateFieldPath('logoutTime'),
                         Expression::dateSubtract(
                             startDate: Expression::variable('NOW'),
-                            unit: 'week',
+                            unit: TimeUnit::Week,
                             amount: 1,
                         ),
                     ),
@@ -118,7 +119,7 @@ class DateSubtractOperatorTest extends PipelineTestCase
             Stage::project(
                 logoutTime: Expression::dateSubtract(
                     startDate: Expression::dateFieldPath('logout'),
-                    unit: 'hour',
+                    unit: TimeUnit::Hour,
                     amount: 3,
                 ),
             ),

--- a/tests/Builder/Expression/DateTruncOperatorTest.php
+++ b/tests/Builder/Expression/DateTruncOperatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\TimeUnit;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -24,7 +25,7 @@ class DateTruncOperatorTest extends PipelineTestCase
                 _id: object(
                     truncatedOrderDate: Expression::dateTrunc(
                         date: Expression::dateFieldPath('orderDate'),
-                        unit: 'month',
+                        unit: TimeUnit::Month,
                         binSize: 6,
                     ),
                 ),
@@ -45,7 +46,7 @@ class DateTruncOperatorTest extends PipelineTestCase
                 orderDate: 1,
                 truncatedOrderDate: Expression::dateTrunc(
                     date: Expression::dateFieldPath('orderDate'),
-                    unit: 'week',
+                    unit: TimeUnit::Week,
                     binSize: 2,
                     timezone: 'America/Los_Angeles',
                     startOfWeek: 'Monday',

--- a/tests/Builder/Expression/SortArrayOperatorTest.php
+++ b/tests/Builder/Expression/SortArrayOperatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\BSON\Decimal128;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -24,7 +25,7 @@ class SortArrayOperatorTest extends PipelineTestCase
                 _id: 0,
                 result: Expression::sortArray(
                     input: [1, 4, 1, 6, 12, 5],
-                    sortBy: 1,
+                    sortBy: Sort::Asc,
                 ),
             ),
         );
@@ -41,7 +42,7 @@ class SortArrayOperatorTest extends PipelineTestCase
                     input: Expression::arrayFieldPath('team'),
                     // @todo This object should be typed as "sort spec"
                     sortBy: object(
-                        name: 1,
+                        name: Sort::Asc,
                     ),
                 ),
             ),
@@ -57,9 +58,8 @@ class SortArrayOperatorTest extends PipelineTestCase
                 _id: 0,
                 result: Expression::sortArray(
                     input: Expression::arrayFieldPath('team'),
-                    // @todo This array should be typed as "sort spec"
                     sortBy: [
-                        'address.city' => -1,
+                        'address.city' => Sort::Desc,
                     ],
                 ),
             ),
@@ -87,7 +87,7 @@ class SortArrayOperatorTest extends PipelineTestCase
                         new Decimal128('10.23'),
                         ['a' => 'On sale'],
                     ],
-                    sortBy: 1,
+                    sortBy: Sort::Asc,
                 ),
             ),
         );
@@ -104,8 +104,8 @@ class SortArrayOperatorTest extends PipelineTestCase
                     input: Expression::arrayFieldPath('team'),
                     // @todo This array should be typed as "sort spec"
                     sortBy: object(
-                        age: -1,
-                        name: 1,
+                        age: Sort::Desc,
+                        name: Sort::Asc,
                     ),
                 ),
             ),

--- a/tests/Builder/Expression/SplitOperatorTest.php
+++ b/tests/Builder/Expression/SplitOperatorTest.php
@@ -43,9 +43,7 @@ class SplitOperatorTest extends PipelineTestCase
                 ),
             ),
             Stage::sort(
-                object(
-                    total_qty: -1,
-                ),
+                total_qty: -1,
             ),
         );
 

--- a/tests/Builder/Expression/SplitOperatorTest.php
+++ b/tests/Builder/Expression/SplitOperatorTest.php
@@ -9,6 +9,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -43,7 +44,7 @@ class SplitOperatorTest extends PipelineTestCase
                 ),
             ),
             Stage::sort(
-                total_qty: -1,
+                total_qty: Sort::Desc,
             ),
         );
 

--- a/tests/Builder/Expression/ToDateOperatorTest.php
+++ b/tests/Builder/Expression/ToDateOperatorTest.php
@@ -9,8 +9,6 @@ use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
-use function MongoDB\object;
-
 /**
  * Test $toDate expression
  */
@@ -25,9 +23,7 @@ class ToDateOperatorTest extends PipelineTestCase
                 ),
             ),
             Stage::sort(
-                object(
-                    convertedDate: 1,
-                ),
+                convertedDate: 1,
             ),
         );
 

--- a/tests/Builder/Expression/ToDateOperatorTest.php
+++ b/tests/Builder/Expression/ToDateOperatorTest.php
@@ -7,6 +7,7 @@ namespace MongoDB\Tests\Builder\Expression;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 /**
@@ -23,7 +24,7 @@ class ToDateOperatorTest extends PipelineTestCase
                 ),
             ),
             Stage::sort(
-                convertedDate: 1,
+                convertedDate: Sort::Asc,
             ),
         );
 

--- a/tests/Builder/Expression/ToLongOperatorTest.php
+++ b/tests/Builder/Expression/ToLongOperatorTest.php
@@ -9,8 +9,6 @@ use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
-use function MongoDB\object;
-
 /**
  * Test $toLong expression
  */
@@ -25,9 +23,7 @@ class ToLongOperatorTest extends PipelineTestCase
                 ),
             ),
             Stage::sort(
-                object(
-                    convertedQty: -1,
-                ),
+                convertedQty: -1,
             ),
         );
 

--- a/tests/Builder/Expression/ToLongOperatorTest.php
+++ b/tests/Builder/Expression/ToLongOperatorTest.php
@@ -7,6 +7,7 @@ namespace MongoDB\Tests\Builder\Expression;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 /**
@@ -23,7 +24,7 @@ class ToLongOperatorTest extends PipelineTestCase
                 ),
             ),
             Stage::sort(
-                convertedQty: -1,
+                convertedQty: Sort::Desc,
             ),
         );
 

--- a/tests/Builder/Expression/ToObjectIdOperatorTest.php
+++ b/tests/Builder/Expression/ToObjectIdOperatorTest.php
@@ -9,8 +9,6 @@ use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
-use function MongoDB\object;
-
 /**
  * Test $toObjectId expression
  */
@@ -25,9 +23,7 @@ class ToObjectIdOperatorTest extends PipelineTestCase
                 ),
             ),
             Stage::sort(
-                object(
-                    convertedId: -1,
-                ),
+                convertedId: -1,
             ),
         );
 

--- a/tests/Builder/Expression/ToObjectIdOperatorTest.php
+++ b/tests/Builder/Expression/ToObjectIdOperatorTest.php
@@ -7,6 +7,7 @@ namespace MongoDB\Tests\Builder\Expression;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 /**
@@ -23,7 +24,7 @@ class ToObjectIdOperatorTest extends PipelineTestCase
                 ),
             ),
             Stage::sort(
-                convertedId: -1,
+                convertedId: Sort::Desc,
             ),
         );
 

--- a/tests/Builder/Expression/ToStringOperatorTest.php
+++ b/tests/Builder/Expression/ToStringOperatorTest.php
@@ -9,8 +9,6 @@ use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
-use function MongoDB\object;
-
 /**
  * Test $toString expression
  */
@@ -25,9 +23,7 @@ class ToStringOperatorTest extends PipelineTestCase
                 ),
             ),
             Stage::sort(
-                object(
-                    convertedZipCode: 1,
-                ),
+                convertedZipCode: 1,
             ),
         );
 

--- a/tests/Builder/Expression/ToStringOperatorTest.php
+++ b/tests/Builder/Expression/ToStringOperatorTest.php
@@ -7,6 +7,7 @@ namespace MongoDB\Tests\Builder\Expression;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 /**
@@ -23,7 +24,7 @@ class ToStringOperatorTest extends PipelineTestCase
                 ),
             ),
             Stage::sort(
-                convertedZipCode: 1,
+                convertedZipCode: Sort::Asc,
             ),
         );
 

--- a/tests/Builder/Query/Pipelines.php
+++ b/tests/Builder/Query/Pipelines.php
@@ -1874,7 +1874,11 @@ enum Pipelines: string
                 "$text": {
                     "$search": "CAF\u00c9",
                     "$diacriticSensitive": true
-                },
+                }
+            }
+        },
+        {
+            "$project": {
                 "score": {
                     "$meta": "textScore"
                 }

--- a/tests/Builder/Query/TextOperatorTest.php
+++ b/tests/Builder/Query/TextOperatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Tests\Builder\Query;
 
+use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Query;
 use MongoDB\Builder\Stage;
@@ -97,20 +98,18 @@ class TextOperatorTest extends PipelineTestCase
 
     public function testTextSearchScoreExamples(): void
     {
-        /**
-         * @todo: add support for $meta: "textScore"
-         * @todo: add support for $sort spec with object
-         */
         $pipeline = new Pipeline(
             Stage::match(
                 Query::text(
                     search: 'CAFÉ',
                     diacriticSensitive: true,
                 ),
-                score: ['$meta' => 'textScore'],
+            ),
+            Stage::project(
+                score: Expression::meta('textScore'),
             ),
             Stage::sort(
-                ['score' => ['$meta' => 'textScore']],
+                score: Expression::meta('textScore'),
             ),
             Stage::limit(5),
         );

--- a/tests/Builder/Query/TextOperatorTest.php
+++ b/tests/Builder/Query/TextOperatorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Query;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 /**
@@ -109,7 +110,7 @@ class TextOperatorTest extends PipelineTestCase
                 score: Expression::meta('textScore'),
             ),
             Stage::sort(
-                score: Expression::meta('textScore'),
+                score: Sort::TextScore,
             ),
             Stage::limit(5),
         );

--- a/tests/Builder/Stage/DensifyStageTest.php
+++ b/tests/Builder/Stage/DensifyStageTest.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\TimeUnit;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -40,7 +41,7 @@ class DensifyStageTest extends PipelineTestCase
                 field: 'timestamp',
                 range: object(
                     step: 1,
-                    unit: 'hour',
+                    unit: TimeUnit::Hour,
                     bounds: [
                         new UTCDateTime(new DateTimeImmutable('2021-05-18T00:00:00.000Z')),
                         new UTCDateTime(new DateTimeImmutable('2021-05-18T08:00:00.000Z')),

--- a/tests/Builder/Stage/FillStageTest.php
+++ b/tests/Builder/Stage/FillStageTest.php
@@ -7,6 +7,7 @@ namespace MongoDB\Tests\Builder\Stage;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -21,7 +22,7 @@ class FillStageTest extends PipelineTestCase
         $pipeline = new Pipeline(
             Stage::fill(
                 sortBy: object(
-                    date: 1,
+                    date: Sort::Asc,
                 ),
                 partitionBy: object(
                     restaurant: Expression::stringFieldPath('restaurant'),
@@ -40,7 +41,7 @@ class FillStageTest extends PipelineTestCase
         $pipeline = new Pipeline(
             Stage::fill(
                 sortBy: object(
-                    date: 1,
+                    date: Sort::Asc,
                 ),
                 output: object(
                     score: object(method: 'locf'),
@@ -71,7 +72,7 @@ class FillStageTest extends PipelineTestCase
         $pipeline = new Pipeline(
             Stage::fill(
                 sortBy: object(
-                    time: 1,
+                    time: Sort::Asc,
                 ),
                 output: object(
                     price: object(method: 'linear'),
@@ -97,7 +98,7 @@ class FillStageTest extends PipelineTestCase
             ),
             Stage::fill(
                 sortBy: object(
-                    date: 1,
+                    date: Sort::Asc,
                 ),
                 output: object(
                     score: object(method: 'locf'),

--- a/tests/Builder/Stage/GroupStageTest.php
+++ b/tests/Builder/Stage/GroupStageTest.php
@@ -13,8 +13,6 @@ use MongoDB\Builder\Query;
 use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
-use function MongoDB\object;
-
 /**
  * Test $group stage
  */
@@ -43,9 +41,7 @@ class GroupStageTest extends PipelineTestCase
                 count: Accumulator::sum(1),
             ),
             Stage::sort(
-                object(
-                    totalSaleAmount: -1,
-                ),
+                totalSaleAmount: -1,
             ),
         );
 

--- a/tests/Builder/Stage/GroupStageTest.php
+++ b/tests/Builder/Stage/GroupStageTest.php
@@ -11,6 +11,7 @@ use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Query;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 /**
@@ -41,7 +42,7 @@ class GroupStageTest extends PipelineTestCase
                 count: Accumulator::sum(1),
             ),
             Stage::sort(
-                totalSaleAmount: -1,
+                totalSaleAmount: Sort::Desc,
             ),
         );
 

--- a/tests/Builder/Stage/SetWindowFieldsStageTest.php
+++ b/tests/Builder/Stage/SetWindowFieldsStageTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\TimeUnit;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 use function MongoDB\object;
@@ -49,7 +50,7 @@ class SetWindowFieldsStageTest extends PipelineTestCase
                             Expression::dateFieldPath('orderDate'),
                         ),
                         range: ['unbounded', -10],
-                        unit: 'month',
+                        unit: TimeUnit::Month,
                     ),
                 ),
             ),
@@ -70,7 +71,7 @@ class SetWindowFieldsStageTest extends PipelineTestCase
                             Expression::dateFieldPath('orderDate'),
                         ),
                         range: ['unbounded', 10],
-                        unit: 'month',
+                        unit: TimeUnit::Month,
                     ),
                 ),
             ),

--- a/tests/Builder/Stage/SetWindowFieldsStageTest.php
+++ b/tests/Builder/Stage/SetWindowFieldsStageTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Builder\Type\TimeUnit;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
@@ -23,7 +24,7 @@ class SetWindowFieldsStageTest extends PipelineTestCase
         $pipeline = new Pipeline(
             Stage::setWindowFields(
                 partitionBy: Expression::stringFieldPath('state'),
-                sortBy: object(price: 1),
+                sortBy: object(price: Sort::Asc),
                 output: object(
                     quantityFromSimilarOrders: Accumulator::outputWindow(
                         Accumulator::sum(
@@ -43,7 +44,7 @@ class SetWindowFieldsStageTest extends PipelineTestCase
         $pipeline = new Pipeline(
             Stage::setWindowFields(
                 partitionBy: Expression::stringFieldPath('state'),
-                sortBy: object(orderDate: 1),
+                sortBy: object(orderDate: Sort::Asc),
                 output: object(
                     recentOrders: Accumulator::outputWindow(
                         Accumulator::push(
@@ -64,7 +65,7 @@ class SetWindowFieldsStageTest extends PipelineTestCase
         $pipeline = new Pipeline(
             Stage::setWindowFields(
                 partitionBy: Expression::stringFieldPath('state'),
-                sortBy: object(orderDate: 1),
+                sortBy: object(orderDate: Sort::Asc),
                 output: object(
                     recentOrders: Accumulator::outputWindow(
                         Accumulator::push(
@@ -87,7 +88,7 @@ class SetWindowFieldsStageTest extends PipelineTestCase
                 partitionBy: Expression::year(
                     Expression::dateFieldPath('orderDate'),
                 ),
-                sortBy: object(orderDate: 1),
+                sortBy: object(orderDate: Sort::Asc),
                 output: object(
                     cumulativeQuantityForYear: Accumulator::outputWindow(
                         Accumulator::sum(
@@ -113,7 +114,7 @@ class SetWindowFieldsStageTest extends PipelineTestCase
         $pipeline = new Pipeline(
             Stage::setWindowFields(
                 partitionBy: Expression::stringFieldPath('state'),
-                sortBy: object(orderDate: 1),
+                sortBy: object(orderDate: Sort::Asc),
                 output: object(
                     cumulativeQuantityForState: Accumulator::outputWindow(
                         Accumulator::sum(
@@ -135,7 +136,7 @@ class SetWindowFieldsStageTest extends PipelineTestCase
                 partitionBy: Expression::year(
                     Expression::dateFieldPath('orderDate'),
                 ),
-                sortBy: object(orderDate: 1),
+                sortBy: object(orderDate: Sort::Asc),
                 output: object(
                     cumulativeQuantityForYear: Accumulator::outputWindow(
                         Accumulator::sum(
@@ -157,7 +158,7 @@ class SetWindowFieldsStageTest extends PipelineTestCase
                 partitionBy: Expression::year(
                     Expression::dateFieldPath('orderDate'),
                 ),
-                sortBy: object(orderDate: 1),
+                sortBy: object(orderDate: Sort::Asc),
                 output: object(
                     averageQuantity: Accumulator::outputWindow(
                         Accumulator::avg(

--- a/tests/Builder/Stage/SortStageTest.php
+++ b/tests/Builder/Stage/SortStageTest.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace MongoDB\Tests\Builder\Stage;
 
+use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Query;
 use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
-
-use function MongoDB\object;
 
 /**
  * Test $sort stage
@@ -20,10 +19,8 @@ class SortStageTest extends PipelineTestCase
     {
         $pipeline = new Pipeline(
             Stage::sort(
-                object(
-                    age: -1,
-                    posts: 1,
-                ),
+                age: -1,
+                posts: 1,
             ),
         );
 
@@ -37,10 +34,8 @@ class SortStageTest extends PipelineTestCase
                 Query::text('operating'),
             ),
             Stage::sort(
-                object(
-                    score: ['$meta' => 'textScore'],
-                    posts: -1,
-                ),
+                score: Expression::meta('textScore'),
+                posts: -1,
             ),
         );
 

--- a/tests/Builder/Stage/SortStageTest.php
+++ b/tests/Builder/Stage/SortStageTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace MongoDB\Tests\Builder\Stage;
 
-use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Query;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 /**
@@ -19,8 +19,8 @@ class SortStageTest extends PipelineTestCase
     {
         $pipeline = new Pipeline(
             Stage::sort(
-                age: -1,
-                posts: 1,
+                age: Sort::Desc,
+                posts: Sort::Asc,
             ),
         );
 
@@ -34,8 +34,8 @@ class SortStageTest extends PipelineTestCase
                 Query::text('operating'),
             ),
             Stage::sort(
-                score: Expression::meta('textScore'),
-                posts: -1,
+                score: Sort::TextScore,
+                posts: Sort::Desc,
             ),
         );
 

--- a/tests/Builder/Stage/UnionWithStageTest.php
+++ b/tests/Builder/Stage/UnionWithStageTest.php
@@ -10,8 +10,6 @@ use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
-use function MongoDB\object;
-
 /**
  * Test $unionWith stage
  */
@@ -48,11 +46,9 @@ class UnionWithStageTest extends PipelineTestCase
                 ),
             ),
             Stage::sort(
-                object(
-                    _id: 1,
-                    store: 1,
-                    item: 1,
-                ),
+                _id: 1,
+                store: 1,
+                item: 1,
             ),
         );
 
@@ -72,9 +68,7 @@ class UnionWithStageTest extends PipelineTestCase
                 ),
             ),
             Stage::sort(
-                object(
-                    total: -1,
-                ),
+                total: -1,
             ),
         );
 

--- a/tests/Builder/Stage/UnionWithStageTest.php
+++ b/tests/Builder/Stage/UnionWithStageTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 /**
@@ -46,9 +47,9 @@ class UnionWithStageTest extends PipelineTestCase
                 ),
             ),
             Stage::sort(
-                _id: 1,
-                store: 1,
-                item: 1,
+                _id: Sort::Asc,
+                store: Sort::Asc,
+                item: Sort::Asc,
             ),
         );
 
@@ -68,7 +69,7 @@ class UnionWithStageTest extends PipelineTestCase
                 ),
             ),
             Stage::sort(
-                total: -1,
+                total: Sort::Desc,
             ),
         );
 

--- a/tests/Builder/Stage/UnwindStageTest.php
+++ b/tests/Builder/Stage/UnwindStageTest.php
@@ -10,8 +10,6 @@ use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
-use function MongoDB\object;
-
 /**
  * Test $unwind stage
  */
@@ -31,9 +29,7 @@ class UnwindStageTest extends PipelineTestCase
                 ),
             ),
             Stage::sort(
-                object(
-                    averagePrice: -1,
-                ),
+                averagePrice: -1,
             ),
         );
 

--- a/tests/Builder/Stage/UnwindStageTest.php
+++ b/tests/Builder/Stage/UnwindStageTest.php
@@ -8,6 +8,7 @@ use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
+use MongoDB\Builder\Type\Sort;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 /**
@@ -29,7 +30,7 @@ class UnwindStageTest extends PipelineTestCase
                 ),
             ),
             Stage::sort(
-                averagePrice: -1,
+                averagePrice: Sort::Desc,
             ),
         );
 

--- a/tests/Builder/Type/OutputWindowTest.php
+++ b/tests/Builder/Type/OutputWindowTest.php
@@ -7,6 +7,7 @@ namespace MongoDB\Tests\Builder\Type;
 use Generator;
 use MongoDB\Builder\Type\Optional;
 use MongoDB\Builder\Type\OutputWindow;
+use MongoDB\Builder\Type\TimeUnit;
 use MongoDB\Builder\Type\WindowInterface;
 use MongoDB\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -49,11 +50,11 @@ class OutputWindowTest extends TestCase
     {
         $outputWindow = new OutputWindow(
             operator: $operator = $this->createMock(WindowInterface::class),
-            unit: 'day',
+            unit: TimeUnit::Day,
         );
 
         $this->assertSame($operator, $outputWindow->operator);
-        $this->assertEquals((object) ['unit' => 'day'], $outputWindow->window);
+        $this->assertEquals((object) ['unit' => TimeUnit::Day], $outputWindow->window);
     }
 
     /**


### PR DESCRIPTION
Fix [PHPLIB-1381](https://jira.mongodb.org/browse/PHPLIB-1381) and [PHPLIB-1269](https://jira.mongodb.org/browse/PHPLIB-1269)

I decided to not rely on `BackedEnum`, but use a specific `Dictionary` interface, with a method `getValue()` so that the value can be different than only `string` or only `int`. This is the case for `Sort::TextScore`.