### PR TITLE
Fix MongoDB namespace for `InvalidArgumentException`

### DIFF
--- a/generator/src/OperatorClassGenerator.php
+++ b/generator/src/OperatorClassGenerator.php
@@ -78,9 +78,10 @@ class OperatorClassGenerator extends OperatorGenerator
                 $constuctor->addComment('@param ' . $type->doc . ' ...$' . $argument->name . rtrim(' ' . $argument->description));
 
                 if ($argument->variadicMin > 0) {
+                    $namespace->addUse(InvalidArgumentException::class);
                     $constuctor->addBody(<<<PHP
                     if (\count(\${$argument->name}) < {$argument->variadicMin}) {
-                        throw new \InvalidArgumentException(\sprintf('Expected at least %d values for \${$argument->name}, got %d.', {$argument->variadicMin}, \count(\${$argument->name})));
+                        throw new InvalidArgumentException(\sprintf('Expected at least %d values for \${$argument->name}, got %d.', {$argument->variadicMin}, \count(\${$argument->name})));
                     }
 
                     PHP);

--- a/src/Builder/Expression/AddOperator.php
+++ b/src/Builder/Expression/AddOperator.php
@@ -36,7 +36,7 @@ class AddOperator implements ResolvesToInt, ResolvesToLong, ResolvesToDouble, Re
     public function __construct(Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int ...$expression)
     {
         if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
 
         if (! array_is_list($expression)) {

--- a/src/Builder/Expression/AndOperator.php
+++ b/src/Builder/Expression/AndOperator.php
@@ -39,7 +39,7 @@ class AndOperator implements ResolvesToBool, OperatorInterface
         Decimal128|Int64|Type|ResolvesToBool|ResolvesToNull|ResolvesToNumber|ResolvesToString|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
     ) {
         if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
 
         if (! array_is_list($expression)) {

--- a/src/Builder/Expression/AvgOperator.php
+++ b/src/Builder/Expression/AvgOperator.php
@@ -36,7 +36,7 @@ class AvgOperator implements ResolvesToNumber, OperatorInterface
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int ...$expression)
     {
         if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
 
         if (! array_is_list($expression)) {

--- a/src/Builder/Expression/BitAndOperator.php
+++ b/src/Builder/Expression/BitAndOperator.php
@@ -35,7 +35,7 @@ class BitAndOperator implements ResolvesToInt, ResolvesToLong, OperatorInterface
     public function __construct(Int64|ResolvesToInt|ResolvesToLong|int ...$expression)
     {
         if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
 
         if (! array_is_list($expression)) {

--- a/src/Builder/Expression/BitOrOperator.php
+++ b/src/Builder/Expression/BitOrOperator.php
@@ -35,7 +35,7 @@ class BitOrOperator implements ResolvesToInt, ResolvesToLong, OperatorInterface
     public function __construct(Int64|ResolvesToInt|ResolvesToLong|int ...$expression)
     {
         if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
 
         if (! array_is_list($expression)) {

--- a/src/Builder/Expression/BitXorOperator.php
+++ b/src/Builder/Expression/BitXorOperator.php
@@ -35,7 +35,7 @@ class BitXorOperator implements ResolvesToInt, ResolvesToLong, OperatorInterface
     public function __construct(Int64|ResolvesToInt|ResolvesToLong|int ...$expression)
     {
         if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
 
         if (! array_is_list($expression)) {

--- a/src/Builder/Expression/ConcatArraysOperator.php
+++ b/src/Builder/Expression/ConcatArraysOperator.php
@@ -35,7 +35,7 @@ class ConcatArraysOperator implements ResolvesToArray, OperatorInterface
     public function __construct(PackedArray|ResolvesToArray|BSONArray|array ...$array)
     {
         if (\count($array) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $array, got %d.', 1, \count($array)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $array, got %d.', 1, \count($array)));
         }
 
         if (! array_is_list($array)) {

--- a/src/Builder/Expression/ConcatOperator.php
+++ b/src/Builder/Expression/ConcatOperator.php
@@ -33,7 +33,7 @@ class ConcatOperator implements ResolvesToString, OperatorInterface
     public function __construct(ResolvesToString|string ...$expression)
     {
         if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
 
         if (! array_is_list($expression)) {

--- a/src/Builder/Expression/IfNullOperator.php
+++ b/src/Builder/Expression/IfNullOperator.php
@@ -36,7 +36,7 @@ class IfNullOperator implements ResolvesToAny, OperatorInterface
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression)
     {
         if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
 
         if (! array_is_list($expression)) {

--- a/src/Builder/Expression/MaxOperator.php
+++ b/src/Builder/Expression/MaxOperator.php
@@ -37,7 +37,7 @@ class MaxOperator implements ResolvesToAny, OperatorInterface
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression)
     {
         if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
 
         if (! array_is_list($expression)) {

--- a/src/Builder/Expression/MergeObjectsOperator.php
+++ b/src/Builder/Expression/MergeObjectsOperator.php
@@ -36,7 +36,7 @@ class MergeObjectsOperator implements ResolvesToObject, OperatorInterface
     public function __construct(Document|Serializable|ResolvesToObject|stdClass|array ...$document)
     {
         if (\count($document) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $document, got %d.', 1, \count($document)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $document, got %d.', 1, \count($document)));
         }
 
         if (! array_is_list($document)) {

--- a/src/Builder/Expression/MinOperator.php
+++ b/src/Builder/Expression/MinOperator.php
@@ -37,7 +37,7 @@ class MinOperator implements ResolvesToAny, OperatorInterface
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression)
     {
         if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
 
         if (! array_is_list($expression)) {

--- a/src/Builder/Expression/MultiplyOperator.php
+++ b/src/Builder/Expression/MultiplyOperator.php
@@ -39,7 +39,7 @@ class MultiplyOperator implements ResolvesToDecimal, OperatorInterface
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int ...$expression)
     {
         if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
 
         if (! array_is_list($expression)) {

--- a/src/Builder/Expression/OrOperator.php
+++ b/src/Builder/Expression/OrOperator.php
@@ -37,7 +37,7 @@ class OrOperator implements ResolvesToBool, OperatorInterface
         Type|ResolvesToBool|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
     ) {
         if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
 
         if (! array_is_list($expression)) {

--- a/src/Builder/Expression/SetEqualsOperator.php
+++ b/src/Builder/Expression/SetEqualsOperator.php
@@ -35,7 +35,7 @@ class SetEqualsOperator implements ResolvesToBool, OperatorInterface
     public function __construct(PackedArray|ResolvesToArray|BSONArray|array ...$expression)
     {
         if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
 
         if (! array_is_list($expression)) {

--- a/src/Builder/Expression/SetIntersectionOperator.php
+++ b/src/Builder/Expression/SetIntersectionOperator.php
@@ -35,7 +35,7 @@ class SetIntersectionOperator implements ResolvesToArray, OperatorInterface
     public function __construct(PackedArray|ResolvesToArray|BSONArray|array ...$expression)
     {
         if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
 
         if (! array_is_list($expression)) {

--- a/src/Builder/Expression/SetUnionOperator.php
+++ b/src/Builder/Expression/SetUnionOperator.php
@@ -35,7 +35,7 @@ class SetUnionOperator implements ResolvesToArray, OperatorInterface
     public function __construct(PackedArray|ResolvesToArray|BSONArray|array ...$expression)
     {
         if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
 
         if (! array_is_list($expression)) {

--- a/src/Builder/Expression/StdDevPopOperator.php
+++ b/src/Builder/Expression/StdDevPopOperator.php
@@ -37,7 +37,7 @@ class StdDevPopOperator implements ResolvesToDouble, OperatorInterface
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int ...$expression)
     {
         if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
 
         if (! array_is_list($expression)) {

--- a/src/Builder/Expression/StdDevSampOperator.php
+++ b/src/Builder/Expression/StdDevSampOperator.php
@@ -36,7 +36,7 @@ class StdDevSampOperator implements ResolvesToDouble, OperatorInterface
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int ...$expression)
     {
         if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
 
         if (! array_is_list($expression)) {

--- a/src/Builder/Expression/SumOperator.php
+++ b/src/Builder/Expression/SumOperator.php
@@ -39,7 +39,7 @@ class SumOperator implements ResolvesToNumber, OperatorInterface
         Decimal128|Int64|PackedArray|ResolvesToArray|ResolvesToNumber|BSONArray|array|float|int ...$expression,
     ) {
         if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
 
         if (! array_is_list($expression)) {

--- a/src/Builder/Query/AllOperator.php
+++ b/src/Builder/Query/AllOperator.php
@@ -36,7 +36,7 @@ class AllOperator implements FieldQueryInterface, OperatorInterface
     public function __construct(Type|FieldQueryInterface|stdClass|array|bool|float|int|null|string ...$value)
     {
         if (\count($value) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $value, got %d.', 1, \count($value)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $value, got %d.', 1, \count($value)));
         }
 
         if (! array_is_list($value)) {

--- a/src/Builder/Query/AndOperator.php
+++ b/src/Builder/Query/AndOperator.php
@@ -34,7 +34,7 @@ class AndOperator implements QueryInterface, OperatorInterface
     public function __construct(QueryInterface|array ...$queries)
     {
         if (\count($queries) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $queries, got %d.', 1, \count($queries)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $queries, got %d.', 1, \count($queries)));
         }
 
         if (! array_is_list($queries)) {

--- a/src/Builder/Query/NorOperator.php
+++ b/src/Builder/Query/NorOperator.php
@@ -34,7 +34,7 @@ class NorOperator implements QueryInterface, OperatorInterface
     public function __construct(QueryInterface|array ...$queries)
     {
         if (\count($queries) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $queries, got %d.', 1, \count($queries)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $queries, got %d.', 1, \count($queries)));
         }
 
         if (! array_is_list($queries)) {

--- a/src/Builder/Query/OrOperator.php
+++ b/src/Builder/Query/OrOperator.php
@@ -34,7 +34,7 @@ class OrOperator implements QueryInterface, OperatorInterface
     public function __construct(QueryInterface|array ...$queries)
     {
         if (\count($queries) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $queries, got %d.', 1, \count($queries)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $queries, got %d.', 1, \count($queries)));
         }
 
         if (! array_is_list($queries)) {

--- a/src/Builder/Query/TypeOperator.php
+++ b/src/Builder/Query/TypeOperator.php
@@ -34,7 +34,7 @@ class TypeOperator implements FieldQueryInterface, OperatorInterface
     public function __construct(int|string ...$type)
     {
         if (\count($type) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $type, got %d.', 1, \count($type)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $type, got %d.', 1, \count($type)));
         }
 
         if (! array_is_list($type)) {

--- a/src/Builder/Stage/AddFieldsStage.php
+++ b/src/Builder/Stage/AddFieldsStage.php
@@ -36,7 +36,7 @@ class AddFieldsStage implements StageInterface, OperatorInterface
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression)
     {
         if (\count($expression) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }
 
         foreach($expression as $key => $value) {

--- a/src/Builder/Stage/FacetStage.php
+++ b/src/Builder/Stage/FacetStage.php
@@ -37,7 +37,7 @@ class FacetStage implements StageInterface, OperatorInterface
     public function __construct(PackedArray|Pipeline|BSONArray|array ...$facet)
     {
         if (\count($facet) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $facet, got %d.', 1, \count($facet)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $facet, got %d.', 1, \count($facet)));
         }
 
         foreach($facet as $key => $value) {

--- a/src/Builder/Stage/ProjectStage.php
+++ b/src/Builder/Stage/ProjectStage.php
@@ -36,7 +36,7 @@ class ProjectStage implements StageInterface, OperatorInterface
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$specification)
     {
         if (\count($specification) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $specification, got %d.', 1, \count($specification)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $specification, got %d.', 1, \count($specification)));
         }
 
         foreach($specification as $key => $value) {

--- a/src/Builder/Stage/SetStage.php
+++ b/src/Builder/Stage/SetStage.php
@@ -37,7 +37,7 @@ class SetStage implements StageInterface, OperatorInterface
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$field)
     {
         if (\count($field) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $field, got %d.', 1, \count($field)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $field, got %d.', 1, \count($field)));
         }
 
         foreach($field as $key => $value) {

--- a/src/Builder/Stage/SortStage.php
+++ b/src/Builder/Stage/SortStage.php
@@ -37,7 +37,7 @@ class SortStage implements StageInterface, OperatorInterface
     public function __construct(Type|ExpressionInterface|Sort|stdClass|array|bool|float|int|null|string ...$sort)
     {
         if (\count($sort) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $sort, got %d.', 1, \count($sort)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $sort, got %d.', 1, \count($sort)));
         }
 
         foreach($sort as $key => $value) {

--- a/src/Builder/Stage/UnsetStage.php
+++ b/src/Builder/Stage/UnsetStage.php
@@ -36,7 +36,7 @@ class UnsetStage implements StageInterface, OperatorInterface
     public function __construct(FieldPath|string ...$field)
     {
         if (\count($field) < 1) {
-            throw new \InvalidArgumentException(\sprintf('Expected at least %d values for $field, got %d.', 1, \count($field)));
+            throw new InvalidArgumentException(\sprintf('Expected at least %d values for $field, got %d.', 1, \count($field)));
         }
 
         if (! array_is_list($field)) {


### PR DESCRIPTION
An extra backslash and the wrong exception class was used.

I realize that we don't have tests on exceptions.